### PR TITLE
feat: consolidate migration review UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Consolidated the first-run product experience around the playground/migration review flow, fixed hash routing for all visible app tabs, and replaced remaining active emoji icons with Lucide icons.
 - Removed Archmorph's staging deployment path from GitHub Actions and updated release guidance for a production-only environment model.
 - Added server-side production gates and readiness metadata for live scanner, deployment execution/rollback, SSO/SCIM, Redis-backed session persistence, and PostgreSQL production parity; billing remains disabled/out of scope.
 - Refreshed README, PRD, architecture diagram, and application flow diagram for the April 28 release-hardening checkpoint, including React/Vite versions, test counts, drift baselines, admin release gates, post-deploy smoke, and gated scanner/deploy posture.

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -38,6 +38,9 @@ vi.mock('../components/LandingPage', () => ({
 vi.mock('../components/LegalPages', () => ({
   default: () => <div data-testid="legal">LegalPages</div>,
 }))
+vi.mock('../components/PlaygroundPage', () => ({
+  default: () => <div data-testid="playground">PlaygroundPage</div>,
+}))
 vi.mock('../components/CookieBanner', () => ({
   default: () => null,
 }))
@@ -53,13 +56,13 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.history.replaceState(null, '', '/')
-    useAppStore.setState({ activeTab: 'landing', adminOpen: false, updateStatus: null, pendingResumeId: null })
+    useAppStore.setState({ activeTab: 'playground', adminOpen: false, updateStatus: null, pendingResumeId: null, pendingSample: null })
     fetch.mockResolvedValue({ json: () => Promise.resolve({}) })
   })
 
   const renderSettledApp = async () => {
     const result = render(<App />)
-    await screen.findByTestId('landing')
+    await screen.findByTestId('playground')
     await screen.findByTestId('chat-widget')
     return result
   }
@@ -69,9 +72,9 @@ describe('App', () => {
     expect(screen.getByTestId('nav')).toBeInTheDocument()
   })
 
-  it('shows landing page by default', async () => {
+  it('shows the playground by default', async () => {
     await renderSettledApp()
-    // Default tab is now 'landing' (#211)
+    expect(screen.getByTestId('playground')).toBeInTheDocument()
     expect(screen.queryByTestId('translator')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/CompliancePanel.jsx
+++ b/frontend/src/components/CompliancePanel.jsx
@@ -6,17 +6,17 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Shield, ShieldCheck, ShieldX, Loader2, AlertTriangle, RefreshCw, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
+import { Shield, ShieldCheck, ShieldX, Loader2, AlertTriangle, RefreshCw, ChevronDown, ChevronUp, ExternalLink, Hospital, CreditCard, LockKeyhole, BadgeCheck, ClipboardCheck, Landmark } from 'lucide-react';
 import { Card, Badge, Button } from './ui';
 import api from '../services/apiClient';
 
 const FRAMEWORK_ICONS = {
-  HIPAA: '🏥',
-  'PCI-DSS': '💳',
-  'SOC 2': '🔒',
-  GDPR: '🇪🇺',
-  'ISO 27001': '📋',
-  FedRAMP: '🏛️',
+  HIPAA: Hospital,
+  'PCI-DSS': CreditCard,
+  'SOC 2': LockKeyhole,
+  GDPR: BadgeCheck,
+  'ISO 27001': ClipboardCheck,
+  FedRAMP: Landmark,
 };
 
 function ScoreRing({ score, size = 48 }) {
@@ -50,7 +50,7 @@ function ScoreRing({ score, size = 48 }) {
 
 function FrameworkCard({ framework }) {
   const [open, setOpen] = useState(false);
-  const icon = FRAMEWORK_ICONS[framework.framework] || '📋';
+  const FrameworkIcon = FRAMEWORK_ICONS[framework.framework] || ClipboardCheck;
   const gapCount = framework.gaps?.length || 0;
 
   return (
@@ -59,7 +59,7 @@ function FrameworkCard({ framework }) {
         <ScoreRing score={framework.score} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-lg">{icon}</span>
+            <FrameworkIcon className="w-4 h-4 text-cta" aria-hidden="true" />
             <h4 className="text-sm font-semibold text-text-primary truncate">{framework.framework}</h4>
           </div>
           <p className="text-xs text-text-muted mt-0.5">

--- a/frontend/src/components/DiagramTranslator/UploadStep.jsx
+++ b/frontend/src/components/DiagramTranslator/UploadStep.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Upload, FileText, X } from 'lucide-react';
+import { Upload, FileText, X, Building2, Globe2, Boxes, Network } from 'lucide-react';
 import { Badge, Button, Card } from '../ui';
 import { ContextualHint } from '../OnboardingTour';
 
 const SAMPLES = [
-  { id: 'aws-hub-spoke', name: 'Hub & Spoke', icon: '🏛️', desc: 'Secure Landing Zone', provider: 'aws' },
-  { id: 'aws-iaas', name: 'Classic Web App', icon: '🌐', desc: 'Basic 3-tier Architecture', provider: 'aws' },
-  { id: 'aws-eks', name: 'Microservices', icon: '🐳', desc: 'EKS Containerized App', provider: 'aws' },
-  { id: 'gcp-gke', name: 'GKE Cluster', icon: '⚡', desc: 'Scalable K8s Platform', provider: 'gcp' }
+  { id: 'aws-hub-spoke', name: 'Hub & Spoke', icon: Building2, desc: 'Secure Landing Zone', provider: 'aws' },
+  { id: 'aws-iaas', name: 'Classic Web App', icon: Globe2, desc: 'Basic 3-tier Architecture', provider: 'aws' },
+  { id: 'aws-eks', name: 'Microservices', icon: Boxes, desc: 'EKS Containerized App', provider: 'aws' },
+  { id: 'gcp-gke', name: 'GKE Cluster', icon: Network, desc: 'Scalable K8s Platform', provider: 'gcp' }
 ];
 
 export default function UploadStep({
@@ -94,24 +94,32 @@ export default function UploadStep({
           <p className="text-sm text-text-secondary mb-4">Or try with a sample architecture:</p>
           <div className="grid grid-cols-2 gap-3">
             {SAMPLES.map(sample => (
-              <button
-                key={sample.id}
-                onClick={() => onLoadSample(sample)}
-                className={`p-3 rounded-lg bg-secondary hover:bg-secondary/80 transition-all text-left cursor-pointer border border-border hover:scale-[1.02] ${
-                  sample.provider === 'gcp' ? 'hover:border-[#EA4335]/50' : 'hover:border-[#FF9900]/50'
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-lg">{sample.icon}</span>
-                  <Badge variant={sample.provider}>{sample.provider.toUpperCase()}</Badge>
-                </div>
-                <p className="text-sm font-medium text-text-primary mt-1.5">{sample.name}</p>
-                <p className="text-xs text-text-muted">{sample.desc}</p>
-              </button>
+              <SampleButton key={sample.id} sample={sample} onLoadSample={onLoadSample} />
             ))}
           </div>
         </div>
       </div>
     </Card>
+  );
+}
+
+function SampleButton({ sample, onLoadSample }) {
+  const SampleIcon = sample.icon;
+  return (
+    <button
+      onClick={() => onLoadSample(sample)}
+      className={`p-3 rounded-lg bg-secondary hover:bg-secondary/80 transition-all text-left cursor-pointer border border-border hover:scale-[1.02] ${
+        sample.provider === 'gcp' ? 'hover:border-[#EA4335]/50' : 'hover:border-[#FF9900]/50'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="w-7 h-7 rounded-md bg-surface/70 flex items-center justify-center">
+          <SampleIcon className="w-4 h-4 text-cta" aria-hidden="true" />
+        </span>
+        <Badge variant={sample.provider}>{sample.provider.toUpperCase()}</Badge>
+      </div>
+      <p className="text-sm font-medium text-text-primary mt-1.5">{sample.name}</p>
+      <p className="text-xs text-text-muted">{sample.desc}</p>
+    </button>
   );
 }

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -130,6 +130,8 @@ export default function DiagramTranslator() {
   // ── Resume analysis from Dashboard (#517) ──
   const pendingResumeId = useAppStore(s => s.pendingResumeId);
   const setPendingResumeId = useAppStore(s => s.setPendingResumeId);
+  const pendingSample = useAppStore(s => s.pendingSample);
+  const setPendingSample = useAppStore(s => s.setPendingSample);
   useEffect(() => {
     if (!pendingResumeId) return;
     const resumeId = pendingResumeId;
@@ -486,6 +488,13 @@ export default function DiagramTranslator() {
       set({ error: 'Failed to load sample: ' + err.message, step: 'upload' });
     }
   };
+
+  useEffect(() => {
+    if (!pendingSample) return;
+    setPendingSample(null);
+    handleLoadSample(pendingSample);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSample]);
 
   const handleApplyAnswers = async () => {
     set({ loading: true });

--- a/frontend/src/components/DriftDashboard/CloudCredentialsModal.jsx
+++ b/frontend/src/components/DriftDashboard/CloudCredentialsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { LockKeyhole } from 'lucide-react';
 import api from '../../services/apiClient';
 
 // Helper component for Code Block with Copy
@@ -337,7 +338,7 @@ export function CloudCredentialsModal({ provider, onClose, onSuccess }) {
 
             <div className="mt-8 pt-6 border-t border-slate-100">
               <div className="mb-4 flex items-start text-xs text-slate-600 bg-slate-50 p-3 rounded">
-                <span className="mr-2 text-base leading-none">🔒</span>
+                <LockKeyhole className="mr-2 mt-0.5 h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" />
                 <p>
                   <strong>Read-only access.</strong> Archmorph only requires read access to scan infrastructure states. We never request write permissions. All credentials are encrypted at rest using AES-256 and never shared.
                 </p>

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -173,7 +173,7 @@ export default function Nav({ activeTab, setActiveTab, updateStatus }) {
           <div className="flex items-center justify-between h-14">
             {/* Logo — clickable to go Home (#1), catalog dot as tooltip (#10), tagline removed (#2) */}
             <button
-              onClick={() => setActiveTab('landing')}
+              onClick={() => setActiveTab('playground')}
               className="flex items-center gap-2.5 cursor-pointer group"
               aria-label="Go to home"
               title={catalogLabel}

--- a/frontend/src/components/PlaygroundPage.jsx
+++ b/frontend/src/components/PlaygroundPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Upload, ArrowRight, Cloud, Layers, FileCode, BarChart3, Lock } from 'lucide-react';
+import { ArrowRight, Cloud, Layers, FileCode, BarChart3, Lock, Globe2, Network, Boxes } from 'lucide-react';
 import { Button, Card, Badge } from './ui';
 import useAppStore from '../stores/useAppStore';
 
@@ -17,7 +17,7 @@ const PLAYGROUND_SAMPLES = [
     provider: 'aws',
     description: 'Classic EC2 + RDS + S3 architecture with ALB and CloudFront',
     services: 6,
-    icon: '🌐',
+    icon: Globe2,
   },
   {
     id: 'aws-eks',
@@ -25,7 +25,7 @@ const PLAYGROUND_SAMPLES = [
     provider: 'aws',
     description: 'Containerized microservices on EKS with SQS and DynamoDB',
     services: 8,
-    icon: '🐳',
+    icon: Boxes,
   },
   {
     id: 'gcp-gke',
@@ -33,7 +33,7 @@ const PLAYGROUND_SAMPLES = [
     provider: 'gcp',
     description: 'GKE cluster with Cloud SQL, Pub/Sub, and Cloud Storage',
     services: 7,
-    icon: '⚡',
+    icon: Network,
   },
 ];
 
@@ -49,18 +49,16 @@ const DEMO_FEATURES = [
 
 export default function PlaygroundPage() {
   const setActiveTab = useAppStore(s => s.setActiveTab);
+  const setPendingSample = useAppStore(s => s.setPendingSample);
   const [selectedSample, setSelectedSample] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const handleTrySample = async (sample) => {
     setSelectedSample(sample.id);
     setLoading(true);
-    // Navigate to translator with sample pre-loaded
-    // The translator already supports onLoadSample
+    setPendingSample(sample);
     setTimeout(() => {
       setActiveTab('translator');
-      // Dispatch sample load event
-      window.dispatchEvent(new CustomEvent('archmorph-load-sample', { detail: { sampleId: sample.id } }));
       setLoading(false);
     }, 500);
   };
@@ -71,7 +69,7 @@ export default function PlaygroundPage() {
       <div className="text-center mb-12">
         <Badge variant="azure" className="mb-4">No sign-up required</Badge>
         <h1 className="text-3xl sm:text-4xl font-bold text-text-primary mb-3">
-          Try Archmorph <span className="text-cta">instantly</span>
+          Start a migration review <span className="text-cta">instantly</span>
         </h1>
         <p className="text-lg text-text-secondary max-w-2xl mx-auto">
           Pick a sample architecture below and see how Archmorph translates it to Azure
@@ -82,32 +80,13 @@ export default function PlaygroundPage() {
       {/* Sample Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12">
         {PLAYGROUND_SAMPLES.map((sample) => (
-          <Card
+          <SampleCard
             key={sample.id}
-            hover
-            className={`p-6 transition-all duration-200 ${
-              selectedSample === sample.id ? 'border-cta ring-2 ring-cta/20' : ''
-            }`}
-          >
-            <div className="text-3xl mb-3">{sample.icon}</div>
-            <div className="flex items-center gap-2 mb-2">
-              <h3 className="text-sm font-semibold text-text-primary">{sample.name}</h3>
-              <Badge variant={sample.provider}>{sample.provider.toUpperCase()}</Badge>
-            </div>
-            <p className="text-xs text-text-muted mb-3">{sample.description}</p>
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-text-muted">{sample.services} services</span>
-              <Button
-                size="sm"
-                variant="primary"
-                icon={ArrowRight}
-                loading={loading && selectedSample === sample.id}
-                onClick={() => handleTrySample(sample)}
-              >
-                Try it
-              </Button>
-            </div>
-          </Card>
+            sample={sample}
+            selected={selectedSample === sample.id}
+            loading={loading && selectedSample === sample.id}
+            onTry={handleTrySample}
+          />
         ))}
       </div>
 
@@ -129,9 +108,40 @@ export default function PlaygroundPage() {
       <div className="text-center">
         <p className="text-sm text-text-muted mb-3">Want full access? Downloads, exports, history, and more.</p>
         <Button variant="primary" size="lg" icon={ArrowRight} onClick={() => setActiveTab('translator')}>
-          Sign up free
+          Start with your own diagram
         </Button>
       </div>
     </div>
+  );
+}
+
+function SampleCard({ sample, selected, loading, onTry }) {
+  const SampleIcon = sample.icon;
+  return (
+    <Card
+      hover
+      className={`p-6 transition-all duration-200 ${selected ? 'border-cta ring-2 ring-cta/20' : ''}`}
+    >
+      <div className="w-10 h-10 rounded-lg bg-cta/10 flex items-center justify-center mb-3">
+        <SampleIcon className="w-5 h-5 text-cta" aria-hidden="true" />
+      </div>
+      <div className="flex items-center gap-2 mb-2">
+        <h3 className="text-sm font-semibold text-text-primary">{sample.name}</h3>
+        <Badge variant={sample.provider}>{sample.provider.toUpperCase()}</Badge>
+      </div>
+      <p className="text-xs text-text-muted mb-3">{sample.description}</p>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-text-muted">{sample.services} services</span>
+        <Button
+          size="sm"
+          variant="primary"
+          icon={ArrowRight}
+          loading={loading}
+          onClick={() => onTry(sample)}
+        >
+          Try it
+        </Button>
+      </div>
+    </Card>
   );
 }

--- a/frontend/src/stores/useAppStore.js
+++ b/frontend/src/stores/useAppStore.js
@@ -2,7 +2,7 @@
  * Global application state store (#170).
  *
  * Manages top-level UI state that was previously in App.jsx useState calls:
- * - activeTab (translator | services | roadmap)
+ * - activeTab (see VALID_TABS below for the full set of supported values)
  * - adminOpen
  * - updateStatus (fetched from /api/service-updates/status)
  *
@@ -12,13 +12,27 @@
 import { create } from 'zustand';
 import api from '../services/apiClient';
 
-const VALID_TABS = new Set(['landing', 'dashboard', 'playground', 'translator', 'services', 'roadmap', 'legal']);
+const VALID_TABS = new Set([
+  'landing',
+  'dashboard',
+  'playground',
+  'translator',
+  'services',
+  'roadmap',
+  'legal',
+  'drift',
+  'canvas',
+  'api-docs',
+  'gallery',
+  'collab',
+  'replay',
+]);
 
-/** Read initial tab from URL hash, default to 'landing' */
+/** Read initial tab from URL hash, default to the zero-friction playground. */
 function getInitialTab() {
-  if (typeof window === 'undefined') return 'landing';
+  if (typeof window === 'undefined') return 'playground';
   const hash = window.location.hash.replace('#', '').replace('/', '');
-  return VALID_TABS.has(hash) ? hash : 'landing';
+  return VALID_TABS.has(hash) ? hash : 'playground';
 }
 
 const useAppStore = create((set) => {
@@ -38,19 +52,22 @@ const useAppStore = create((set) => {
     adminOpen: false,
     updateStatus: null,
     pendingResumeId: null,
+    pendingSample: null,
 
     // ── Actions ──
     setActiveTab: (tab) => {
       set({ activeTab: tab });
       // Sync URL hash (#310)
       if (typeof window !== 'undefined') {
-        const newHash = tab === 'landing' ? '' : `#${tab}`;
-        if (window.location.hash !== `#${tab}`) {
+        const newHash = tab === 'playground' ? '' : `#${tab}`;
+        const currentHash = window.location.hash === '#playground' ? '' : window.location.hash;
+        if (currentHash !== newHash) {
           window.history.pushState(null, '', newHash || window.location.pathname);
         }
       }
     },
     setPendingResumeId: (id) => set({ pendingResumeId: id }),
+    setPendingSample: (sample) => set({ pendingSample: sample }),
     setAdminOpen: (open) => set({ adminOpen: open }),
     toggleAdmin: () => set((s) => ({ adminOpen: !s.adminOpen })),
 


### PR DESCRIPTION
## Summary
- Make the no-signup playground the default first screen so users can start a migration review immediately
- Fix hash routing so every visible app tab can be restored from the URL
- Replace active emoji sample/security/compliance icons with Lucide icons for a more consistent UI
- Move playground sample handoff to store-backed state instead of dispatching a timing-sensitive browser event

## Validation
- `npm run lint`
- `npx vitest run` — 262 tests passed
- `npm run build`
- `git diff --check`

## Notes
- Main branch protection is now enforced, so this is intentionally flowing through PR review rather than a direct push.