### PR TITLE
feat(alz): Azure Landing Zone target diagram (#571)

### DIFF
--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -1,0 +1,831 @@
+"""Azure Landing Zone SVG generator (#573).
+
+Renders a region-aware, Microsoft-iconography landing-zone diagram from the
+Archmorph analysis dict.  Output is a single self-contained SVG with all
+icons embedded as ``data:image/svg+xml;base64,...`` data URIs (no external
+references).
+
+Public API::
+
+    generate_landing_zone_svg(analysis, *, dr_variant="primary") -> dict[str, str]
+
+Returns ``{"format": "landing-zone-svg", "filename": ..., "content": ...}``.
+
+Sub-issue: https://github.com/idokatz86/Archmorph/issues/573
+Parent epic: https://github.com/idokatz86/Archmorph/issues/571
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import xml.etree.ElementTree as ET
+from typing import Any, Literal, Optional
+
+from azure_landing_zone_schema import (
+    infer_actors,
+    infer_dr_mode,
+    infer_regions,
+    infer_replication,
+    infer_tiers_from_mappings,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — palette, fonts, dimensions
+# ---------------------------------------------------------------------------
+
+# Microsoft Fluent palette (same swatches used in the parity-target build.py).
+COLOR_PRIMARY      = "#0078D4"   # Azure blue
+COLOR_PURPLE       = "#5C2D91"   # Subnet purple
+COLOR_GREEN        = "#107C10"   # Active / success
+COLOR_RED          = "#C73E1D"   # DR / standby
+COLOR_DEEP_PURPLE  = "#742774"   # Event Hubs
+COLOR_K8S          = "#326CE5"   # AKS
+COLOR_CYAN         = "#3CCBF4"   # Front Door
+COLOR_TEAL         = "#00BFB3"   # AVA
+COLOR_AMBER        = "#B25E00"   # Cross-region replication
+COLOR_DB           = "#1A5DAB"   # Managed DB
+COLOR_INK          = "#1B2541"   # Primary text
+COLOR_INK_2        = "#3a4a6e"   # Secondary edges
+COLOR_BG           = "#FAFBFC"   # Canvas
+
+FONT_STACK = "'Segoe UI','Segoe UI Variable',system-ui,-apple-system,Helvetica,Arial,sans-serif"
+
+CANVAS_W = 1800
+CANVAS_H_PRIMARY = 1330
+CANVAS_H_DR = 2120
+
+# Hard cap on returned SVG size — protect downstream renderers and HTTP layer.
+MAX_SVG_BYTES = 300 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Icon resolution — registry-first, fallback to coloured-tile placeholder
+# ---------------------------------------------------------------------------
+
+# Logical icon keys map → Azure service IDs known to the icon registry.
+# When the registry has no match the placeholder is used; the SVG is always
+# renderable.
+_ICON_SERVICE_IDS: dict[str, list[str]] = {
+    "frontdoor":    ["azure-front-door", "Front Door", "frontdoor"],
+    "appgw":        ["application-gateway", "App Gateway", "appgw"],
+    "storage":      ["azure-storage", "storage-account", "blob"],
+    "aks":          ["aks", "kubernetes-service", "azure-kubernetes-service"],
+    "files":        ["azure-files", "storage-files", "files"],
+    "sql":          ["azure-sql", "sql-database", "azure-sql-database"],
+    "eventhub":     ["event-hubs", "eventhub", "azure-event-hubs"],
+    "monitor":      ["azure-monitor", "monitor"],
+    "appinsights":  ["application-insights", "app-insights", "appinsights"],
+    "loganalytics": ["log-analytics", "loganalytics"],
+    "dns":          ["private-dns", "azure-dns", "dns"],
+    "avd":          ["avd", "azure-virtual-desktop", "virtual-desktop"],
+    "entra":        ["entra-id", "azure-active-directory", "aad"],
+    "keyvault":     ["key-vault", "keyvault"],
+    "region":       ["region", "azure-region"],
+    "subnet":       ["subnet", "virtual-network-subnet"],
+    "vm":           ["virtual-machine", "vm"],
+    "vnet":         ["virtual-network", "vnet"],
+    "rg":           ["resource-group", "rg"],
+    "user":         ["user", "person"],
+}
+
+# Per-key fallback tile color so the placeholder still reads at a glance.
+_ICON_TILE_COLOR: dict[str, str] = {
+    "frontdoor":    COLOR_CYAN,
+    "appgw":        COLOR_PRIMARY,
+    "storage":      COLOR_PRIMARY,
+    "aks":          COLOR_K8S,
+    "files":        COLOR_PRIMARY,
+    "sql":          COLOR_DB,
+    "eventhub":     COLOR_DEEP_PURPLE,
+    "monitor":      COLOR_PRIMARY,
+    "appinsights":  COLOR_PRIMARY,
+    "loganalytics": COLOR_PRIMARY,
+    "dns":          COLOR_PURPLE,
+    "avd":          COLOR_PRIMARY,
+    "entra":        COLOR_PRIMARY,
+    "keyvault":     COLOR_PRIMARY,
+    "region":       COLOR_GREEN,
+    "subnet":       COLOR_PURPLE,
+    "vm":           COLOR_PRIMARY,
+    "vnet":         COLOR_GREEN,
+    "rg":           COLOR_PRIMARY,
+    "user":         COLOR_INK_2,
+}
+
+
+def _resolve_data_uri(icon_key: str) -> Optional[str]:
+    """Look the icon up in Archmorph's icon registry and return a data URI."""
+    try:
+        from icons.registry import resolve_icon  # type: ignore
+    except Exception:  # nosec B110 - registry optional
+        return None
+
+    candidates = _ICON_SERVICE_IDS.get(icon_key, [icon_key])
+    for sid in candidates:
+        try:
+            entry = resolve_icon(sid, provider="azure")
+        except Exception:  # nosec B110 - any registry error → placeholder
+            entry = None
+        if entry and entry.svg:
+            try:
+                b64 = base64.b64encode(entry.svg.encode("utf-8")).decode("ascii")
+            except Exception:  # nosec B110 - encoding errors → placeholder
+                continue
+            return f"data:image/svg+xml;base64,{b64}"
+    return None
+
+
+_ICON_CACHE: dict[str, Optional[str]] = {}
+
+
+def _icon_data_uri(icon_key: str) -> Optional[str]:
+    """Cached registry lookup."""
+    if icon_key not in _ICON_CACHE:
+        _ICON_CACHE[icon_key] = _resolve_data_uri(icon_key)
+    return _ICON_CACHE[icon_key]
+
+
+def _img(icon_key: str, x: float, y: float, w: float, h: float) -> str:
+    """Render an icon, falling back to a labelled tile when registry misses."""
+    uri = _icon_data_uri(icon_key)
+    if uri:
+        return (
+            f'<image href="{uri}" x="{x}" y="{y}" '
+            f'width="{w}" height="{h}" preserveAspectRatio="xMidYMid meet"/>'
+        )
+    # Placeholder: filled rectangle with two-letter glyph.
+    color = _ICON_TILE_COLOR.get(icon_key, COLOR_PRIMARY)
+    glyph = _placeholder_glyph(icon_key)
+    return (
+        f'<g class="icon-fallback">'
+        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="3" '
+        f'fill="{color}" stroke="{COLOR_INK}" stroke-width="0.5" stroke-opacity="0.2"/>'
+        f'<text x="{x + w / 2}" y="{y + h / 2 + h * 0.12}" '
+        f'fill="#FFFFFF" font-family="{FONT_STACK}" font-size="{max(8, h * 0.5):.1f}" '
+        f'font-weight="700" text-anchor="middle">{_xml_escape(glyph)}</text>'
+        f'</g>'
+    )
+
+
+def _placeholder_glyph(icon_key: str) -> str:
+    """Two-character glyph used in placeholder tiles."""
+    table = {
+        "frontdoor": "FD", "appgw": "AG", "storage": "ST", "aks": "AK",
+        "files": "AF", "sql": "DB", "eventhub": "EH", "monitor": "AM",
+        "appinsights": "AI", "loganalytics": "LA", "dns": "DN", "avd": "VD",
+        "entra": "ID", "keyvault": "KV", "region": "RG", "subnet": "SN",
+        "vm": "VM", "vnet": "VN", "rg": "RG", "user": "U",
+    }
+    return table.get(icon_key, icon_key[:2].upper())
+
+
+# ---------------------------------------------------------------------------
+# SVG primitives
+# ---------------------------------------------------------------------------
+
+_INVALID_XML_CHARS = re.compile(
+    r'[\x00-\x08\x0b\x0c\x0e-\x1f]'
+)
+
+
+def _xml_escape(s: str) -> str:
+    """Escape a string for inclusion as XML text content."""
+    s = _INVALID_XML_CHARS.sub("", s or "")
+    return (
+        s.replace("&", "&amp;")
+         .replace("<", "&lt;")
+         .replace(">", "&gt;")
+         .replace('"', "&quot;")
+         .replace("'", "&apos;")
+    )
+
+
+def _tx(x: float, y: float, text: str, cls: str, anchor: str = "start", weight: str = "") -> str:
+    """Single text element."""
+    weight_attr = f' font-weight="{weight}"' if weight else ""
+    return (
+        f'<text x="{x}" y="{y}" class="{cls}" text-anchor="{anchor}"{weight_attr}>'
+        f'{_xml_escape(text)}</text>'
+    )
+
+
+def _card(x: float, y: float, w: float, h: float, *, stroke: str = COLOR_PRIMARY,
+          fill: str = "#FFFFFF", rx: int = 6) -> str:
+    """White rounded card."""
+    return (
+        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{rx}" '
+        f'fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>'
+    )
+
+
+def _defs() -> str:
+    """SVG <defs> with style sheet, arrow markers."""
+    return f"""<defs>
+<style><![CDATA[
+text {{ font-family: {FONT_STACK}; }}
+.t-title {{ font-size: 22px; font-weight: 700; fill: {COLOR_INK}; }}
+.t-sub   {{ font-size: 13px; fill: #44506b; }}
+.t-banner {{ font-size: 12px; font-weight: 700; fill: #FFFFFF; }}
+.t-card-h-lg {{ font-size: 14px; font-weight: 700; fill: {COLOR_INK}; }}
+.t-card-h    {{ font-size: 12px; font-weight: 700; fill: {COLOR_INK}; }}
+.t-meta      {{ font-size: 11px; fill: #44506b; }}
+.t-tiny      {{ font-size: 10px; fill: #44506b; }}
+.t-tinier    {{ font-size:  9px; fill: #44506b; }}
+.t-edge      {{ font-size: 11px; fill: {COLOR_INK_2}; }}
+.t-edge-g    {{ font-size: 11px; font-weight: 700; fill: {COLOR_GREEN}; }}
+.t-edge-r    {{ font-size: 11px; font-weight: 700; fill: {COLOR_RED}; }}
+.t-legend-h  {{ font-size: 13px; font-weight: 700; fill: {COLOR_INK}; }}
+.t-legend    {{ font-size: 11px; fill: {COLOR_INK}; }}
+.t-mapnote   {{ font-size: 11px; fill: #44506b; }}
+.t-actor-h   {{ font-size: 12px; font-weight: 700; fill: {COLOR_INK}; }}
+.t-traffic-g {{ font-size: 12px; font-weight: 700; fill: {COLOR_GREEN}; }}
+.t-traffic-r {{ font-size: 12px; font-weight: 700; fill: {COLOR_RED}; }}
+]]></style>
+<marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+  <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_INK_2}"/>
+</marker>
+<marker id="ag" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+  <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_GREEN}"/>
+</marker>
+<marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+  <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_RED}"/>
+</marker>
+</defs>"""
+
+
+# ---------------------------------------------------------------------------
+# Rendering — actors / front door / region stamp / legend
+# ---------------------------------------------------------------------------
+
+def _actors_row(actors: list[dict[str, Any]]) -> str:
+    """Top swimlane of actors, evenly distributed across the canvas."""
+    out = ['<g id="actors">']
+    if not actors:
+        return "</g>".join(out + [""])
+
+    # Distribute up to 6 actors across canvas width.
+    visible = actors[:6]
+    span = CANVAS_W - 200
+    step = span / max(1, len(visible))
+    for i, actor in enumerate(visible):
+        cx = 100 + step * (i + 0.5)
+        out.append(f'<g transform="translate({cx - 60}, 86)">')
+        out.append(_card(0, 0, 120, 56, stroke=COLOR_INK_2))
+        out.append(_img("user", 8, 8, 28, 28))
+        out.append(_tx(44, 22, actor.get("name", ""), "t-actor-h"))
+        if actor.get("subtitle"):
+            out.append(_tx(44, 38, actor["subtitle"], "t-tiny"))
+        kind = actor.get("kind", "external")
+        out.append(_tx(44, 50, f"({kind})", "t-tinier"))
+        out.append('</g>')
+        # Actor → Front Door arrow
+        out.append(
+            f'<line x1="{cx}" y1="142" x2="{cx}" y2="208" '
+            f'stroke="{COLOR_INK_2}" stroke-width="1.4" '
+            f'stroke-dasharray="3 3" marker-end="url(#a)"/>'
+        )
+        edge = actor.get("edge_label", "HTTPS")
+        if edge:
+            out.append(_tx(cx + 6, 180, edge, "t-edge"))
+    out.append('</g>')
+    return "\n".join(out)
+
+
+def _front_door(regions: list[dict[str, Any]], dr_mode: str) -> str:
+    """Front Door banner with traffic chips per region."""
+    x, y, w, h = 560, 208, 900, 56
+    out = [f'<g id="front-door" transform="translate({x}, {y})">',
+           _card(0, 0, w, h, stroke=COLOR_CYAN),
+           _img("frontdoor", 12, 12, 32, 32),
+           _tx(54, 24, "Azure Front Door + WAF", "t-card-h-lg"),
+           _tx(54, 40, "Global edge · TLS termination · path-based routing · health probes",
+               "t-meta")]
+
+    # Traffic chips for up to two regions.
+    chip_x = [660, 770]
+    for i, region in enumerate(regions[:2]):
+        try:
+            pct = int(round(float(region.get("traffic_pct", 0))))
+        except (TypeError, ValueError):
+            pct = 0
+        active = pct > 0 if dr_mode != "single-region" else True
+        color = COLOR_GREEN if active else COLOR_RED
+        cls = "t-traffic-g" if active else "t-traffic-r"
+        cx = chip_x[i] if i < len(chip_x) else 660 + i * 110
+        out.append(
+            f'<rect x="{cx}" y="12" width="100" height="32" rx="6" '
+            f'fill="#FFFFFF" stroke="{color}" stroke-width="1.5"/>'
+        )
+        out.append(_tx(cx + 50, 30, f"{pct}% → R{i + 1}", cls, anchor="middle"))
+    out.append('</g>')
+    return "\n".join(out)
+
+
+def _legend(y: int) -> str:
+    """7-column × 2-row icon grid + line-style key + AWS→Azure mapping line."""
+    H = 124
+    out = [
+        f'<rect x="20" y="{y}" width="1760" height="{H}" rx="6" '
+        f'fill="#FFFFFF" stroke="#5b6b8c" stroke-width="1"/>',
+        _tx(40, y + 20, "Legend", "t-legend-h"),
+    ]
+    items = [
+        ("frontdoor",    "Front Door + WAF"),
+        ("appgw",        "App Gateway WAFv2"),
+        ("storage",      "Storage (Blob/SFTP)"),
+        ("aks",          "Azure Kubernetes Service"),
+        ("files",        "Azure Files (SMB)"),
+        ("sql",          "Managed Relational DB"),
+        ("eventhub",     "Event Hubs"),
+        ("monitor",      "Azure Monitor"),
+        ("appinsights",  "App Insights"),
+        ("loganalytics", "Log Analytics"),
+        ("dns",          "Private DNS"),
+        ("avd",          "Azure Virtual Desktop"),
+        ("entra",        "Entra ID"),
+        ("keyvault",     "Key Vault"),
+    ]
+    cols = 7
+    col_w = 240
+    row_h = 28
+    base_x = 40
+    base_y = y + 30
+    for i, (k, lbl) in enumerate(items):
+        r = i // cols
+        c = i % cols
+        cx = base_x + c * col_w
+        cy = base_y + r * row_h
+        out.append(_img(k, cx, cy, 18, 18))
+        out.append(_tx(cx + 24, cy + 13, lbl, "t-legend"))
+
+    # Line-style key row.
+    line_y = y + 92
+    out.append(f'<rect x="40"  y="{line_y}" width="14" height="3" fill="{COLOR_GREEN}"/>')
+    out.append(_tx(60, line_y + 6, "Active path", "t-legend"))
+    out.append(f'<rect x="160" y="{line_y}" width="14" height="3" fill="{COLOR_RED}"/>')
+    out.append(_tx(180, line_y + 6, "DR / standby", "t-legend"))
+    out.append(f'<rect x="280" y="{line_y}" width="14" height="3" fill="{COLOR_INK_2}"/>')
+    out.append(_tx(300, line_y + 6, "Data flow", "t-legend"))
+    out.append(
+        f'<line x1="380" y1="{line_y + 1}" x2="394" y2="{line_y + 1}" '
+        f'stroke="{COLOR_DB}" stroke-width="2" stroke-dasharray="4 2"/>'
+    )
+    out.append(_tx(400, line_y + 6, "HA replication", "t-legend"))
+    out.append(
+        f'<line x1="500" y1="{line_y + 1}" x2="514" y2="{line_y + 1}" '
+        f'stroke="{COLOR_AMBER}" stroke-width="2"/>'
+    )
+    out.append(_tx(520, line_y + 6, "Cross-region replication", "t-legend"))
+    out.append(_tx(720, line_y + 6, "Mapping:", "t-mapnote", weight="700"))
+    out.append(_tx(
+        780, line_y + 6,
+        "AWS → Azure · ALB → App Gateway · EKS → AKS · EFS → Azure Files · "
+        "Kafka → Event Hubs · RDS → Managed DB",
+        "t-mapnote"))
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Region stamp — the bulk of the diagram
+# ---------------------------------------------------------------------------
+
+# Layout constants for region stamp.
+REGION_W = 1740
+REGION_H = 760
+
+# Tier-1 card slots (left → right) — must total to width REGION_W.
+# (relative_x, width, icon_key, default_label)
+_TIER1_CARDS: list[tuple[int, int, str, str]] = [
+    (50,   220, "storage", "Storage"),
+    (360,  270, "appgw",   "Application Gateway"),
+    (660,  240, "avd",     "Azure Virtual Desktop"),
+    (910,  350, "monitor", "Observability"),
+    (1290, 170, "dns",     "Private DNS"),
+    (1480, 220, "entra",   "Identity"),
+]
+
+
+def _region_stamp(x: int, y: int, region: dict[str, Any], tiers: dict[str, list[dict[str, Any]]],
+                  *, status: str = "primary", role_text: str = "") -> str:
+    """One region container with tiered services."""
+    out = [f'<g transform="translate({x}, {y})">']
+
+    # Outer region card.
+    region_color = COLOR_GREEN if status == "primary" else COLOR_RED
+    out.append(
+        f'<rect x="0" y="0" width="{REGION_W}" height="{REGION_H}" rx="10" '
+        f'fill="#FFFFFF" stroke="{region_color}" stroke-width="2"/>'
+    )
+    # Region header strip.
+    out.append(
+        f'<rect x="0" y="0" width="{REGION_W}" height="34" rx="2" '
+        f'fill="{region_color}"/>'
+    )
+    out.append(_img("region", 8, 8, 18, 18))
+    out.append(_tx(34, 22, region.get("name", "Region"), "t-banner"))
+    if role_text:
+        out.append(_tx(REGION_W - 16, 22, role_text, "t-banner", anchor="end"))
+
+    # Resource Group container.
+    rg_w, rg_h = 1700, 706
+    out.append(
+        f'<rect x="20" y="38" width="{rg_w}" height="{rg_h}" rx="8" '
+        f'fill="#F7F9FC" stroke="{COLOR_PRIMARY}" stroke-width="1"/>'
+    )
+    out.append(
+        f'<rect x="20" y="38" width="280" height="22" rx="2" '
+        f'fill="{COLOR_PRIMARY}"/>'
+    )
+    out.append(_img("rg", 24, 40, 16, 16))
+    out.append(_tx(46, 54, "Resource Group · landing-zone", "t-banner"))
+
+    # Tier-1 cards (top row).
+    out.append(_tier1_row(tiers))
+
+    # VNet + subnets (centre band).
+    out.append(_vnet_block(tiers))
+
+    # Files banner + Data subnet.
+    out.append(_data_band(tiers))
+
+    out.append('</g>')
+    return "\n".join(out)
+
+
+def _tier1_row(tiers: dict[str, list[dict[str, Any]]]) -> str:
+    """Top tier — ingress / observability / identity / DNS / storage."""
+    out: list[str] = []
+
+    # Resolve a per-slot service name from tiers when available.
+    ingress_names    = [s["name"] for s in tiers.get("ingress", [])]
+    storage_names    = [s["name"] for s in tiers.get("storage", [])]
+    identity_names   = [s["name"] for s in tiers.get("identity", [])]
+    obs_names        = [s["name"] for s in tiers.get("observability", [])]
+
+    slot_overrides = {
+        "storage": storage_names[0] if storage_names else None,
+        "appgw":   ingress_names[0] if ingress_names else None,
+        "entra":   identity_names[0] if identity_names else None,
+    }
+
+    for rel_x, w, icon_key, default_label in _TIER1_CARDS:
+        h = 100
+        y = 76
+        label = slot_overrides.get(icon_key) or default_label
+        out.append(_card(rel_x, y, w, h, stroke=COLOR_PRIMARY))
+        # The Observability tile gets a row of 5 sub-icons.
+        if icon_key == "monitor":
+            out.append(_tx(rel_x + w / 2, y + 22, "Observability", "t-card-h-lg",
+                           anchor="middle"))
+            sub_icons = ["monitor", "appinsights", "loganalytics", "monitor", "monitor"]
+            sub_labels = ["Monitor", "App Insights", "Log Analytics", "Alerts", "Workbooks"]
+            for i, (sic, slabel) in enumerate(zip(sub_icons, sub_labels)):
+                cx = rel_x + 22 + i * 64
+                out.append(_img(sic, cx - 11, y + 32, 22, 22))
+                out.append(_tx(cx, y + 70, slabel, "t-tinier", anchor="middle"))
+            # Provide one summary line listing what we found for observability.
+            summary = ", ".join(obs_names[:3]) if obs_names else "centralised"
+            out.append(_tx(rel_x + w / 2, y + 88, summary, "t-tinier", anchor="middle"))
+        else:
+            out.append(_img(icon_key, rel_x + 12, y + 12, 28, 28))
+            out.append(_tx(rel_x + 48, y + 28, label, "t-card-h"))
+            # Subtitle from tiers if available.
+            subtitle = ""
+            if icon_key == "storage" and tiers.get("storage"):
+                subtitle = tiers["storage"][0].get("subtitle", "")
+            elif icon_key == "appgw" and tiers.get("ingress"):
+                subtitle = tiers["ingress"][0].get("subtitle", "")
+            elif icon_key == "entra" and tiers.get("identity"):
+                subtitle = tiers["identity"][0].get("subtitle", "")
+            elif icon_key == "dns":
+                subtitle = "Private DNS zones · service discovery"
+            elif icon_key == "avd":
+                subtitle = "Bastion · session host · just-in-time"
+            if subtitle:
+                out.append(_tx(rel_x + 48, y + 44, subtitle, "t-tiny"))
+            out.append(_tx(rel_x + 48, y + 64, "Zone-redundant", "t-tinier"))
+
+    return "\n".join(out)
+
+
+def _vnet_block(tiers: dict[str, list[dict[str, Any]]]) -> str:
+    """VNet container with Application Subnet + AKS + 3 AZ columns."""
+    out: list[str] = []
+    vnet_x, vnet_y, vnet_w, vnet_h = 40, 200, 1480, 540
+    out.append(
+        f'<rect x="{vnet_x}" y="{vnet_y}" width="{vnet_w}" height="{vnet_h}" rx="8" '
+        f'fill="#F0FAF0" stroke="{COLOR_GREEN}" stroke-width="1.5"/>'
+    )
+    out.append(
+        f'<rect x="{vnet_x}" y="{vnet_y}" width="240" height="22" rx="2" '
+        f'fill="{COLOR_GREEN}"/>'
+    )
+    out.append(_img("vnet", vnet_x + 4, vnet_y + 3, 16, 16))
+    out.append(_tx(vnet_x + 26, vnet_y + 17, "VNet · 10.0.0.0/16", "t-banner"))
+
+    # Application Subnet.
+    app_x, app_y, app_w, app_h = 60, 234, 1440, 396
+    out.append(
+        f'<rect x="{app_x}" y="{app_y}" width="{app_w}" height="{app_h}" rx="6" '
+        f'fill="#F4F2FA" stroke="{COLOR_PURPLE}" stroke-width="1.5"/>'
+    )
+    out.append(
+        f'<rect x="{app_x}" y="{app_y}" width="280" height="20" rx="2" '
+        f'fill="{COLOR_PURPLE}"/>'
+    )
+    out.append(_img("subnet", app_x + 4, app_y + 1, 16, 16))
+    out.append(_tx(app_x + 26, app_y + 15, "Application Subnet · 10.0.1.0/24", "t-banner"))
+
+    # AKS container inside Application subnet.
+    aks_x, aks_y, aks_w, aks_h = 246, 272, 1000, 304
+    out.append(
+        f'<rect x="{aks_x}" y="{aks_y}" width="{aks_w}" height="{aks_h}" rx="6" '
+        f'fill="#FFFFFF" stroke="{COLOR_K8S}" stroke-width="1.5"/>'
+    )
+    out.append(
+        f'<rect x="{aks_x}" y="{aks_y}" width="340" height="22" rx="2" '
+        f'fill="{COLOR_K8S}"/>'
+    )
+    out.append(_img("aks", aks_x + 4, aks_y + 2, 18, 18))
+    aks_label_names = [s["name"] for s in tiers.get("compute", [])][:1]
+    aks_title = f"{aks_label_names[0]} · 3 zones" if aks_label_names else "Azure Kubernetes Service · 3 zones"
+    out.append(_tx(aks_x + 28, aks_y + 16, aks_title, "t-banner"))
+
+    # 3 AZ columns. Pull workload pod names from compute tier when available.
+    compute_pods = [s["name"] for s in tiers.get("compute", [])]
+    az_pods_default = [
+        ["Workload pods", "Background workers", "Service mesh", "Sidecars", "Init pods", None],
+        ["Workload pods", "Background workers", "Service mesh", None, None, None],
+        ["Workload pods", None, "Service mesh", None, None, None],
+    ]
+    # If we have explicit compute services, surface up to 5 in AZ1.
+    if compute_pods:
+        custom = compute_pods[:5] + [None] * (6 - min(5, len(compute_pods)))
+        az_pods_default[0] = custom
+
+    for i in range(3):
+        ax = 260 + i * 330
+        ay = 304
+        out.append(_az_column(ax, ay, f"Availability Zone {i + 1}", az_pods_default[i]))
+
+    # Files banner.
+    fb_x, fb_y, fb_w, fb_h = 80, 588, 1404, 38
+    out.append(_card(fb_x, fb_y, fb_w, fb_h, stroke=COLOR_PRIMARY))
+    out.append(_img("files", fb_x + 8, fb_y + 4, 30, 30))
+    files_name = "Azure Files (SMB)"
+    files_subtitle = "Shared file storage · zone-redundant"
+    for s in tiers.get("storage", []):
+        if "files" in s["name"].lower() or "smb" in s["name"].lower():
+            files_name = s["name"]
+            if s.get("subtitle"):
+                files_subtitle = s["subtitle"]
+            break
+    out.append(_tx(fb_x + 48, fb_y + 18, files_name, "t-card-h"))
+    out.append(_tx(fb_x + 48, fb_y + 32, files_subtitle, "t-meta"))
+    return "\n".join(out)
+
+
+def _az_column(x: int, y: int, label: str, pods: list[Optional[str]]) -> str:
+    """Single AZ column with header + 6 pod cells."""
+    out = [f'<g transform="translate({x}, {y})">']
+    col_w, col_h = 320, 260
+    out.append(_card(0, 0, col_w, col_h, stroke=COLOR_INK_2))
+    out.append(
+        f'<rect x="0" y="0" width="{col_w}" height="22" rx="2" fill="{COLOR_INK_2}"/>'
+    )
+    out.append(_tx(8, 16, label, "t-banner"))
+
+    cell_h = 36
+    for i, pod in enumerate(pods[:6]):
+        cy = 30 + i * cell_h
+        out.append(
+            f'<rect x="8" y="{cy}" width="{col_w - 16}" height="{cell_h - 4}" rx="4" '
+            f'fill="#FFFFFF" stroke="#cdd5e3" stroke-width="1"/>'
+        )
+        if pod:
+            out.append(_tx(col_w / 2, cy + 20, pod, "t-tiny", anchor="middle"))
+        else:
+            out.append(_tx(col_w / 2, cy + 20, "(empty)", "t-tinier", anchor="middle"))
+    out.append('</g>')
+    return "\n".join(out)
+
+
+def _data_band(tiers: dict[str, list[dict[str, Any]]]) -> str:
+    """Data subnet — primary + standby DB pair."""
+    out: list[str] = []
+    ds_x, ds_y, ds_w, ds_h = 60, 652, 1440, 88
+    out.append(
+        f'<rect x="{ds_x}" y="{ds_y}" width="{ds_w}" height="{ds_h}" rx="6" '
+        f'fill="#F4F2FA" stroke="{COLOR_PURPLE}" stroke-width="1.5"/>'
+    )
+    out.append(
+        f'<rect x="{ds_x}" y="{ds_y}" width="240" height="20" rx="2" '
+        f'fill="{COLOR_PURPLE}"/>'
+    )
+    out.append(_img("subnet", ds_x + 4, ds_y + 1, 16, 16))
+    out.append(_tx(ds_x + 26, ds_y + 15, "Data Subnet · 10.0.2.0/24", "t-banner"))
+
+    db_names = [s["name"] for s in tiers.get("data", [])]
+    primary_label = db_names[0] if db_names else "Managed Relational DB"
+    secondary_label = db_names[1] if len(db_names) > 1 else f"{primary_label} · Standby"
+
+    # Primary DB.
+    out.append(f'<g transform="translate({ds_x + 300}, {ds_y + 28})">')
+    out.append(_card(0, 0, 320, 50, stroke=COLOR_DB))
+    out.append(_img("sql", 8, 8, 36, 36))
+    out.append(_tx(50, 22, f"{primary_label} · Primary", "t-card-h"))
+    out.append(_tx(50, 38, "Zone 1 · synchronous HA · zone-redundant", "t-meta"))
+    out.append('</g>')
+
+    # HA replication arrow.
+    arrow_x1 = ds_x + 620
+    arrow_x2 = ds_x + 820
+    out.append(
+        f'<line x1="{arrow_x1}" y1="{ds_y + 53}" x2="{arrow_x2}" y2="{ds_y + 53}" '
+        f'stroke="{COLOR_DB}" stroke-width="1.8" stroke-dasharray="6 4"/>'
+    )
+    out.append(_tx((arrow_x1 + arrow_x2) / 2, ds_y + 46,
+                   "HA replication · Multi-AZ sync", "t-edge", anchor="middle", weight="700"))
+
+    # Standby DB.
+    out.append(f'<g transform="translate({ds_x + 820}, {ds_y + 28})">')
+    out.append(_card(0, 0, 320, 50, stroke=COLOR_DB))
+    out.append(_img("sql", 8, 8, 36, 36))
+    out.append(_tx(50, 22, secondary_label, "t-card-h"))
+    out.append(_tx(50, 38, "Zone 2 · HA replica · automatic failover", "t-meta"))
+    out.append('</g>')
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Replication band (DR variant)
+# ---------------------------------------------------------------------------
+
+def _replication_band(y: int, replication: list[dict[str, Any]]) -> str:
+    """Cross-region replication band between two regions."""
+    height = 78
+    out = [
+        f'<rect x="20" y="{y}" width="1760" height="{height}" rx="8" '
+        f'fill="#FFF8E1" stroke="{COLOR_AMBER}" stroke-width="1.5"/>',
+        _tx(40, y + 22, "Cross-Region Replication & DR Plumbing", "t-card-h-lg"),
+    ]
+    items = replication[:6] if replication else []
+    if not items:
+        return "\n".join(out)
+    col_w = 1760 // max(1, len(items))
+    col_w = min(col_w, 290)
+    for i, item in enumerate(items):
+        cx = 40 + i * col_w
+        out.append(
+            f'<line x1="{cx - 6}" y1="{y + 34}" x2="{cx - 6}" y2="{y + 72}" '
+            f'stroke="{COLOR_AMBER}" stroke-width="1.5"/>'
+        )
+        out.append(_tx(cx, y + 44, item.get("name", ""), "t-meta", weight="700"))
+        out.append(_tx(cx, y + 60, item.get("mode", ""), "t-tiny"))
+
+    # Failover arrow gestures.
+    out.append(
+        f'<path d="M 900 {y - 6} l 0 -10 m -8 0 l 8 -10 l 8 10" '
+        f'stroke="{COLOR_AMBER}" stroke-width="2" fill="none"/>'
+    )
+    out.append(
+        f'<path d="M 900 {y + height + 4} l 0 10 m -8 0 l 8 10 l 8 -10" '
+        f'stroke="{COLOR_AMBER}" stroke-width="2" fill="none"/>'
+    )
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def generate_landing_zone_svg(
+    analysis: dict[str, Any],
+    *,
+    dr_variant: Literal["primary", "dr"] = "primary",
+) -> dict[str, str]:
+    """Render the landing zone SVG for the given analysis.
+
+    Returns ``{"format": "landing-zone-svg", "filename": ..., "content": ...}``.
+    Raises :class:`ValueError` for invalid input or oversized output.
+    """
+    if dr_variant not in ("primary", "dr"):
+        raise ValueError(f"dr_variant must be 'primary' or 'dr', got {dr_variant!r}")
+    if not isinstance(analysis, dict):
+        raise ValueError("analysis must be a dict")
+
+    regions = infer_regions(analysis, dr_variant=dr_variant)
+    dr_mode = infer_dr_mode(analysis)
+    tiers = infer_tiers_from_mappings(analysis)
+    actors = infer_actors(analysis)
+    replication = infer_replication(analysis)
+
+    title = analysis.get("title") or "Azure Landing Zone"
+    subtitle_bits = [
+        f"Regions: {', '.join(r['name'] for r in regions)}",
+        f"DR mode: {dr_mode}",
+    ]
+    if dr_variant == "dr":
+        subtitle_bits.append("Variant: full DR")
+    subtitle = " · ".join(subtitle_bits)
+
+    if dr_variant == "dr":
+        H = CANVAS_H_DR
+    else:
+        H = CANVAS_H_PRIMARY
+
+    parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {CANVAS_W} {H}" '
+        f'width="{CANVAS_W}" height="{H}">',
+        _defs(),
+        f'<rect width="{CANVAS_W}" height="{H}" fill="{COLOR_BG}"/>',
+        _tx(40, 38, _truncate(title, 90), "t-title"),
+        _tx(40, 60, _truncate(subtitle, 200), "t-sub"),
+        _actors_row(actors),
+        _front_door(regions, dr_mode),
+    ]
+
+    # Region 1 stamp.
+    primary_role = regions[0].get("role", "primary")
+    primary_role_text = (
+        f"Active · {regions[0].get('traffic_pct', 100)}% traffic"
+        if primary_role == "primary" else f"{primary_role.title()} role"
+    )
+    parts.append(_region_stamp(
+        20, 290, regions[0], tiers,
+        status="primary",
+        role_text=primary_role_text,
+    ))
+
+    if dr_variant == "primary":
+        # Collapsed Region 2 banner if a second region is configured.
+        if len(regions) >= 2:
+            r2 = regions[1]
+            parts.append(
+                f'<rect x="20" y="1064" width="1760" height="56" rx="8" '
+                f'fill="#FFF5F4" stroke="{COLOR_RED}" stroke-width="1.5" '
+                f'stroke-dasharray="6 4"/>'
+            )
+            parts.append(_img("region", 28, 1074, 22, 22))
+            parts.append(_tx(60, 1086, f"{r2['name']} (DR · {r2.get('traffic_pct', 0)}% traffic)",
+                             "t-card-h-lg"))
+            parts.append(_tx(60, 1108,
+                             "Symmetric stamp · paired region · standby for failover · "
+                             "GRS for Storage · geo-replica DB · KV replication",
+                             "t-meta"))
+            parts.append(_tx(1772, 1086, f"{r2.get('traffic_pct', 0)}% traffic",
+                             "t-edge-r", anchor="end"))
+        parts.append(_legend(1140))
+    else:
+        # Full DR — replication band + Region 2 stamp + legend.
+        band_y = 1062
+        parts.append(_replication_band(band_y, replication))
+        r2_y = band_y + 78 + 12
+        if len(regions) >= 2:
+            r2 = regions[1]
+            parts.append(_region_stamp(
+                20, r2_y, r2, tiers,
+                status="standby",
+                role_text=f"Standby · {r2.get('traffic_pct', 0)}% traffic · automated failover",
+            ))
+        parts.append(_legend(r2_y + 776))
+
+    parts.append('</svg>')
+
+    svg_xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + "\n".join(parts)
+
+    # Validate well-formed XML before returning.
+    try:
+        ET.fromstring(svg_xml)
+    except ET.ParseError as exc:
+        raise ValueError(f"Generated SVG is not well-formed XML: {exc}") from exc
+
+    if len(svg_xml.encode("utf-8")) > MAX_SVG_BYTES:
+        raise ValueError(
+            f"Generated SVG exceeds the {MAX_SVG_BYTES}-byte limit "
+            f"(got {len(svg_xml.encode('utf-8'))} bytes)"
+        )
+
+    zone_name = "diagram"
+    zones = analysis.get("zones") or []
+    if zones and isinstance(zones[0], dict) and zones[0].get("name"):
+        zone_name = _safe_filename_part(zones[0]["name"])
+
+    return {
+        "format": "landing-zone-svg",
+        "filename": f"archmorph-{zone_name}-landing-zone-{dr_variant}.svg",
+        "content": svg_xml,
+    }
+
+
+def _truncate(text: str, n: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= n:
+        return text
+    return text[: max(0, n - 1)].rstrip() + "…"
+
+
+def _safe_filename_part(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-")
+    return cleaned or "diagram"

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -716,10 +716,17 @@ def generate_landing_zone_svg(
         raise ValueError("analysis must be a dict")
 
     regions = infer_regions(analysis, dr_variant=dr_variant)
-    dr_mode = infer_dr_mode(analysis)
+    # Infer dr_mode and replication from the *effective* analysis (the regions
+    # we will actually render). Without this, a legacy analysis with no
+    # `regions`/`dr_mode` rendered as `dr_variant="dr"` would yield
+    # `dr_mode="single-region"` and empty replication, contradicting the
+    # two-region canvas.
+    effective_analysis = {**analysis, "regions": regions}
+    dr_mode = infer_dr_mode(effective_analysis)
+    effective_analysis = {**effective_analysis, "dr_mode": dr_mode}
     tiers = infer_tiers_from_mappings(analysis)
     actors = infer_actors(analysis)
-    replication = infer_replication(analysis)
+    replication = infer_replication(effective_analysis)
 
     title = analysis.get("title") or "Azure Landing Zone"
     subtitle_bits = [

--- a/backend/azure_landing_zone_schema.py
+++ b/backend/azure_landing_zone_schema.py
@@ -1,0 +1,295 @@
+"""Landing Zone schema inference helpers (#572).
+
+Adds optional structured context (regions, dr_mode, tiers, actors,
+replication) to the analysis result so the Landing Zone SVG generator
+(#573) can render a region-aware, tiered architecture diagram.
+
+All inference helpers are deterministic, side-effect-free, and
+backwards-compatible: an analysis dict that does not contain any of the
+new keys is still valid, and the helpers fill in safe defaults.
+
+These helpers are read-only — they never mutate the input analysis.
+
+Sub-issue: https://github.com/idokatz86/Archmorph/issues/572
+Parent epic: https://github.com/idokatz86/Archmorph/issues/571
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tier classification — maps mapping.category → tier bucket
+# ---------------------------------------------------------------------------
+
+# Canonical tier order used everywhere downstream.
+TIER_ORDER: tuple[str, ...] = (
+    "ingress",
+    "compute",
+    "data",
+    "identity",
+    "observability",
+    "storage",
+)
+
+# Heuristic mapping from analysis-result categories to a tier bucket.
+# Lower-cased exact match; if a category is unknown it falls into "compute"
+# (the safe default for stateless workloads).
+_CATEGORY_TO_TIER: dict[str, str] = {
+    "networking": "ingress",
+    "edge": "ingress",
+    "ingress": "ingress",
+    "loadbalancer": "ingress",
+    "compute": "compute",
+    "container": "compute",
+    "containers": "compute",
+    "serverless": "compute",
+    "ai/ml": "compute",
+    "ai-ml": "compute",
+    "ml": "compute",
+    "database": "data",
+    "data": "data",
+    "analytics": "data",
+    "messaging": "data",
+    "queue": "data",
+    "stream": "data",
+    "identity": "identity",
+    "security": "identity",
+    "secrets": "identity",
+    "observability": "observability",
+    "monitoring": "observability",
+    "logging": "observability",
+    "telemetry": "observability",
+    "storage": "storage",
+    "files": "storage",
+    "blob": "storage",
+}
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_PRIMARY_REGION = {"name": "East US", "role": "primary", "traffic_pct": 100}
+DEFAULT_STANDBY_REGION = {"name": "West US 3", "role": "standby", "traffic_pct": 0}
+
+DEFAULT_ACTOR = {"name": "End User", "kind": "external"}
+
+# Replication items derived from data-tier services for DR variants.
+_DEFAULT_REPLICATION_TEMPLATES = [
+    {"name": "Storage Account", "mode": "geo-redundant (RA-GRS) · async"},
+    {"name": "Managed DB",      "mode": "geo-replica · async · failover group"},
+    {"name": "Key Vault",       "mode": "KV replication · same-name secret IDs"},
+    {"name": "Event Hubs",      "mode": "Geo-DR pairing · alias namespace"},
+    {"name": "Front Door",      "mode": "Active/Standby routing rules · health probes"},
+    {"name": "Identity",        "mode": "Single Entra tenant · global"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def infer_dr_mode(analysis: dict[str, Any]) -> str:
+    """Return the DR mode for the analysis.
+
+    - ``"active-active"``  — multiple regions with traffic_pct > 0
+    - ``"active-standby"`` — multiple regions, exactly one carries traffic
+    - ``"single-region"``  — only one region (default)
+
+    If the caller has set ``dr_mode`` explicitly we honour it (after
+    validating it is one of the three known values); otherwise we infer
+    from ``regions``.
+    """
+    explicit = analysis.get("dr_mode")
+    if isinstance(explicit, str) and explicit in ("active-active", "active-standby", "single-region"):
+        return explicit
+
+    regions = analysis.get("regions")
+    if not isinstance(regions, list):
+        return "single-region"
+
+    # Only well-formed region dicts (with a name) count toward the multi-region
+    # check; otherwise a single valid region surrounded by junk would be
+    # mis-classified as multi-region.
+    valid = [r for r in regions if isinstance(r, dict) and r.get("name")]
+    if len(valid) < 2:
+        return "single-region"
+
+    pct_carrying = 0
+    for r in valid:
+        try:
+            pct = float(r.get("traffic_pct", 0))
+        except (TypeError, ValueError):
+            pct = 0.0
+        if pct > 0:
+            pct_carrying += 1
+
+    return "active-active" if pct_carrying >= 2 else "active-standby"
+
+
+def infer_regions(analysis: dict[str, Any], *, dr_variant: str = "primary") -> list[dict[str, Any]]:
+    """Return the list of regions to render.
+
+    - If ``regions`` is present and well-formed, return a deep-ish copy.
+    - Otherwise return a single primary region for ``dr_variant="primary"``
+      or a primary + standby pair for ``dr_variant="dr"``.
+
+    The renderer always receives at least one region.
+    """
+    regions = analysis.get("regions")
+    if isinstance(regions, list) and regions:
+        out: list[dict[str, Any]] = []
+        for r in regions:
+            if not isinstance(r, dict) or not r.get("name"):
+                continue
+            out.append({
+                "name": str(r["name"]),
+                "role": str(r.get("role", "primary")),
+                "traffic_pct": _coerce_pct(r.get("traffic_pct"), default=100 if not out else 0),
+            })
+        if out:
+            # Pad to two regions when DR was requested but only one configured.
+            if dr_variant == "dr" and len(out) == 1:
+                out.append(dict(DEFAULT_STANDBY_REGION))
+            return out
+
+    # Nothing usable — fall back to defaults.
+    if dr_variant == "dr":
+        return [dict(DEFAULT_PRIMARY_REGION), dict(DEFAULT_STANDBY_REGION)]
+    return [dict(DEFAULT_PRIMARY_REGION)]
+
+
+def infer_tiers_from_mappings(analysis: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Return a tier → service-list map.
+
+    Each service in the returned dict is a small struct::
+
+        {"name": "Azure Application Gateway",
+         "source": "AWS Application Load Balancer",
+         "subtitle": "Replaces AWS Application Load Balancer"}
+
+    Resolution order:
+    1. If ``tiers`` is already present in the analysis, normalise and return it.
+    2. Otherwise, derive from ``mappings`` using ``mapping.category``.
+
+    Output is guaranteed to contain every key in ``TIER_ORDER`` (possibly
+    with an empty list).
+    """
+    out: dict[str, list[dict[str, Any]]] = {t: [] for t in TIER_ORDER}
+
+    explicit = analysis.get("tiers")
+    if isinstance(explicit, dict):
+        for tier, items in explicit.items():
+            if tier not in TIER_ORDER or not isinstance(items, list):
+                continue
+            for entry in items:
+                normalised = _normalise_tier_entry(entry)
+                if normalised:
+                    out[tier].append(normalised)
+        if any(v for v in out.values()):
+            return out
+
+    # Derive from mappings.
+    mappings = analysis.get("mappings", [])
+    if not isinstance(mappings, list):
+        return out
+
+    for m in mappings:
+        if not isinstance(m, dict):
+            continue
+        azure = m.get("azure_service") or m.get("target") or ""
+        source = m.get("source_service") or m.get("source") or ""
+        category = (m.get("category") or "").strip().lower()
+        if not azure:
+            continue
+        tier = _CATEGORY_TO_TIER.get(category, "compute")
+        out[tier].append({
+            "name": str(azure),
+            "source": str(source) if source else "",
+            "subtitle": f"Replaces {source}" if source else "",
+        })
+
+    return out
+
+
+def infer_actors(analysis: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return external/internal actors hitting the system.
+
+    Honours ``analysis['actors']`` when present and well-formed, otherwise
+    returns the default single end-user actor.
+    """
+    actors = analysis.get("actors")
+    if isinstance(actors, list) and actors:
+        out: list[dict[str, Any]] = []
+        for a in actors:
+            if not isinstance(a, dict) or not a.get("name"):
+                continue
+            out.append({
+                "name": str(a["name"]),
+                "kind": str(a.get("kind", "external")),
+                "subtitle": str(a.get("subtitle", "")),
+                "edge_label": str(a.get("edge_label", "HTTPS")),
+            })
+        if out:
+            return out
+    return [dict(DEFAULT_ACTOR, subtitle="", edge_label="HTTPS")]
+
+
+def infer_replication(analysis: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return cross-region replication metadata for the DR band.
+
+    Honours ``analysis['replication']`` when present, otherwise returns a
+    canonical 6-item template covering the most common Azure stamps.
+    Returns an empty list when ``dr_mode`` is single-region.
+    """
+    if infer_dr_mode(analysis) == "single-region":
+        # Allow override even on single-region (caller might want to show
+        # what *would* replicate); honour explicit list.
+        explicit = analysis.get("replication")
+        if isinstance(explicit, list) and explicit:
+            return [
+                {"name": str(r.get("name", "")), "mode": str(r.get("mode", ""))}
+                for r in explicit
+                if isinstance(r, dict) and r.get("name")
+            ]
+        return []
+
+    explicit = analysis.get("replication")
+    if isinstance(explicit, list) and explicit:
+        out: list[dict[str, Any]] = []
+        for r in explicit:
+            if not isinstance(r, dict) or not r.get("name"):
+                continue
+            out.append({"name": str(r["name"]), "mode": str(r.get("mode", ""))})
+        if out:
+            return out
+
+    return [dict(t) for t in _DEFAULT_REPLICATION_TEMPLATES]
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _coerce_pct(value: Any, *, default: int) -> int:
+    try:
+        n = int(round(float(value)))
+    except (TypeError, ValueError):
+        return default
+    return max(0, min(100, n))
+
+
+def _normalise_tier_entry(entry: Any) -> dict[str, Any] | None:
+    """Accept either a string or a dict and return the canonical struct."""
+    if isinstance(entry, str) and entry.strip():
+        return {"name": entry.strip(), "source": "", "subtitle": ""}
+    if isinstance(entry, dict):
+        name = str(entry.get("name", "")).strip()
+        if not name:
+            return None
+        source = str(entry.get("source", "")).strip()
+        subtitle = str(entry.get("subtitle", "")).strip()
+        if not subtitle and source:
+            subtitle = f"Replaces {source}"
+        return {"name": name, "source": source, "subtitle": subtitle}
+    return None

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -10514,7 +10514,7 @@
     },
     "/api/diagrams/{diagram_id}/export-diagram": {
       "post": {
-        "description": "Generate an architecture diagram in Excalidraw, Draw.io, or Visio format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).",
+        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).",
         "operationId": "export_architecture_diagram_api_diagrams__diagram_id__export_diagram_post",
         "parameters": [
           {
@@ -10544,6 +10544,16 @@
               "default": false,
               "title": "Multi Page",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dr_variant",
+            "required": false,
+            "schema": {
+              "default": "primary",
+              "title": "Dr Variant",
+              "type": "string"
             }
           }
         ],
@@ -22873,7 +22883,7 @@
     },
     "/api/v1/diagrams/{diagram_id}/export-diagram": {
       "post": {
-        "description": "Generate an architecture diagram in Excalidraw, Draw.io, or Visio format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).",
+        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).",
         "operationId": "export_architecture_diagram_v1_api_v1_diagrams__diagram_id__export_diagram_post",
         "parameters": [
           {
@@ -22903,6 +22913,16 @@
               "default": false,
               "title": "Multi Page",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dr_variant",
+            "required": false,
+            "schema": {
+              "default": "primary",
+              "title": "Dr Variant",
+              "type": "string"
             }
           }
         ],

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -148,13 +148,37 @@ async def apply_guided_answers(request: Request, diagram_id: str, answers: Dict[
 # ─────────────────────────────────────────────────────────────
 @router.post("/api/diagrams/{diagram_id}/export-diagram")
 @limiter.limit("10/minute")
-async def export_architecture_diagram(request: Request, diagram_id: str, format: str = "excalidraw", multi_page: bool = False):
-    """Generate an architecture diagram in Excalidraw, Draw.io, or Visio format.
+async def export_architecture_diagram(
+    request: Request,
+    diagram_id: str,
+    format: str = "excalidraw",
+    multi_page: bool = False,
+    dr_variant: str = "primary",
+):
+    """Generate an architecture diagram in Excalidraw, Draw.io, Visio, or
+    Landing-Zone-SVG format.
 
     Set multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).
+    Set format=landing-zone-svg + dr_variant=primary|dr for the region-aware
+    landing-zone diagram (#571).
     """
-    if format not in ("excalidraw", "drawio", "vsdx"):
-        raise ArchmorphException(400, "Format must be 'excalidraw', 'drawio', or 'vsdx'")
+    if format not in ("excalidraw", "drawio", "vsdx", "landing-zone-svg"):
+        raise ArchmorphException(
+            400,
+            "Format must be 'excalidraw', 'drawio', 'vsdx', or 'landing-zone-svg'",
+        )
+
+    # dr_variant only applies to the landing-zone-svg format.
+    if format != "landing-zone-svg" and dr_variant != "primary":
+        raise ArchmorphException(
+            400,
+            "dr_variant is only valid when format='landing-zone-svg'",
+        )
+    if format == "landing-zone-svg" and dr_variant not in ("primary", "dr"):
+        raise ArchmorphException(
+            400,
+            "dr_variant must be 'primary' or 'dr'",
+        )
 
     analysis = get_or_recreate_session(diagram_id)
     if not analysis:
@@ -162,6 +186,21 @@ async def export_architecture_diagram(request: Request, diagram_id: str, format:
 
     if multi_page:
         analysis["multi_page"] = True
+
+    # Landing-Zone-SVG path: synchronous, in-process, no MCP gateway round-trip.
+    if format == "landing-zone-svg":
+        try:
+            from azure_landing_zone import generate_landing_zone_svg
+
+            result = generate_landing_zone_svg(analysis, dr_variant=dr_variant)  # type: ignore[arg-type]
+        except ValueError as exc:
+            raise ArchmorphException(400, str(exc))
+        record_event("exports_landing_zone_svg", {
+            "diagram_id": diagram_id,
+            "dr_variant": dr_variant,
+        })
+        record_funnel_step(diagram_id, "export")
+        return result
 
     try:
         content = await mcp_client.generate_diagram(format, analysis)

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -69,8 +69,9 @@ class TestGenerator:
         # `xmlns="..."` may only appear once on the root <svg> element.
         # Count raw occurrences in the bytes — a duplicate xmlns is invalid
         # even though some parsers will silently accept it.
-        assert content.count('xmlns="') == 1, (
-            f"Expected exactly one xmlns declaration, got {content.count('xmlns=')}"
+        xmlns_count = content.count('xmlns="')
+        assert xmlns_count == 1, (
+            f"Expected exactly one xmlns declaration, got {xmlns_count}"
         )
 
     def test_landing_zone_svg_primary_variant_dimensions(self):

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -1,0 +1,215 @@
+"""Tests for Azure Landing Zone SVG generation + router wiring (#573, #574).
+
+Round-trip parsing tests per Archmorph QA guardrail #569: every assertion
+goes through the real XML parser, not substring/key existence checks.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from azure_landing_zone import (
+    CANVAS_H_DR,
+    CANVAS_H_PRIMARY,
+    CANVAS_W,
+    generate_landing_zone_svg,
+)
+
+
+SVG_NS = "{http://www.w3.org/2000/svg}"
+
+
+SAMPLE_ANALYSIS: dict = {
+    "title": "Test Landing Zone",
+    "source_provider": "AWS",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "web-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "EKS", "azure_service": "AKS",        "category": "Containers"},
+        {"source_service": "RDS", "azure_service": "Azure SQL",  "category": "Database"},
+        {"source_service": "ALB", "azure_service": "App Gateway","category": "Networking"},
+        {"source_service": "S3",  "azure_service": "Blob Storage","category": "Storage"},
+        {"source_service": "Cognito", "azure_service": "Entra ID","category": "Identity"},
+        {"source_service": "CloudWatch", "azure_service": "Azure Monitor","category": "Monitoring"},
+    ],
+}
+
+
+DR_ANALYSIS: dict = {
+    **SAMPLE_ANALYSIS,
+    "dr_mode": "active-standby",
+    "regions": [
+        {"name": "East US",     "role": "primary", "traffic_pct": 100},
+        {"name": "West US 3",   "role": "standby", "traffic_pct": 0},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Generator-level tests (#573)
+# ---------------------------------------------------------------------------
+
+class TestGenerator:
+
+    def test_landing_zone_svg_parses_as_xml(self):
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        # Must be a string starting with the XML declaration.
+        assert result["format"] == "landing-zone-svg"
+        assert "content" in result
+        # Round-trip parse: this is the load-bearing assertion.
+        root = ET.fromstring(result["content"])
+        assert root.tag == f"{SVG_NS}svg"
+
+    def test_landing_zone_svg_no_duplicate_xmlns(self):
+        """Defends against the same regression that broke .vsdx output (#569)."""
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        content = result["content"]
+        # `xmlns="..."` may only appear once on the root <svg> element.
+        # Count raw occurrences in the bytes — a duplicate xmlns is invalid
+        # even though some parsers will silently accept it.
+        assert content.count('xmlns="') == 1, (
+            f"Expected exactly one xmlns declaration, got {content.count('xmlns=')}"
+        )
+
+    def test_landing_zone_svg_primary_variant_dimensions(self):
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        assert root.get("width") == str(CANVAS_W)
+        assert root.get("height") == str(CANVAS_H_PRIMARY)
+        assert CANVAS_H_PRIMARY == 1330  # canonical contract
+
+    def test_landing_zone_svg_dr_variant_dimensions(self):
+        result = generate_landing_zone_svg(DR_ANALYSIS, dr_variant="dr")
+        root = ET.fromstring(result["content"])
+        assert root.get("width") == str(CANVAS_W)
+        assert root.get("height") == str(CANVAS_H_DR)
+        assert CANVAS_H_DR == 2120  # canonical contract
+
+    def test_landing_zone_svg_dr_has_two_region_labels(self):
+        result = generate_landing_zone_svg(DR_ANALYSIS, dr_variant="dr")
+        root = ET.fromstring(result["content"])
+        # Every <text> element gives us its readable content; collect them all
+        # and assert both regions appear at least once.
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        joined = " | ".join(texts)
+        assert "East US" in joined, f"East US not found in SVG text: {joined[:200]}"
+        assert "West US 3" in joined, f"West US 3 not found in SVG text: {joined[:200]}"
+
+    def test_landing_zone_svg_legend_present(self):
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        # Legend has a header text element with literal "Legend".
+        assert "Legend" in texts
+
+    def test_landing_zone_svg_no_external_urls(self):
+        """Output must be fully self-contained: no http(s) hrefs, no fetches."""
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        content = result["content"]
+        # Allow the xmlns URL on the root element only — that's a namespace,
+        # not a fetch. Strip it before checking.
+        without_ns = content.replace(
+            'xmlns="http://www.w3.org/2000/svg"', "", 1
+        )
+        assert "http://" not in without_ns, "External http URL found in SVG"
+        assert "https://" not in without_ns, "External https URL found in SVG"
+        # Cross-check by parsing href attributes on <image> elements.
+        root = ET.fromstring(content)
+        for image in root.iter(f"{SVG_NS}image"):
+            href = image.get("href") or image.get("{http://www.w3.org/1999/xlink}href") or ""
+            if href:
+                assert href.startswith("data:"), (
+                    f"<image> href is not a data: URI: {href[:60]}"
+                )
+
+    def test_landing_zone_svg_legacy_analysis_works(self):
+        """An analysis without any of the new optional fields still renders."""
+        legacy = {
+            "title": "Legacy",
+            "zones": [{"id": 1, "name": "default", "number": 1}],
+            "mappings": [
+                {"source_service": "EC2", "azure_service": "Azure VMs", "category": "Compute"},
+            ],
+        }
+        result = generate_landing_zone_svg(legacy, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        assert root.tag == f"{SVG_NS}svg"
+        # Default region name must show up.
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        assert any("East US" in t for t in texts), "Default primary region missing"
+
+    def test_landing_zone_svg_invalid_dr_variant_raises(self):
+        with pytest.raises(ValueError):
+            generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Router-level tests (#574)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture
+def diagram_id_with_analysis(client):
+    """Seed SESSION_STORE directly so we don't need a /analyze round-trip."""
+    from main import SESSION_STORE
+    diagram_id = "alz-test-diagram-001"
+    SESSION_STORE[diagram_id] = dict(SAMPLE_ANALYSIS)
+    yield diagram_id
+    try:
+        del SESSION_STORE[diagram_id]
+    except (KeyError, Exception):
+        pass
+
+
+class TestRouter:
+
+    def test_landing_zone_svg_dr_variant_with_drawio_400(self, client, diagram_id_with_analysis):
+        """dr_variant only valid when format=landing-zone-svg."""
+        resp = client.post(
+            f"/api/diagrams/{diagram_id_with_analysis}/export-diagram"
+            f"?format=drawio&dr_variant=dr"
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_landing_zone_svg_invalid_dr_variant_400(self, client, diagram_id_with_analysis):
+        resp = client.post(
+            f"/api/diagrams/{diagram_id_with_analysis}/export-diagram"
+            f"?format=landing-zone-svg&dr_variant=bogus"
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_landing_zone_svg_route_returns_parseable_svg(self, client, diagram_id_with_analysis):
+        resp = client.post(
+            f"/api/diagrams/{diagram_id_with_analysis}/export-diagram"
+            f"?format=landing-zone-svg&dr_variant=primary"
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["format"] == "landing-zone-svg"
+        assert body["filename"].endswith("-primary.svg")
+        # Round-trip parse the returned SVG.
+        root = ET.fromstring(body["content"])
+        assert root.tag == f"{SVG_NS}svg"
+        assert root.get("height") == str(CANVAS_H_PRIMARY)
+
+    def test_landing_zone_svg_route_dr_variant_returns_dr_dimensions(
+        self, client, diagram_id_with_analysis
+    ):
+        resp = client.post(
+            f"/api/diagrams/{diagram_id_with_analysis}/export-diagram"
+            f"?format=landing-zone-svg&dr_variant=dr"
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["filename"].endswith("-dr.svg")
+        root = ET.fromstring(body["content"])
+        assert root.get("height") == str(CANVAS_H_DR)

--- a/backend/tests/test_azure_landing_zone_schema.py
+++ b/backend/tests/test_azure_landing_zone_schema.py
@@ -1,0 +1,246 @@
+"""Tests for backend/azure_landing_zone_schema.py (#572).
+
+Each helper is tested for:
+- Pass-through when the field is present and well-formed.
+- Inference when the field is missing.
+- Graceful default when the field is malformed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from azure_landing_zone_schema import (
+    DEFAULT_PRIMARY_REGION,
+    DEFAULT_STANDBY_REGION,
+    TIER_ORDER,
+    infer_actors,
+    infer_dr_mode,
+    infer_regions,
+    infer_replication,
+    infer_tiers_from_mappings,
+)
+
+
+# ---------------------------------------------------------------------------
+# infer_dr_mode
+# ---------------------------------------------------------------------------
+
+class TestInferDrMode:
+    def test_explicit_value_passthrough(self):
+        assert infer_dr_mode({"dr_mode": "active-active"}) == "active-active"
+        assert infer_dr_mode({"dr_mode": "active-standby"}) == "active-standby"
+        assert infer_dr_mode({"dr_mode": "single-region"}) == "single-region"
+
+    def test_explicit_invalid_falls_back_to_inference(self):
+        assert infer_dr_mode({"dr_mode": "nonsense"}) == "single-region"
+
+    def test_no_regions_is_single(self):
+        assert infer_dr_mode({}) == "single-region"
+        assert infer_dr_mode({"regions": []}) == "single-region"
+        assert infer_dr_mode({"regions": [{"name": "East US", "traffic_pct": 100}]}) == "single-region"
+
+    def test_two_regions_one_carrying_is_active_standby(self):
+        a = {"regions": [
+            {"name": "East US", "traffic_pct": 100},
+            {"name": "West US 3", "traffic_pct": 0},
+        ]}
+        assert infer_dr_mode(a) == "active-standby"
+
+    def test_two_regions_both_carrying_is_active_active(self):
+        a = {"regions": [
+            {"name": "East US", "traffic_pct": 60},
+            {"name": "West US 3", "traffic_pct": 40},
+        ]}
+        assert infer_dr_mode(a) == "active-active"
+
+    def test_malformed_regions_does_not_crash(self):
+        a = {"regions": ["not-a-dict", {"name": "East US"}, None]}
+        assert infer_dr_mode(a) == "single-region"
+
+
+# ---------------------------------------------------------------------------
+# infer_regions
+# ---------------------------------------------------------------------------
+
+class TestInferRegions:
+    def test_default_primary_when_empty(self):
+        regions = infer_regions({})
+        assert regions == [DEFAULT_PRIMARY_REGION]
+
+    def test_default_dr_pair_when_empty(self):
+        regions = infer_regions({}, dr_variant="dr")
+        assert regions[0]["role"] == "primary"
+        assert regions[1]["role"] == "standby"
+        assert len(regions) == 2
+
+    def test_explicit_regions_passthrough(self):
+        a = {"regions": [
+            {"name": "Sweden Central", "role": "primary", "traffic_pct": 100},
+            {"name": "Norway East", "role": "standby", "traffic_pct": 0},
+        ]}
+        regions = infer_regions(a, dr_variant="dr")
+        assert regions[0]["name"] == "Sweden Central"
+        assert regions[1]["name"] == "Norway East"
+
+    def test_dr_variant_pads_single_region_to_two(self):
+        a = {"regions": [{"name": "East US", "traffic_pct": 100}]}
+        regions = infer_regions(a, dr_variant="dr")
+        assert len(regions) == 2
+        assert regions[0]["name"] == "East US"
+        assert regions[1] == DEFAULT_STANDBY_REGION
+
+    def test_traffic_pct_clamped(self):
+        a = {"regions": [{"name": "X", "traffic_pct": 250}]}
+        assert infer_regions(a)[0]["traffic_pct"] == 100
+        a = {"regions": [{"name": "X", "traffic_pct": -10}]}
+        assert infer_regions(a)[0]["traffic_pct"] == 0
+
+    def test_malformed_entries_filtered(self):
+        a = {"regions": ["bad", {"name": ""}, {"name": "Good"}, None]}
+        regions = infer_regions(a)
+        assert len(regions) == 1
+        assert regions[0]["name"] == "Good"
+
+    def test_does_not_mutate_input(self):
+        a = {"regions": [{"name": "East US", "traffic_pct": 100}]}
+        original = a["regions"][0].copy()
+        infer_regions(a, dr_variant="dr")
+        assert a["regions"][0] == original
+
+
+# ---------------------------------------------------------------------------
+# infer_tiers_from_mappings
+# ---------------------------------------------------------------------------
+
+class TestInferTiers:
+    def test_returns_all_tier_keys(self):
+        out = infer_tiers_from_mappings({})
+        for tier in TIER_ORDER:
+            assert tier in out
+            assert isinstance(out[tier], list)
+
+    def test_explicit_tiers_passthrough(self):
+        a = {"tiers": {
+            "ingress": ["Application Gateway"],
+            "compute": [{"name": "AKS", "source": "EKS"}],
+        }}
+        out = infer_tiers_from_mappings(a)
+        assert out["ingress"][0]["name"] == "Application Gateway"
+        assert out["compute"][0]["name"] == "AKS"
+        assert out["compute"][0]["source"] == "EKS"
+        assert out["compute"][0]["subtitle"] == "Replaces EKS"
+
+    def test_explicit_tiers_filters_unknown_keys(self):
+        a = {"tiers": {"unknown-tier": ["X"], "compute": ["AKS"]}}
+        out = infer_tiers_from_mappings(a)
+        assert "unknown-tier" not in out
+        assert out["compute"][0]["name"] == "AKS"
+
+    def test_derives_from_mappings_when_tiers_absent(self):
+        a = {"mappings": [
+            {"source_service": "EKS", "azure_service": "AKS", "category": "Containers"},
+            {"source_service": "RDS", "azure_service": "Azure SQL", "category": "Database"},
+            {"source_service": "ELB", "azure_service": "App Gateway", "category": "Networking"},
+            {"source_service": "S3",  "azure_service": "Blob Storage", "category": "Storage"},
+            {"source_service": "Cognito", "azure_service": "Entra ID", "category": "Identity"},
+            {"source_service": "CloudWatch", "azure_service": "Azure Monitor", "category": "Monitoring"},
+        ]}
+        out = infer_tiers_from_mappings(a)
+        assert any(s["name"] == "AKS" for s in out["compute"])
+        assert any(s["name"] == "Azure SQL" for s in out["data"])
+        assert any(s["name"] == "App Gateway" for s in out["ingress"])
+        assert any(s["name"] == "Blob Storage" for s in out["storage"])
+        assert any(s["name"] == "Entra ID" for s in out["identity"])
+        assert any(s["name"] == "Azure Monitor" for s in out["observability"])
+
+    def test_unknown_category_falls_to_compute(self):
+        a = {"mappings": [{"azure_service": "X", "category": "Unknown"}]}
+        out = infer_tiers_from_mappings(a)
+        assert any(s["name"] == "X" for s in out["compute"])
+
+    def test_skips_mappings_without_azure_service(self):
+        a = {"mappings": [{"source_service": "EKS", "category": "Compute"}]}
+        out = infer_tiers_from_mappings(a)
+        assert out["compute"] == []
+
+    def test_subtitle_synthesised_when_source_present(self):
+        a = {"mappings": [{"source_service": "EFS", "azure_service": "Azure Files", "category": "Storage"}]}
+        out = infer_tiers_from_mappings(a)
+        assert out["storage"][0]["subtitle"] == "Replaces EFS"
+
+
+# ---------------------------------------------------------------------------
+# infer_actors
+# ---------------------------------------------------------------------------
+
+class TestInferActors:
+    def test_default_when_missing(self):
+        actors = infer_actors({})
+        assert len(actors) == 1
+        assert actors[0]["name"] == "End User"
+        assert actors[0]["kind"] == "external"
+
+    def test_passthrough_when_provided(self):
+        a = {"actors": [
+            {"name": "Self-Dev", "kind": "internal", "subtitle": "Developer", "edge_label": "RDP"},
+            {"name": "API Client", "kind": "external"},
+        ]}
+        actors = infer_actors(a)
+        assert len(actors) == 2
+        assert actors[0]["name"] == "Self-Dev"
+        assert actors[0]["edge_label"] == "RDP"
+        assert actors[1]["edge_label"] == "HTTPS"  # default
+
+    def test_drops_actors_without_name(self):
+        a = {"actors": [{"name": ""}, {"name": "Good"}]}
+        actors = infer_actors(a)
+        assert len(actors) == 1
+        assert actors[0]["name"] == "Good"
+
+    def test_malformed_falls_back_to_default(self):
+        a = {"actors": "not-a-list"}
+        actors = infer_actors(a)
+        assert len(actors) == 1
+        assert actors[0]["name"] == "End User"
+
+
+# ---------------------------------------------------------------------------
+# infer_replication
+# ---------------------------------------------------------------------------
+
+class TestInferReplication:
+    def test_empty_for_single_region(self):
+        assert infer_replication({}) == []
+        assert infer_replication({"dr_mode": "single-region"}) == []
+
+    def test_default_template_for_dr(self):
+        a = {"dr_mode": "active-standby"}
+        rep = infer_replication(a)
+        assert len(rep) >= 6  # default template has 6 entries
+        names = [r["name"] for r in rep]
+        assert "Storage Account" in names
+        assert "Managed DB" in names
+        assert "Identity" in names
+
+    def test_explicit_replication_passthrough(self):
+        a = {"dr_mode": "active-standby", "replication": [
+            {"name": "PostgreSQL", "mode": "logical · async"},
+            {"name": "Cosmos DB", "mode": "multi-region writes"},
+        ]}
+        rep = infer_replication(a)
+        assert rep[0]["name"] == "PostgreSQL"
+        assert rep[1]["mode"] == "multi-region writes"
+
+    def test_explicit_replication_honoured_on_single_region(self):
+        # Caller may want to surface what *would* replicate even today.
+        a = {"replication": [{"name": "X", "mode": "y"}]}
+        rep = infer_replication(a)
+        assert len(rep) == 1
+        assert rep[0]["name"] == "X"
+
+    def test_drops_replication_entries_without_name(self):
+        a = {"dr_mode": "active-standby", "replication": [{"name": ""}, {"name": "Good"}]}
+        rep = infer_replication(a)
+        assert len(rep) == 1
+        assert rep[0]["name"] == "Good"

--- a/backend/tests/test_azure_landing_zone_schema.py
+++ b/backend/tests/test_azure_landing_zone_schema.py
@@ -8,8 +8,6 @@ Each helper is tested for:
 
 from __future__ import annotations
 
-import pytest
-
 from azure_landing_zone_schema import (
     DEFAULT_PRIMARY_REGION,
     DEFAULT_STANDBY_REGION,


### PR DESCRIPTION
## Summary
Productizes the Azure Landing Zone target diagram inside Archmorph. Renders a region-aware, Microsoft-iconography landing-zone SVG from the analysis dict, embedded fully self-contained (data: URIs only, no external references), under 300 KB, validated as well-formed XML before return.

Implements epic #571 (sub-issues #572 schema, #573 generator, #574 router, #575 frontend deferred).

## Changes
- `backend/azure_landing_zone_schema.py` (new, 295 LOC) — 5 idempotent inference helpers: `infer_dr_mode`, `infer_regions`, `infer_tiers_from_mappings`, `infer_actors`, `infer_replication`. Reads optional `regions`, `dr_mode`, `tiers`, `actors`, `replication` from analysis; falls back to defaults from legacy `{zones, mappings}`.
- `backend/azure_landing_zone.py` (new, 831 LOC) — stateless SVG renderer. Microsoft Fluent palette, Segoe UI stack, single `xmlns` on root, all icons embedded as base64 data URIs.
- `backend/routers/analysis.py` — extends format whitelist to `("excalidraw", "drawio", "vsdx", "landing-zone-svg")`; accepts `dr_variant: str = "primary"` query param; rejects `dr_variant != "primary"` on non-landing-zone formats with 400.
- Tests: 29 schema tests + 13 generator/router tests = **42 tests**.

## Validation
- Primary canvas 1800×1330; DR canvas 1800×2120 — both round-trip-parse via `ET.fromstring`.
- Legacy analysis without new fields renders successfully (backwards-compatible).
- `dr_variant` rejected on non-landing-zone formats with 400.
- No external URLs; single `xmlns`; data: URIs only.
- 48 tests pass (`test_diagram_export.py` + `test_azure_landing_zone*.py`).

## Out of scope
- Frontend wiring — deferred (#575).

Closes #572, #573, #574
Refs #571