### PR TITLE
fix(export): vsdx→vdx extension + empty-content guard (#569)

### DIFF
--- a/backend/diagram_export.py
+++ b/backend/diagram_export.py
@@ -192,12 +192,6 @@ def generate_diagram(analysis_result: dict, format: str) -> dict:
         raise ValueError(
             f"Unsupported format '{format}'. Choose from: {', '.join(generators)}"
         )
-    generators = {
-        "excalidraw": _generate_excalidraw,
-        "drawio": _generate_drawio,
-        "vsdx": _generate_vsdx,
-    }
-    gen = generators.get(format)
     if gen is None:
         raise ValueError(
             f"Unsupported format '{format}'. Choose from: {', '.join(generators)}"
@@ -1142,16 +1136,13 @@ def _generate_vsdx(analysis: dict) -> dict:
         confidence = m.get("confidence", "medium")
         svc_map[aws] = {"azure": azure, "confidence": confidence}
 
-    # Register default namespace so output is cleaner
+    # Register default namespace so the serializer emits a single ``xmlns``
+    # declaration on the root element. Setting ``xmlns`` again via ``attrib``
+    # produced an invalid duplicate attribute that broke Visio parsing.
     ET.register_namespace("", _VDX_NS)
+    ET.register_namespace("vx", "http://schemas.microsoft.com/visio/2006/extension")
 
-    vdx = ET.Element(
-        f"{{{_VDX_NS}}}VisioDocument",
-        attrib={
-            "xmlns": _VDX_NS,
-            "xmlns:vx": "http://schemas.microsoft.com/visio/2006/extension",
-        },
-    )
+    vdx = ET.Element(f"{{{_VDX_NS}}}VisioDocument")
 
     # DocumentProperties
     doc_props = ET.SubElement(vdx, f"{{{_VDX_NS}}}DocumentProperties")

--- a/backend/mcp_diagram_generator.py
+++ b/backend/mcp_diagram_generator.py
@@ -69,9 +69,29 @@ class DiagramMCPClient:
         title = analysis.get("title", "Azure Architecture Diagram")
         zones = analysis.get("zones", [])
         mappings = analysis.get("mappings", [])
+
+        def _service_name(s: Any) -> str | None:
+            """Normalize a service entry from any of several known shapes."""
+            if isinstance(s, str):
+                return s
+            if isinstance(s, dict):
+                # Vision analyzer schema (name/short_name), legacy mapping rows
+                # (azure_service/source_service), test fixtures (aws/azure/source).
+                for key in ("azure_service", "source_service", "azure", "aws", "source", "name", "short_name"):
+                    val = s.get(key)
+                    if val:
+                        return val
+            return None
+
         # Trim to keep the prompt under control on very large analyses.
         zones_summary = [
-            {"name": z.get("name"), "services": [s.get("azure_service") or s.get("source_service") or s.get("source") for s in z.get("services", [])]}
+            {
+                "name": z.get("name") if isinstance(z, dict) else None,
+                "services": [
+                    name for name in (_service_name(s) for s in (z.get("services", []) if isinstance(z, dict) else []))
+                    if name
+                ],
+            }
             for z in zones[:32]
         ]
         mappings_summary = [

--- a/backend/mcp_diagram_generator.py
+++ b/backend/mcp_diagram_generator.py
@@ -37,7 +37,19 @@ class DiagramMCPClient:
                         json={"prompt": prompt, "context": analysis_data}
                     )
                     if response.status_code == 200:
-                        return response.json().get("diagram_payload", "")
+                        try:
+                            payload = response.json().get("diagram_payload", "")
+                        except ValueError as e:  # invalid JSON
+                            logger.warning(
+                                f"MCP Gateway returned non-JSON for {format_type}: {e}. Falling back."
+                            )
+                            return self._fallback_generation(format_type, analysis_data)
+                        if isinstance(payload, str) and payload.strip():
+                            return payload
+                        logger.warning(
+                            f"MCP Gateway returned empty payload for {format_type}. Falling back."
+                        )
+                        return self._fallback_generation(format_type, analysis_data)
                     else:
                         logger.warning(f"MCP Gateway returned status {response.status_code}. Retrying...")
             except httpx.ConnectError as e:
@@ -54,15 +66,34 @@ class DiagramMCPClient:
         return self._fallback_generation(format_type, analysis_data)
 
     def _build_prompt(self, analysis: Dict[str, Any]) -> str:
-        return f"Generate a highly detailed Azure architecture diagram for the following zones: {json.dumps(analysis.get('zones', []))}."
+        title = analysis.get("title", "Azure Architecture Diagram")
+        zones = analysis.get("zones", [])
+        mappings = analysis.get("mappings", [])
+        # Trim to keep the prompt under control on very large analyses.
+        zones_summary = [
+            {"name": z.get("name"), "services": [s.get("azure_service") or s.get("source_service") or s.get("source") for s in z.get("services", [])]}
+            for z in zones[:32]
+        ]
+        mappings_summary = [
+            {"from": m.get("source_service") or m.get("source"), "to": m.get("azure_service") or m.get("target"), "category": m.get("category")}
+            for m in mappings[:64]
+        ]
+        return (
+            f"Generate a clean, presentation-ready Azure architecture diagram titled '{title}'. "
+            f"Zones: {json.dumps(zones_summary)}. "
+            f"Service mappings: {json.dumps(mappings_summary)}. "
+            "Group services by zone, draw labelled connections only when implied by the mappings, "
+            "and use Microsoft Azure brand colours."
+        )
 
     def _fallback_generation(self, format_type: str, analysis_data: Dict[str, Any]) -> str:
-        # If MCP is offline or not configured, fallback to the legacy layout engine
+        # If MCP is offline, returns an empty/garbage payload, or is not configured,
+        # delegate to the deterministic in-process layout engine.
         from diagram_export import generate_diagram as diagram_export_generate
         if format_type in ["excalidraw", "drawio", "visio", "vsdx"]:
             real_format = "vsdx" if format_type == "visio" else format_type
             res = diagram_export_generate(analysis_data, real_format)
-            return res.get("content")
+            return res.get("content") or ""
         raise ValueError(f"Unsupported MCP format: {format_type}")
 
 # Singleton client

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -165,16 +165,22 @@ async def export_architecture_diagram(request: Request, diagram_id: str, format:
 
     try:
         content = await mcp_client.generate_diagram(format, analysis)
+        if not content or not isinstance(content, str) or not content.strip():
+            # MCP gateway returned empty payload and the local fallback also
+            # produced nothing usable. Fail loudly instead of writing an empty
+            # file the user cannot open.
+            raise ArchmorphException(502, "Diagram generation produced empty content")
         zones = analysis.get("zones", [])
         zone_name = zones[0].get("name", "diagram") if zones else "diagram"
-        if format == "vsdx":
-            format_ext = "vsdx"
-        else:
-            format_ext = format
+        # Visio export uses the legacy VDX 2003 XML format (single XML file).
+        # The on-disk extension must be ``.vdx`` — modern ``.vsdx`` is an
+        # OOXML zip container, which Visio refuses if the bytes are raw XML.
+        # The API ``format`` value remains ``"vsdx"`` for frontend stability.
+        format_ext = "vdx" if format == "vsdx" else format
         result = {
             "format": format,
             "filename": f"archmorph-{zone_name}.{format_ext}",
-            "content": content
+            "content": content,
         }
     except ValueError as exc:
         raise ArchmorphException(400, str(exc))

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -3,7 +3,7 @@
 These tests do real round-trip parsing of each exporter's output. The
 previous coverage only checked that the result dict contained ``content`` or
 ``filename`` keys, which always passed regardless of whether the file was
-valid — masking the broken Visio output (#xxx).
+valid — masking the broken Visio output (#569).
 """
 import json
 import xml.etree.ElementTree as ET

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -1,4 +1,13 @@
-"""Tests for diagram_export module (#281)."""
+"""Tests for diagram_export module (#281).
+
+These tests do real round-trip parsing of each exporter's output. The
+previous coverage only checked that the result dict contained ``content`` or
+``filename`` keys, which always passed regardless of whether the file was
+valid — masking the broken Visio output (#xxx).
+"""
+import json
+import xml.etree.ElementTree as ET
+
 import pytest
 from diagram_export import generate_diagram, get_azure_stencil_id
 
@@ -7,6 +16,7 @@ SAMPLE_ANALYSIS = {
     "source_provider": "AWS",
     "target_provider": "azure",
     "services_detected": 3,
+    "title": "Round-Trip Test Diagram",
     "zones": [
         {
             "id": 1, "number": 1, "name": "Web Tier",
@@ -44,18 +54,59 @@ class TestGetAzureStencilId:
 
 
 class TestGenerateDiagram:
-    def test_excalidraw_format(self):
+    def test_excalidraw_produces_valid_json_with_elements(self):
         result = generate_diagram(SAMPLE_ANALYSIS, format="excalidraw")
-        assert "content" in result or "filename" in result
+        assert result["format"] == "excalidraw"
+        assert result["filename"].endswith(".excalidraw")
+        # Must be parseable JSON conforming to the Excalidraw schema.
+        doc = json.loads(result["content"])
+        assert doc.get("type") == "excalidraw"
+        assert isinstance(doc.get("elements"), list)
+        assert len(doc["elements"]) > 0, "Excalidraw export was empty"
 
-    def test_drawio_format(self):
+    def test_drawio_produces_valid_xml_with_mxgraph(self):
         result = generate_diagram(SAMPLE_ANALYSIS, format="drawio")
-        assert "content" in result or "filename" in result
+        assert result["format"] == "drawio"
+        assert result["filename"].endswith(".drawio")
+        # Must be parseable XML and contain at least one mxCell child.
+        root = ET.fromstring(result["content"])
+        assert root.tag in ("mxfile", "mxGraphModel"), f"Unexpected root: {root.tag}"
+        cells = root.findall(".//mxCell")
+        assert len(cells) > 0, "Draw.io export had no mxCell elements"
 
-    def test_vsdx_format(self):
+    def test_vsdx_produces_valid_vdx_xml_visio_can_open(self):
+        """The Visio exporter emits legacy VDX 2003 XML. Output must be valid
+        XML with a single ``xmlns`` declaration on the root element — a
+        previous regression emitted duplicate xmlns attributes that broke
+        every Visio open."""
         result = generate_diagram(SAMPLE_ANALYSIS, format="vsdx")
-        assert "content" in result or "filename" in result
+        assert result["format"] == "vsdx"
+        # File extension must be .vdx (legacy XML format) — NOT .vsdx (which
+        # is OOXML zip and would be a lie).
+        assert result["filename"].endswith(".vdx")
+        content = result["content"]
+        # Detect the duplicate xmlns regression directly in the source bytes
+        # before parsing — ET.fromstring will silently accept the second
+        # ``xmlns`` only on some platforms, so we scan the root element's
+        # opening tag manually.
+        # Skip past any ``<?xml ...?>`` declaration to reach the root tag.
+        rest = content
+        if rest.lstrip().startswith("<?xml"):
+            rest = rest.split("?>", 1)[1]
+        root_open = rest[: rest.find(">") + 1]
+        assert root_open.count('xmlns="') == 1, (
+            f"VDX root must have exactly one xmlns declaration; got: {root_open}"
+        )
+        # Must be parseable XML.
+        root = ET.fromstring(content)
+        assert root.tag.endswith("VisioDocument")
+        # Must contain at least one Page.
+        ns = "{http://schemas.microsoft.com/visio/2003/core}"
+        pages = root.find(f"{ns}Pages")
+        assert pages is not None, "VDX missing <Pages> element"
+        assert len(pages.findall(f"{ns}Page")) >= 1
 
     def test_invalid_format_raises(self):
         with pytest.raises((ValueError, KeyError)):
             generate_diagram(SAMPLE_ANALYSIS, format="invalid_format")
+

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -96,8 +96,17 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
   if (id === 'diagram') {
     const data = await api.post(`/diagrams/${diagramId}/export-diagram?format=${format}`);
     const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
+    // Visio export is legacy VDX 2003 XML — extension must be .vdx, not .vsdx.
+    // .vsdx is OOXML zip; if we labelled raw XML as .vsdx, Visio refuses to open.
     const ext = format === 'excalidraw' ? 'excalidraw' : format === 'drawio' ? 'drawio' : 'vdx';
-    return { blob: new Blob([content], { type: 'application/octet-stream' }), filename: data.filename || `archmorph-diagram.${ext}` };
+    // Use format-specific MIME types so the browser/OS can route the file
+    // correctly when saved (instead of a generic octet-stream).
+    const mime = format === 'excalidraw'
+      ? 'application/json'
+      : format === 'drawio'
+      ? 'application/xml'
+      : 'application/vnd.visio'; // VDX legacy XML
+    return { blob: new Blob([content], { type: mime }), filename: data.filename || `archmorph-diagram.${ext}` };
   }
 
   if (id === 'hld') {

--- a/tests/e2e_flow_test.py
+++ b/tests/e2e_flow_test.py
@@ -149,34 +149,58 @@ def run_flow(d: dict):
             print(f"     IaC params: {json.dumps({k: v for k, v in list(iac_params.items())[:5]}, default=str)}")
 
     # ── Step 5a: Export Excalidraw ────────────────────────────
+    # NOTE: ``format`` is a query parameter on the FastAPI route, not a body
+    # field. Sending it via ``json=...`` silently falls back to the default
+    # ("excalidraw") for every call — which is how all three format tests
+    # passed for months while drawio/vsdx exports were broken.
     resp = client.post(
         f"/api/diagrams/{diagram_id}/export-diagram",
-        json={"format": "excalidraw"},
+        params={"format": "excalidraw"},
     )
     ok = resp.status_code == 200
     export_data = resp.json() if ok else {}
-    content_len = len(export_data.get("content", ""))
-    step(f"[{pid}] 5a. Export Excalidraw", ok, f"{content_len} chars")
+    content = export_data.get("content", "")
+    is_excalidraw = ok and content.startswith("{") and '"type": "excalidraw"' in content
+    step(
+        f"[{pid}] 5a. Export Excalidraw",
+        ok and is_excalidraw,
+        f"{len(content)} chars, valid_excalidraw={is_excalidraw}",
+    )
 
     # ── Step 5b: Export Draw.io ───────────────────────────────
     resp = client.post(
         f"/api/diagrams/{diagram_id}/export-diagram",
-        json={"format": "drawio"},
+        params={"format": "drawio"},
     )
     ok = resp.status_code == 200
     export_data = resp.json() if ok else {}
-    has_graph = "mxGraphModel" in export_data.get("content", "")
-    step(f"[{pid}] 5b. Export Draw.io", ok, f"has mxGraphModel={has_graph}")
+    content = export_data.get("content", "")
+    has_graph = "mxGraphModel" in content or "mxfile" in content
+    step(
+        f"[{pid}] 5b. Export Draw.io",
+        ok and has_graph,
+        f"{len(content)} chars, has mxGraphModel={has_graph}",
+    )
 
     # ── Step 5c: Export Visio ─────────────────────────────────
     resp = client.post(
         f"/api/diagrams/{diagram_id}/export-diagram",
-        json={"format": "vsdx"},
+        params={"format": "vsdx"},
     )
     ok = resp.status_code == 200
     export_data = resp.json() if ok else {}
-    has_visio = "VisioDocument" in export_data.get("content", "")
-    step(f"[{pid}] 5c. Export Visio", ok, f"has VisioDocument={has_visio}")
+    content = export_data.get("content", "")
+    filename = export_data.get("filename", "")
+    has_visio = "VisioDocument" in content
+    correct_ext = filename.endswith(".vdx")
+    # Detect the duplicate-xmlns regression that previously slipped past CI.
+    head = content[: content.find(">") + 1] if ">" in content else ""
+    single_xmlns = head.count('xmlns="') == 1
+    step(
+        f"[{pid}] 5c. Export Visio",
+        ok and has_visio and correct_ext and single_xmlns,
+        f"{len(content)} chars, has VisioDocument={has_visio}, ext_ok={correct_ext}, single_xmlns={single_xmlns}",
+    )
 
     # ── Step 6a: Generate Terraform ───────────────────────────
     resp = client.post(

--- a/tests/e2e_flow_test.py
+++ b/tests/e2e_flow_test.py
@@ -11,7 +11,6 @@ Tests the full 9-step translation flow for each diagram:
 
 import json
 import sys
-import time
 import httpx
 
 API = "https://archmorph-api.icyisland-c0dee6ba.northeurope.azurecontainerapps.io"
@@ -194,7 +193,13 @@ def run_flow(d: dict):
     has_visio = "VisioDocument" in content
     correct_ext = filename.endswith(".vdx")
     # Detect the duplicate-xmlns regression that previously slipped past CI.
-    head = content[: content.find(">") + 1] if ">" in content else ""
+    # Strip the XML declaration (`<?xml ... ?>`) before scanning so we count
+    # xmlns on the real root element only.
+    body = content.lstrip()
+    if body.startswith("<?xml"):
+        decl_end = body.find("?>")
+        body = body[decl_end + 2 :].lstrip() if decl_end != -1 else ""
+    head = body[: body.find(">") + 1] if ">" in body else ""
     single_xmlns = head.count('xmlns="') == 1
     step(
         f"[{pid}] 5c. Export Visio",
@@ -219,7 +224,7 @@ def run_flow(d: dict):
     if ok and code:
         # Show first few resource blocks
         lines = code.split("\n")
-        resources = [l.strip() for l in lines if l.strip().startswith("resource")]
+        resources = [line.strip() for line in lines if line.strip().startswith("resource")]
         for r in resources[:5]:
             print(f"     {r}")
         if len(resources) > 5:


### PR DESCRIPTION
## Summary
Fixes #569: real-Visio refused exports because the on-disk extension was `.vsdx` (OOXML zip) but the bytes were VDX 2003 single-XML. The MCP gateway also occasionally returned empty payloads, producing zero-byte files the user could not open.

## Changes
- `backend/routers/analysis.py` — rename on-disk extension to `.vdx`; reject empty MCP responses with 502.
- `backend/diagram_export.py` / `backend/mcp_diagram_generator.py` — tighten error handling on the local fallback path so empty payloads bubble up.
- `backend/tests/test_diagram_export.py` + `tests/e2e_flow_test.py` — assert real parser round-trip on every emit format (no key-existence theatre, per QA guardrail #569).
- `frontend/src/components/DiagramTranslator/ExportHub.jsx` — surface vdx extension to the user.

## API surface
- API `format` value remains `"vsdx"` for frontend stability — only the on-disk extension changes.

## Validation
- All export-format round-trip tests parse with their real parsers.

Closes #569