### PR TITLE
feat: wire free activation analytics

### DIFF
--- a/backend/rbac.py
+++ b/backend/rbac.py
@@ -394,6 +394,6 @@ class RequireQuota:
             raise ArchmorphException(
                 429,
                 f"Monthly analysis quota exceeded ({status['used']}/{status['limit']}). "
-                "Upgrade your plan for more.",
+                "Contact the project maintainer if you need a higher safeguard limit.",
             )
         return user

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,9 +59,12 @@ export default function App() {
   useEffect(() => {
     const controller = new AbortController();
     fetchUpdateStatus(controller.signal);
-    trackPageView(activeTab);
     return () => controller.abort();
   }, [fetchUpdateStatus]);
+
+  useEffect(() => {
+    trackPageView(activeTab);
+  }, [activeTab]);
 
   useEffect(() => () => clearTimeout(tapTimer.current), []);
 

--- a/frontend/src/components/Auth/LoginModal.jsx
+++ b/frontend/src/components/Auth/LoginModal.jsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { X } from 'lucide-react';
 import { useAuth } from './AuthProvider';
+import { trackFunnel } from '../../services/analytics';
 
 /* Simple inline SVG provider icons — avoids external dependency */
 function MicrosoftIcon({ className }) {
@@ -93,7 +94,7 @@ export default function LoginModal({ isOpen, onClose }) {
         {/* Header */}
         <div className="text-center mb-6">
           <h2 className="text-xl font-bold text-text-primary">Sign in to Archmorph</h2>
-          <p className="text-sm text-text-muted mt-1">Save your work, unlock features</p>
+          <p className="text-sm text-text-muted mt-1">Save your work across sessions</p>
         </div>
 
         {/* Provider buttons */}
@@ -101,7 +102,10 @@ export default function LoginModal({ isOpen, onClose }) {
           {PROVIDERS.map(({ id, label, Icon, bg, text, border }) => (
             <button
               key={id}
-              onClick={() => loginWithProvider(id)}
+              onClick={() => {
+                trackFunnel('sign_up', { provider: id, source: 'login_modal' });
+                loginWithProvider(id);
+              }}
               className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg border ${border} ${bg} ${text} font-medium text-sm transition-all duration-200 cursor-pointer`}
             >
               <Icon className="w-5 h-5 flex-shrink-0" />

--- a/frontend/src/components/DiagramTranslator/IaCViewer.jsx
+++ b/frontend/src/components/DiagramTranslator/IaCViewer.jsx
@@ -32,7 +32,7 @@ export default function IaCViewer({
   iacChatOpen, iacChatMessages, iacChatInput, iacChatLoading,
   iacChatEndRef, iacChatInputRef,
   onCopyWithFeedback, onToggleChat, onOpenChatWithMessage,
-  onResetChat, onSendChat, onSetChatInput,
+  onResetChat, onSendChat, onSetChatInput, onDownload,
 }) {
   // Compute which lines are new/changed compared to previous version
   const changedLineSet = useMemo(() => {
@@ -87,6 +87,7 @@ export default function IaCViewer({
               const a = document.createElement('a');
               a.href = url; a.download = iacFormat === 'terraform' ? 'main.tf' : iacFormat === 'cloudformation' ? 'template.yaml' : (iacFormat === 'pulumi' || iacFormat === 'aws-cdk') ? 'index.ts' : 'main.bicep'; a.click();
               URL.revokeObjectURL(url);
+              onDownload?.();
             }} variant="secondary" size="sm" icon={Download}>Download</Button>
             <Button onClick={() => {
               const repo = prompt('Enter GitHub repo (owner/repo):');

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -13,6 +13,7 @@ import useSessionExpiry from '../../hooks/useSessionExpiry';
 import useBeforeUnload from '../../hooks/useBeforeUnload';
 import useAppStore from '../../stores/useAppStore';
 import { isFeatureEnabled } from '../../featureFlags';
+import { trackFunnel } from '../../services/analytics';
 
 const UploadStep = lazy(() => import('./UploadStep'));
 const GuidedQuestions = lazy(() => import('./GuidedQuestions'));
@@ -284,6 +285,11 @@ export default function DiagramTranslator() {
       const uploadData = await api.post('/projects/demo-project/diagrams', formData, signal);
       const { diagram_id } = uploadData;
       set({ diagramId: diagram_id });
+      trackFunnel('first_upload', {
+        source: 'upload',
+        file_type: file.type || 'unknown',
+        size_kb: Math.round(file.size / 1024),
+      });
 
       // Cache uploaded image for session restore (#333)
       if (file.type.startsWith('image/') && file.size < 1_000_000) {
@@ -384,6 +390,12 @@ export default function DiagramTranslator() {
         await new Promise(r => setTimeout(r, 400));
 
         set({ analysis: result });
+        trackFunnel('analysis_complete', {
+          source: 'upload',
+          diagram_id,
+          service_count: result.services_detected || result.mappings?.length || 0,
+          provider: result.source_provider || 'unknown',
+        });
 
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questions = qData.questions || [];
@@ -440,6 +452,12 @@ export default function DiagramTranslator() {
         await new Promise(r => setTimeout(r, 800));
 
         set({ analysis: result });
+        trackFunnel('analysis_complete', {
+          source: 'upload',
+          diagram_id,
+          service_count: result.services_detected || result.mappings?.length || 0,
+          provider: result.source_provider || 'unknown',
+        });
 
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questions = qData.questions || [];
@@ -469,6 +487,11 @@ export default function DiagramTranslator() {
     try {
       const result = await api.post(`/samples/${sample.id}/analyze`);
       set({ diagramId: result.diagram_id, analysis: result });
+      trackFunnel('first_upload', {
+        source: 'sample',
+        sample_id: sample.id,
+        provider: sample.provider,
+      });
       for (const zone of (result.zones || [])) {
         const svcNames = (zone.services || []).map(s => s.source || s.name || '').filter(Boolean).slice(0, 3);
         addProgress(`Zone ${zone.id}: ${zone.name} (${svcNames.join(', ')})...`);
@@ -478,6 +501,12 @@ export default function DiagramTranslator() {
       await new Promise(r => setTimeout(r, 400));
       addProgress('Sample loaded successfully \u2713');
       await new Promise(r => setTimeout(r, 600));
+      trackFunnel('analysis_complete', {
+        source: 'sample',
+        diagram_id: result.diagram_id,
+        provider: sample.provider,
+        service_count: result.services_detected || result.mappings?.length || 0,
+      });
       const qData = await api.post(`/diagrams/${result.diagram_id}/questions`);
       const questions = qData.questions || [];
       const defaults = {};
@@ -503,7 +532,13 @@ export default function DiagramTranslator() {
         () => api.post(`/diagrams/${state.diagramId}/apply-answers`, state.answers),
         { cleanup: () => set({ loading: false }) },
       );
-      if (refined) set({ analysis: { ...state.analysis, ...refined }, step: 'results' });
+      if (refined) {
+        trackFunnel('questions_answered', {
+          diagram_id: state.diagramId,
+          question_count: state.questions?.length || 0,
+        });
+        set({ analysis: { ...state.analysis, ...refined }, step: 'results' });
+      }
     } catch (err) {
       set({ error: err.message });
     }
@@ -519,9 +554,13 @@ export default function DiagramTranslator() {
       );
       if (iacData) {
         set({ iacCode: iacData.code, step: 'iac', generatingIac: false });
+        trackFunnel('iac_generated', { diagram_id: state.diagramId, format: fmt });
         updateSessionCache({ iacCode: iacData.code, iacFormat: fmt }); // #263
         // Fetch cost estimate in parallel (non-blocking)
-        api.get(`/diagrams/${state.diagramId}/cost-estimate`).then(cost => set({ costEstimate: cost })).catch(() => {});
+        api.get(`/diagrams/${state.diagramId}/cost-estimate`).then(cost => {
+          set({ costEstimate: cost });
+          trackFunnel('cost_viewed', { diagram_id: state.diagramId, source: 'auto_fetch' });
+        }).catch(() => {});
       }
     } catch (err) {
       set({ error: err.message, generatingIac: false });
@@ -540,6 +579,7 @@ export default function DiagramTranslator() {
       );
       if (iacData) {
         set({ iacCode: iacData.code, genProgress: 'IaC complete. Generating HLD document...' });
+        trackFunnel('iac_generated', { diagram_id: state.diagramId, format: fmt, source: 'generate_all' });
         updateSessionCache({ iacCode: iacData.code, iacFormat: fmt });
         // Start HLD generation in parallel
         const [hldData, costData] = await Promise.allSettled([
@@ -550,7 +590,10 @@ export default function DiagramTranslator() {
           set({ hldData: hldData.value });
           updateSessionCache({ hldData: hldData.value });
         }
-        if (costData.status === 'fulfilled') set({ costEstimate: costData.value });
+        if (costData.status === 'fulfilled') {
+          set({ costEstimate: costData.value });
+          trackFunnel('cost_viewed', { diagram_id: state.diagramId, source: 'generate_all' });
+        }
         set({ step: 'iac', generatingIac: false, generatingAll: false, genProgress: null });
       }
     } catch (err) {
@@ -581,6 +624,7 @@ export default function DiagramTranslator() {
         a.download = data.filename;
         a.click();
         URL.revokeObjectURL(url);
+        trackFunnel('hld_exported', { diagram_id: state.diagramId, format: fmt });
         copyWithFeedback('', `hld-${fmt}`);
       }
     } catch (err) {
@@ -701,6 +745,7 @@ export default function DiagramTranslator() {
         a.download = data.filename || 'archmorph-migration-package.zip';
         a.click();
         URL.revokeObjectURL(url);
+        trackFunnel('iac_downloaded', { diagram_id: state.diagramId, format: state.iacFormat, source: 'migration_package' });
       }
     } catch (err) {
       set({ error: `Migration package export failed: ${err.message}` });
@@ -740,6 +785,7 @@ export default function DiagramTranslator() {
           onResetChat={handleResetChat}
           onSendChat={handleIacChat}
           onSetChatInput={(v) => set({ iacChatInput: v })}
+          onDownload={() => trackFunnel('iac_downloaded', { diagram_id: state.diagramId, format: state.iacFormat, source: 'iac_viewer' })}
         />
       ) : tab.id === 'hld' ? (
         <HLDTab
@@ -895,7 +941,14 @@ export default function DiagramTranslator() {
           loading={state.loading}
           onUpdateAnswer={updateAnswer}
           onApplyAnswers={handleApplyAnswers}
-          onSkip={() => set({ step: 'results' })}
+          onSkip={() => {
+            trackFunnel('questions_answered', {
+              diagram_id: state.diagramId,
+              question_count: state.questions?.length || 0,
+              skipped: true,
+            });
+            set({ step: 'results' });
+          }}
           constraints={state.questionConstraints || []}
           regionGroups={state.regionGroups || {}}
         />
@@ -935,7 +988,10 @@ export default function DiagramTranslator() {
           <Tabs
             tabs={deliverableTabs}
             activeTab={activeDeliverable}
-            onChange={(tabId) => set({ step: tabId })}
+            onChange={(tabId) => {
+              if (tabId === 'pricing') trackFunnel('cost_viewed', { diagram_id: state.diagramId, source: 'pricing_tab' });
+              set({ step: tabId });
+            }}
           />
         </div>
       )}

--- a/frontend/src/services/__tests__/analytics.test.js
+++ b/frontend/src/services/__tests__/analytics.test.js
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadAnalytics() {
+  vi.resetModules();
+  return import('../analytics');
+}
+
+function postedEvents() {
+  return fetch.mock.calls.map(([, options]) => JSON.parse(options.body));
+}
+
+describe('analytics service', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it('tracks page views as generic and funnel events', async () => {
+    const { trackPageView } = await loadAnalytics();
+
+    trackPageView('translator');
+
+    expect(postedEvents().map((payload) => payload.event)).toEqual([
+      'page_view',
+      'funnel:page_view',
+    ]);
+    expect(postedEvents()[1].properties).toMatchObject({
+      tab: 'translator',
+      funnel_step: 'page_view',
+      funnel_index: 0,
+    });
+  });
+
+  it('tracks returning users once per day', async () => {
+    localStorage.setItem('archmorph-last-seen-date', '2026-04-27');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-28T09:00:00Z'));
+    const { trackPageView } = await loadAnalytics();
+
+    trackPageView('playground');
+    trackPageView('services');
+
+    const events = postedEvents().map((payload) => payload.event);
+    expect(events.filter((event) => event === 'funnel:returning_user')).toHaveLength(1);
+    expect(localStorage.getItem('archmorph-last-seen-date')).toBe('2026-04-28');
+  });
+});

--- a/frontend/src/services/analytics.js
+++ b/frontend/src/services/analytics.js
@@ -16,6 +16,7 @@
 const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY || '';
 const ANALYTICS_ENABLED = import.meta.env.VITE_ANALYTICS_ENABLED !== 'false';
+const LAST_SEEN_KEY = 'archmorph-last-seen-date';
 
 // Session ID for anonymous tracking
 let _sessionId = null;
@@ -118,6 +119,21 @@ export function trackFunnel(step, properties = {}) {
  */
 export function trackPageView(tabName) {
   track('page_view', { tab: tabName });
+  trackFunnel('page_view', { tab: tabName });
+  trackReturningUser();
+}
+
+export function trackReturningUser() {
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const lastSeen = localStorage.getItem(LAST_SEEN_KEY);
+    if (lastSeen && lastSeen !== today) {
+      trackFunnel('returning_user', { last_seen: lastSeen });
+    }
+    localStorage.setItem(LAST_SEEN_KEY, today);
+  } catch {
+    // localStorage may be blocked; analytics should never affect UX.
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wire free-product activation funnel events across page views, sign-in intent, sample/upload starts, analysis completion, question completion/skips, IaC generation/downloads, HLD exports, cost views, and returning users.
- Remove remaining gated-sounding sign-in/quota copy so the product stays positioned as free with maintainer-managed safeguard limits.
- Add focused analytics service tests for page-view and returning-user funnel behavior.

## Validation
- `cd frontend && npm test -- --run` (264 passed)
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd backend && .venv/bin/python -m pytest tests/test_auth.py` (22 passed)
- `git diff --check`
- Local browser smoke verified the free playground/sample flow and analytics ingestion; full IaC/HLD local generation remains limited by missing/unreachable Azure OpenAI configuration in the local environment.