### PR TITLE
chore: add production parity stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Added a local production-parity Compose overlay plus guard tests for PostgreSQL/Redis enforcement without requiring a staging environment.
 - Consolidated the first-run product experience around the playground/migration review flow, fixed hash routing for all visible app tabs, and replaced remaining active emoji icons with Lucide icons.
 - Removed Archmorph's staging deployment path from GitHub Actions and updated release guidance for a production-only environment model.
 - Added server-side production gates and readiness metadata for live scanner, deployment execution/rollback, SSO/SCIM, Redis-backed session persistence, and PostgreSQL production parity; billing remains disabled/out of scope.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ npm run dev
 docker-compose up -d   # PostgreSQL 16 + Redis 7 + Backend + Frontend
 ```
 
+**Production-parity local guard mode:**
+```bash
+docker compose -f docker-compose.yml -f docker-compose.parity.yml up --build
+```
+
+This overlay keeps everything local, but starts the backend with production-like persistence guards:
+`ENVIRONMENT=production`, `ENFORCE_POSTGRES=true`, `REQUIRE_REDIS=true`, PostgreSQL via `DATABASE_URL`, Redis via `REDIS_URL`, and Gunicorn/Uvicorn workers instead of the reload server.
+
 ---
 
 ## Architecture
@@ -760,6 +768,7 @@ Archmorph/
 │   ├── architecture.excalidraw      # System architecture diagram
 │   └── application-flow.excalidraw  # Application flow diagram
 ├── docker-compose.yml               # Full-stack local development
+├── docker-compose.parity.yml        # Local production-parity overlay with Postgres/Redis guards
 ├── CONTRIBUTING.md
 ├── playwright.config.ts
 └── README.md

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm run dev
 
 **Docker Compose (full stack):**
 ```bash
