### PR TITLE
fix(ci): remove unused logging import flagged by ruff

### DIFF
--- a/backend/utils/logger_utils.py
+++ b/backend/utils/logger_utils.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 
 def sanitize_log(val: Any) -> Any:


### PR DESCRIPTION
Fixes the latest pipeline failure triggered by ruff F401 on an unused logging module.