-docker-compose up -d   # PostgreSQL 16 + Redis 7 + Backend + Frontend
+docker compose up -d   # PostgreSQL 16 + Redis 7 + Backend + Frontend
 ```
 
 **Production-parity local guard mode:**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,5 +17,12 @@ GITHUB_REPO=your-org/your-repo
 # Environment
 ENVIRONMENT=development
 
+# Production-parity local guard mode
+# Use with: docker compose -f docker-compose.yml -f docker-compose.parity.yml up --build
+# DATABASE_URL=postgresql://archmorph:archmorph_dev@postgres:5432/archmorph
+# REDIS_URL=redis://redis:6379/0
+# ENFORCE_POSTGRES=true
+# REQUIRE_REDIS=true
+
 # CORS (comma-separated origins)
 ALLOWED_ORIGINS=http://localhost:5173,https://your-frontend.azurestaticapps.net

--- a/backend/tests/test_production_parity.py
+++ b/backend/tests/test_production_parity.py
@@ -56,14 +56,12 @@ def test_postgres_readiness_is_production_ready_when_enforced():
     )
     assert result.returncode == 0, result.stderr
     readiness = json.loads(result.stdout)
-    assert readiness == {
-        "backend": "postgresql",
-        "postgres_configured": True,
-        "sqlite_configured": False,
-        "production_like": True,
-        "enforce_postgres": True,
-        "ready_for_production": True,
-    }
+    assert readiness["backend"] == "postgresql"
+    assert readiness["postgres_configured"] is True
+    assert readiness["sqlite_configured"] is False
+    assert readiness["production_like"] is True
+    assert readiness["enforce_postgres"] is True
+    assert readiness["ready_for_production"] is True
 
 
 def test_redis_readiness_is_horizontal_scale_ready_when_required():
@@ -76,14 +74,12 @@ def test_redis_readiness_is_horizontal_scale_ready_when_required():
     )
     assert result.returncode == 0, result.stderr
     readiness = json.loads(result.stdout)
-    assert readiness == {
-        "backend": "redis",
-        "redis_configured": True,
-        "require_redis": True,
-        "production_like": True,
-        "multi_worker": True,
-        "ready_for_horizontal_scale": True,
-    }
+    assert readiness["backend"] == "redis"
+    assert readiness["redis_configured"] is True
+    assert readiness["require_redis"] is True
+    assert readiness["production_like"] is True
+    assert readiness["multi_worker"] is True
+    assert readiness["ready_for_horizontal_scale"] is True
 
 
 def test_require_redis_rejects_missing_redis_in_production():

--- a/backend/tests/test_production_parity.py
+++ b/backend/tests/test_production_parity.py
@@ -1,0 +1,96 @@
+"""Production-parity guard tests for database and session configuration."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+
+def run_backend_snippet(code: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in (
+        "DATABASE_URL",
+        "ENVIRONMENT",
+        "ENFORCE_POSTGRES",
+        "REDIS_URL",
+        "REDIS_HOST",
+        "REQUIRE_REDIS",
+        "ENFORCE_REDIS",
+        "WEB_CONCURRENCY",
+        "UVICORN_WORKERS",
+    ):
+        env.pop(key, None)
+    env.update(overrides)
+    env["PYTHONPATH"] = str(BACKEND_DIR)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=BACKEND_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_enforce_postgres_rejects_sqlite_in_production():
+    result = run_backend_snippet(
+        "import database",
+        ENVIRONMENT="production",
+        ENFORCE_POSTGRES="true",
+        DATABASE_URL="sqlite:///./data/archmorph.db",
+    )
+    assert result.returncode != 0
+    assert "ENFORCE_POSTGRES is set" in result.stderr
+
+
+def test_postgres_readiness_is_production_ready_when_enforced():
+    result = run_backend_snippet(
+        "import json, database; print(json.dumps(database.database_readiness()))",
+        ENVIRONMENT="production",
+        ENFORCE_POSTGRES="true",
+        DATABASE_URL="postgresql://archmorph:archmorph_dev@postgres:5432/archmorph",
+    )
+    assert result.returncode == 0, result.stderr
+    readiness = json.loads(result.stdout)
+    assert readiness == {
+        "backend": "postgresql",
+        "postgres_configured": True,
+        "sqlite_configured": False,
+        "production_like": True,
+        "enforce_postgres": True,
+        "ready_for_production": True,
+    }
+
+
+def test_redis_readiness_is_horizontal_scale_ready_when_required():
+    result = run_backend_snippet(
+        "import json, session_store; print(json.dumps(session_store.session_store_readiness()))",
+        ENVIRONMENT="production",
+        REQUIRE_REDIS="true",
+        REDIS_URL="redis://redis:6379/0",
+        WEB_CONCURRENCY="2",
+    )
+    assert result.returncode == 0, result.stderr
+    readiness = json.loads(result.stdout)
+    assert readiness == {
+        "backend": "redis",
+        "redis_configured": True,
+        "require_redis": True,
+        "production_like": True,
+        "multi_worker": True,
+        "ready_for_horizontal_scale": True,
+    }
+
+
+def test_require_redis_rejects_missing_redis_in_production():
+    result = run_backend_snippet(
+        'import session_store; session_store.get_store("parity")',
+        ENVIRONMENT="production",
+        REQUIRE_REDIS="true",
+    )
+    assert result.returncode != 0
+    assert "REQUIRE_REDIS is set" in result.stderr

--- a/docker-compose.parity.yml
+++ b/docker-compose.parity.yml
@@ -1,0 +1,19 @@
+# Archmorph production-parity local overlay.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.parity.yml up --build
+# This keeps local services on Docker, but enables the same DB/session guards used for production.
+
+services:
+  backend:
+    environment:
+      ENVIRONMENT: production
+      ENFORCE_POSTGRES: "true"
+      REQUIRE_REDIS: "true"
+      DATABASE_URL: "postgresql://archmorph:archmorph_dev@postgres:5432/archmorph"
+      REDIS_URL: "redis://redis:6379/0"
+      WEB_CONCURRENCY: "2"
+      RATE_LIMIT_ENABLED: "false"
+    command: ["gunicorn", "-c", "gunicorn.conf.py", "main:app"]
+
+  frontend:
+    environment:
+      VITE_API_BASE: "http://localhost:8000/api"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -45,6 +45,14 @@ Production guard env vars:
 
 ## 3. Required Quality Gates
 
+Before production promotion, run the local production-parity guard mode at least once after configuration changes:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.parity.yml up --build
+```
+
+The backend must start with PostgreSQL, Redis, `ENFORCE_POSTGRES=true`, and `REQUIRE_REDIS=true`; the admin release gate should report no database/session blockers.
+
 The `CI/CD` workflow must pass before release:
 
 - `backend-tests`: Ruff, pytest, coverage threshold, OpenAPI export, backend SBOM, Grype.

--- a/docs/RELEASE_EVIDENCE.md
+++ b/docs/RELEASE_EVIDENCE.md
@@ -52,4 +52,4 @@ This file records production readiness evidence for release checkpoints. Keep se
 - Compose overlay: `docker-compose.parity.yml` starts the backend with `ENVIRONMENT=production`, `ENFORCE_POSTGRES=true`, `REQUIRE_REDIS=true`, PostgreSQL via `DATABASE_URL`, Redis via `REDIS_URL`, and Gunicorn/Uvicorn workers.
 - Guard tests: `backend/tests/test_production_parity.py` verifies enforced PostgreSQL readiness, enforced Redis readiness, and fail-closed behavior when either guard is misconfigured.
 - Validation: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check backend/tests/test_production_parity.py` passed.
-- Validation: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_database.py tests/test_session_store.py tests/test_production_parity.py -q --no-cov` passed with `45` tests.
+- Validation: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest backend/tests/test_database.py backend/tests/test_session_store.py backend/tests/test_production_parity.py -q --no-cov` passed with `45` tests.

--- a/docs/RELEASE_EVIDENCE.md
+++ b/docs/RELEASE_EVIDENCE.md
@@ -45,3 +45,11 @@ This file records production readiness evidence for release checkpoints. Keep se
 - Identity readiness: SSO/SCIM readiness endpoint reports configured booleans without exposing secret values.
 - Validation: focused backend gate tests passed with `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_feature_flags.py tests/test_session_store.py tests/test_database.py tests/test_deployments.py tests/test_release_gates.py -q --no-cov`.
 - Full backend gate: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest --tb=short -q -n auto --dist loadfile --cov=. --cov-report=term-missing --cov-config=.coveragerc --cov-context=test --cov-fail-under=63` passed with total coverage `64.78%`.
+
+## 2026-04-28 Production-Parity Local Stack Pass
+
+- Purpose: Add a no-staging local parity path for validating production persistence guards before direct production promotion.
+- Compose overlay: `docker-compose.parity.yml` starts the backend with `ENVIRONMENT=production`, `ENFORCE_POSTGRES=true`, `REQUIRE_REDIS=true`, PostgreSQL via `DATABASE_URL`, Redis via `REDIS_URL`, and Gunicorn/Uvicorn workers.
+- Guard tests: `backend/tests/test_production_parity.py` verifies enforced PostgreSQL readiness, enforced Redis readiness, and fail-closed behavior when either guard is misconfigured.
+- Validation: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check backend/tests/test_production_parity.py` passed.
+- Validation: `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_database.py tests/test_session_store.py tests/test_production_parity.py -q --no-cov` passed with `45` tests.


### PR DESCRIPTION
## Summary
- add a local production-parity Compose overlay with PostgreSQL and Redis guards enabled
- add focused subprocess tests for enforced PostgreSQL/Redis readiness and fail-closed guard behavior
- update README, release checklist, release evidence, env example, and changelog with the no-staging parity workflow

## Validation
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check backend/tests/test_production_parity.py
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_database.py tests/test_session_store.py tests/test_production_parity.py -q --no-cov
- git diff --check

## Notes
- Docker/Compose runtime validation could not run locally because neither docker-compose nor docker compose is available in this shell.