### PR TITLE
feat(alz): GCP source provider support (#576)

### DIFF
--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -60,6 +60,45 @@ MAX_SVG_BYTES = 300 * 1024
 
 
 # ---------------------------------------------------------------------------
+# Source-provider contract (#576) — implicit, read from analysis dict.
+# ---------------------------------------------------------------------------
+# The schema is vendor-neutral; the only thing that varies per source provider
+# is the legend mapping line. Callers set ``analysis["source_provider"]`` to
+# one of the values in ``_SUPPORTED_SOURCE_PROVIDERS``. Missing → "aws"
+# (backwards-compatible with #571). Unknown → ValueError.
+
+_SUPPORTED_SOURCE_PROVIDERS: frozenset[str] = frozenset({"aws", "gcp"})
+
+_SOURCE_PROVIDER_LEGEND_LINE: dict[str, str] = {
+    "aws": (
+        "AWS → Azure · ALB → App Gateway · EKS → AKS · "
+        "EFS → Azure Files · Kafka → Event Hubs · RDS → Managed DB"
+    ),
+    "gcp": (
+        "GCP → Azure · GLB → App Gateway · GKE → AKS · "
+        "Filestore → Azure Files · Pub/Sub → Event Hubs · Cloud SQL → Managed DB"
+    ),
+}
+
+# Lockstep invariant — the supported set must match the legend table exactly.
+assert _SUPPORTED_SOURCE_PROVIDERS == frozenset(_SOURCE_PROVIDER_LEGEND_LINE), (
+    "source-provider constants drifted: "
+    f"{_SUPPORTED_SOURCE_PROVIDERS} vs {set(_SOURCE_PROVIDER_LEGEND_LINE)}"
+)
+
+
+def _validate_source_provider(value: str | None) -> str:
+    """Lowercase, default to ``"aws"``, raise ``ValueError`` on unknown."""
+    provider = (value or "aws").lower()
+    if provider not in _SUPPORTED_SOURCE_PROVIDERS:
+        raise ValueError(
+            f"Unsupported source_provider: {value!r}. "
+            f"Expected one of {sorted(_SUPPORTED_SOURCE_PROVIDERS)}."
+        )
+    return provider
+
+
+# ---------------------------------------------------------------------------
 # Icon resolution — registry-first, fallback to coloured-tile placeholder
 # ---------------------------------------------------------------------------
 
@@ -322,8 +361,18 @@ def _front_door(regions: list[dict[str, Any]], dr_mode: str) -> str:
     return "\n".join(out)
 
 
-def _legend(y: int) -> str:
-    """7-column × 2-row icon grid + line-style key + AWS→Azure mapping line."""
+def _legend(y: int, source_provider: str = "aws") -> str:
+    """7-column × 2-row icon grid + line-style key + source→Azure mapping line.
+
+    ``source_provider`` selects the canonical mapping line printed in the
+    bottom-right of the legend. Must be one of
+    ``_SUPPORTED_SOURCE_PROVIDERS`` — validation should happen at the
+    public entry point (``generate_landing_zone_svg``).
+    """
+    if source_provider not in _SOURCE_PROVIDER_LEGEND_LINE:
+        # Defensive guard — callers should validate up front.
+        raise ValueError(f"Unsupported source_provider: {source_provider!r}")
+    mapping_line = _SOURCE_PROVIDER_LEGEND_LINE[source_provider]
     H = 124
     out = [
         f'<rect x="20" y="{y}" width="1760" height="{H}" rx="6" '
@@ -378,11 +427,7 @@ def _legend(y: int) -> str:
     )
     out.append(_tx(520, line_y + 6, "Cross-region replication", "t-legend"))
     out.append(_tx(720, line_y + 6, "Mapping:", "t-mapnote", weight="700"))
-    out.append(_tx(
-        780, line_y + 6,
-        "AWS → Azure · ALB → App Gateway · EKS → AKS · EFS → Azure Files · "
-        "Kafka → Event Hubs · RDS → Managed DB",
-        "t-mapnote"))
+    out.append(_tx(780, line_y + 6, mapping_line, "t-mapnote"))
     return "\n".join(out)
 
 
@@ -715,6 +760,10 @@ def generate_landing_zone_svg(
     if not isinstance(analysis, dict):
         raise ValueError("analysis must be a dict")
 
+    # #576: source_provider is implicit (read from the analysis payload) and
+    # validated here. Default "aws" preserves backwards-compat with #571.
+    source_provider = _validate_source_provider(analysis.get("source_provider"))
+
     regions = infer_regions(analysis, dr_variant=dr_variant)
     # Infer dr_mode and replication from the *effective* analysis (the regions
     # we will actually render). Without this, a legacy analysis with no
@@ -783,7 +832,7 @@ def generate_landing_zone_svg(
                              "t-meta"))
             parts.append(_tx(1772, 1086, f"{r2.get('traffic_pct', 0)}% traffic",
                              "t-edge-r", anchor="end"))
-        parts.append(_legend(1140))
+        parts.append(_legend(1140, source_provider=source_provider))
     else:
         # Full DR — replication band + Region 2 stamp + legend.
         band_y = 1062
@@ -796,7 +845,7 @@ def generate_landing_zone_svg(
                 status="standby",
                 role_text=f"Standby · {r2.get('traffic_pct', 0)}% traffic · automated failover",
             ))
-        parts.append(_legend(r2_y + 776))
+        parts.append(_legend(r2_y + 776, source_provider=source_provider))
 
     parts.append('</svg>')
 

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -10514,7 +10514,7 @@
     },
     "/api/diagrams/{diagram_id}/export-diagram": {
       "post": {
-        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).",
+        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).\n\nNote (#576): the source provider for the landing-zone diagram is read\nimplicitly from ``analysis[\"source_provider\"]`` (allowed: \"aws\"|\"gcp\",\ndefault \"aws\"). It is intentionally NOT exposed as a query param so the\nfrontend stays untouched and the analyzer pipeline remains the single\nsource of truth. Unknown values raise ``ValueError`` → HTTP 400.",
         "operationId": "export_architecture_diagram_api_diagrams__diagram_id__export_diagram_post",
         "parameters": [
           {
@@ -22883,7 +22883,7 @@
     },
     "/api/v1/diagrams/{diagram_id}/export-diagram": {
       "post": {
-        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).",
+        "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).\n\nNote (#576): the source provider for the landing-zone diagram is read\nimplicitly from ``analysis[\"source_provider\"]`` (allowed: \"aws\"|\"gcp\",\ndefault \"aws\"). It is intentionally NOT exposed as a query param so the\nfrontend stays untouched and the analyzer pipeline remains the single\nsource of truth. Unknown values raise ``ValueError`` → HTTP 400.",
         "operationId": "export_architecture_diagram_v1_api_v1_diagrams__diagram_id__export_diagram_post",
         "parameters": [
           {

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -161,6 +161,12 @@ async def export_architecture_diagram(
     Set multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).
     Set format=landing-zone-svg + dr_variant=primary|dr for the region-aware
     landing-zone diagram (#571).
+
+    Note (#576): the source provider for the landing-zone diagram is read
+    implicitly from ``analysis["source_provider"]`` (allowed: "aws"|"gcp",
+    default "aws"). It is intentionally NOT exposed as a query param so the
+    frontend stays untouched and the analyzer pipeline remains the single
+    source of truth. Unknown values raise ``ValueError`` → HTTP 400.
     """
     if format not in ("excalidraw", "drawio", "vsdx", "landing-zone-svg"):
         raise ArchmorphException(

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -214,3 +214,116 @@ class TestRouter:
         assert body["filename"].endswith("-dr.svg")
         root = ET.fromstring(body["content"])
         assert root.get("height") == str(CANVAS_H_DR)
+
+
+# ---------------------------------------------------------------------------
+# GCP source provider (#576, #577, #578, #579)
+# ---------------------------------------------------------------------------
+
+GCP_SAMPLE_ANALYSIS: dict = {
+    "title": "GCP-to-Azure Landing Zone",
+    "source_provider": "gcp",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "web-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "GKE",       "azure_service": "AKS",          "category": "Containers"},
+        {"source_service": "Cloud SQL", "azure_service": "Azure SQL",    "category": "Database"},
+        {"source_service": "GLB",       "azure_service": "App Gateway",  "category": "Networking"},
+        {"source_service": "Cloud Storage", "azure_service": "Blob Storage", "category": "Storage"},
+        {"source_service": "Cloud IAM", "azure_service": "Entra ID",     "category": "Identity"},
+        {"source_service": "Cloud Monitoring", "azure_service": "Azure Monitor", "category": "Monitoring"},
+        {"source_service": "Pub/Sub",   "azure_service": "Event Hubs",   "category": "Messaging"},
+        {"source_service": "Filestore", "azure_service": "Azure Files",  "category": "Storage"},
+    ],
+}
+
+
+GCP_DR_ANALYSIS: dict = {
+    **GCP_SAMPLE_ANALYSIS,
+    "dr_mode": "active-standby",
+    "regions": [
+        {"name": "East US",   "role": "primary", "traffic_pct": 100},
+        {"name": "West US 3", "role": "standby", "traffic_pct": 0},
+    ],
+}
+
+
+# Verbatim strings the legend must contain (or NOT contain) per provider.
+_AWS_LEGEND_FRAGMENT = "AWS → Azure"
+_AWS_EKS_FRAGMENT = "EKS → AKS"
+_GCP_LEGEND_FRAGMENT = "GCP → Azure"
+_GCP_GKE_FRAGMENT = "GKE → AKS"
+_GCP_PUBSUB_FRAGMENT = "Pub/Sub → Event Hubs"
+
+
+class TestGcpSource:
+    """Coverage for the implicit `analysis["source_provider"]` contract."""
+
+    def test_gcp_fixture_round_trip_parse(self):
+        """The GCP analysis dict renders into well-formed XML."""
+        result = generate_landing_zone_svg(GCP_SAMPLE_ANALYSIS, dr_variant="primary")
+        ET.fromstring(result["content"])  # raises ParseError if malformed
+
+    def test_gcp_legend_contains_gcp_to_azure(self):
+        """The GCP legend strip prints the canonical GCP→Azure mapping line."""
+        result = generate_landing_zone_svg(GCP_SAMPLE_ANALYSIS, dr_variant="primary")
+        assert _GCP_LEGEND_FRAGMENT in result["content"]
+        assert _GCP_GKE_FRAGMENT in result["content"]
+        assert _GCP_PUBSUB_FRAGMENT in result["content"]
+
+    def test_gcp_legend_does_not_contain_aws(self):
+        """The GCP legend strip must not leak the AWS mapping line."""
+        result = generate_landing_zone_svg(GCP_SAMPLE_ANALYSIS, dr_variant="primary")
+        assert _AWS_LEGEND_FRAGMENT not in result["content"]
+        assert _AWS_EKS_FRAGMENT not in result["content"]
+
+    def test_default_no_field_still_aws(self):
+        """Backwards-compat with #571: missing `source_provider` ⇒ AWS legend."""
+        legacy = {k: v for k, v in SAMPLE_ANALYSIS.items() if k != "source_provider"}
+        assert "source_provider" not in legacy  # guard the construction
+        result = generate_landing_zone_svg(legacy, dr_variant="primary")
+        assert _AWS_LEGEND_FRAGMENT in result["content"]
+        assert _GCP_LEGEND_FRAGMENT not in result["content"]
+
+    def test_invalid_provider_raises_value_error(self):
+        """Unknown provider → strict ValueError (mirrors `dr_variant`)."""
+        bad = {**GCP_SAMPLE_ANALYSIS, "source_provider": "azure"}
+        with pytest.raises(ValueError, match="Unsupported source_provider"):
+            generate_landing_zone_svg(bad, dr_variant="primary")
+
+        bad2 = {**GCP_SAMPLE_ANALYSIS, "source_provider": "alibaba"}
+        with pytest.raises(ValueError, match="alibaba"):
+            generate_landing_zone_svg(bad2, dr_variant="primary")
+
+    def test_dr_plus_gcp_renders(self):
+        """DR variant × GCP source emits a valid SVG with the GCP legend."""
+        result = generate_landing_zone_svg(GCP_DR_ANALYSIS, dr_variant="dr")
+        root = ET.fromstring(result["content"])
+        assert root.get("height") == str(CANVAS_H_DR)
+        assert _GCP_LEGEND_FRAGMENT in result["content"]
+        assert _AWS_LEGEND_FRAGMENT not in result["content"]
+
+    def test_primary_plus_gcp_renders(self):
+        """Primary variant × GCP source emits a valid SVG with the GCP legend."""
+        result = generate_landing_zone_svg(GCP_SAMPLE_ANALYSIS, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        assert root.get("height") == str(CANVAS_H_PRIMARY)
+        assert _GCP_LEGEND_FRAGMENT in result["content"]
+
+    def test_case_insensitive_provider(self):
+        """`GCP`, `Gcp`, `gcp` must produce identical output."""
+        lower = {**GCP_SAMPLE_ANALYSIS, "source_provider": "gcp"}
+        upper = {**GCP_SAMPLE_ANALYSIS, "source_provider": "GCP"}
+        mixed = {**GCP_SAMPLE_ANALYSIS, "source_provider": "Gcp"}
+        a = generate_landing_zone_svg(lower, dr_variant="primary")["content"]
+        b = generate_landing_zone_svg(upper, dr_variant="primary")["content"]
+        c = generate_landing_zone_svg(mixed, dr_variant="primary")["content"]
+        assert a == b == c
+
+    def test_supported_providers_and_legend_table_in_lockstep(self):
+        """Module-load invariant: drift between the two constants is fatal."""
+        from azure_landing_zone import (
+            _SOURCE_PROVIDER_LEGEND_LINE,
+            _SUPPORTED_SOURCE_PROVIDERS,
+        )
+        assert _SUPPORTED_SOURCE_PROVIDERS == frozenset(_SOURCE_PROVIDER_LEGEND_LINE)

--- a/backend/tests/test_azure_landing_zone_schema.py
+++ b/backend/tests/test_azure_landing_zone_schema.py
@@ -242,3 +242,36 @@ class TestInferReplication:
         rep = infer_replication(a)
         assert len(rep) == 1
         assert rep[0]["name"] == "Good"
+
+
+# ---------------------------------------------------------------------------
+# GCP source-provider sanity (#576, #578)
+# ---------------------------------------------------------------------------
+
+class TestSchemaGcpSource:
+    """The schema is vendor-neutral; this asserts the contract still holds
+    when ``mapping.source_service`` carries GCP-typical strings.
+    """
+
+    def test_infer_tiers_from_mappings_gcp_strings(self):
+        a = {"mappings": [
+            {"source_service": "GLB",        "azure_service": "App Gateway",   "category": "Networking"},
+            {"source_service": "GKE",        "azure_service": "AKS",            "category": "Containers"},
+            {"source_service": "Filestore",  "azure_service": "Azure Files",    "category": "Storage"},
+            {"source_service": "Pub/Sub",    "azure_service": "Event Hubs",     "category": "Messaging"},
+            {"source_service": "Cloud SQL",  "azure_service": "Azure SQL",      "category": "Database"},
+        ]}
+        out = infer_tiers_from_mappings(a)
+
+        # Categories are vendor-neutral and slot into the right tiers.
+        assert any(s["name"] == "App Gateway" for s in out["ingress"])
+        assert any(s["name"] == "AKS"          for s in out["compute"])
+        assert any(s["name"] == "Azure Files"  for s in out["storage"])
+        assert any(s["name"] == "Event Hubs"   for s in out["data"])
+        assert any(s["name"] == "Azure SQL"    for s in out["data"])
+
+        # Subtitles surface the GCP source string verbatim.
+        gke = next(s for s in out["compute"] if s["name"] == "AKS")
+        assert gke["subtitle"] == "Replaces GKE"
+        pubsub = next(s for s in out["data"] if s["name"] == "Event Hubs")
+        assert pubsub["subtitle"] == "Replaces Pub/Sub"

--- a/docs/azure-landing-zone-source-provider.md
+++ b/docs/azure-landing-zone-source-provider.md
@@ -1,0 +1,87 @@
+# Azure Landing Zone — `source_provider` analyzer contract
+
+> Status: **Implemented** (epic #576, extends #571)
+
+## What this is
+
+The Azure Landing Zone target diagram (shipped in #571) renders a region-aware
+SVG that maps an existing cloud workload onto an Azure landing zone. Most of
+the diagram is target-side (Azure regions, tiers, replication, icons, palette)
+and is fully provider-agnostic. The **only** part that varies per source
+provider is the legend's mapping line in the bottom-right.
+
+This document describes the analyzer-side contract that selects which mapping
+line is rendered.
+
+## The field
+
+Set `source_provider` on the analysis dict:
+
+```python
+analysis = {
+    # ... regions, tiers, mappings, etc.
+    "source_provider": "gcp",   # or "aws"; default "aws" if absent
+}
+```
+
+| Value      | Behaviour                                                       |
+| ---------- | --------------------------------------------------------------- |
+| `"aws"`    | Render the AWS→Azure mapping line (default).                    |
+| `"gcp"`    | Render the GCP→Azure mapping line.                              |
+| missing    | Treated as `"aws"` (backwards-compatible with #571).             |
+| `"GCP"`, `"AWS"` (any case) | Lowercased before lookup.                       |
+| anything else | `ValueError` raised by the generator → HTTP 400 from the route. |
+
+## What gets rendered
+
+### `source_provider="aws"` (default)
+```
+Mapping: AWS → Azure · ALB → App Gateway · EKS → AKS · EFS → Azure Files · Kafka → Event Hubs · RDS → Managed DB
+```
+
+### `source_provider="gcp"`
+```
+Mapping: GCP → Azure · GLB → App Gateway · GKE → AKS · Filestore → Azure Files · Pub/Sub → Event Hubs · Cloud SQL → Managed DB
+```
+
+## Why implicit (not a query param)
+
+- The analyzer pipeline already knows the source provider — making the route
+  re-state it would be duplication and a divergence risk.
+- The frontend stays untouched. Frontend wiring is deferred (mirrors how
+  #575 was deferred for #571).
+- Symmetric with how `multi_page` and `dr_variant` were originally scoped:
+  query params are reserved for *renderer-side* preferences, not for facts
+  about the source workload.
+
+## Source of truth
+
+- Constants live in [`backend/azure_landing_zone.py`](../backend/azure_landing_zone.py):
+  - `_SUPPORTED_SOURCE_PROVIDERS: frozenset[str]` — allowed values.
+  - `_SOURCE_PROVIDER_LEGEND_LINE: dict[str, str]` — verbatim mapping line per
+    provider.
+  - `_validate_source_provider(value: str | None) -> str` — single validation
+    entry point. Lowercases, defaults, raises.
+- A module-load `assert` keeps `_SUPPORTED_SOURCE_PROVIDERS` and
+  `_SOURCE_PROVIDER_LEGEND_LINE` in lockstep.
+
+## Adding another provider
+
+1. Add the new key to `_SOURCE_PROVIDER_LEGEND_LINE` with the verbatim mapping
+   line.
+2. Add the same key to `_SUPPORTED_SOURCE_PROVIDERS` (the lockstep assert will
+   fail at import time if you forget).
+3. Add a `TestXxxSource` class in `backend/tests/test_azure_landing_zone.py`
+   covering: legend contains the new mapping line; legend does not contain
+   other providers' lines; primary + DR variants both render; case-insensitive
+   acceptance.
+4. Update this document.
+
+No router, frontend, schema, icon-registry, or replication-template changes
+are required.
+
+## References
+
+- Parent epic: [#571](https://github.com/idokatz86/Archmorph/issues/571)
+- This epic: [#576](https://github.com/idokatz86/Archmorph/issues/576)
+- Sub-issues: [#577](https://github.com/idokatz86/Archmorph/issues/577) (generator), [#578](https://github.com/idokatz86/Archmorph/issues/578) (tests), [#579](https://github.com/idokatz86/Archmorph/issues/579) (validation + this doc)


### PR DESCRIPTION
## Summary
Extends the Azure Landing Zone target diagram (#571) to support GCP as a source provider. Implements all 3 sub-issues of epic #576 in a single change since the delta is ~50 LOC + tests.

**Stacked on #582 (`feat/alz-571-landing-zone`)** — merge that PR first, then re-target this PR to `main`.

## Design
- `analysis["source_provider"]` is **implicit** (read from analysis payload, not query param). Default `"aws"` preserves #571 backwards-compat. Unknown → `ValueError` → HTTP 400. Frontend deferred (mirrors #575 for #571).

## Changes (~297 LOC across 5 files)
- `backend/azure_landing_zone.py` — `_SUPPORTED_SOURCE_PROVIDERS` frozenset, `_SOURCE_PROVIDER_LEGEND_LINE` dict (verbatim AWS line preserved, GCP line added), `_validate_source_provider()` helper, `_legend()` parameterised, threaded through both call sites in `generate_landing_zone_svg()`. Module-load `assert` keeps the two constants in lockstep.
- `backend/routers/analysis.py` — inline contract comment on the export route; **no signature change**.
- `docs/azure-landing-zone-source-provider.md` (new) — full analyzer-contract doc covering field name, defaults, error semantics, and the "how to add another provider" runbook.
- `backend/tests/test_azure_landing_zone.py` — `TestGcpSource` (9 tests).
- `backend/tests/test_azure_landing_zone_schema.py` — `TestSchemaGcpSource` (1 test).

## GCP legend line (verbatim)
`GCP → Azure · GLB → App Gateway · GKE → AKS · Filestore → Azure Files · Pub/Sub → Event Hubs · Cloud SQL → Managed DB`

## Validation
- **52 tests pass** (42 original + 10 new). Zero regressions.
- Backwards-compat: legacy fixtures without `source_provider` render the AWS legend identically to pre-#571.
- No frontend, schema-code, router-signature, icon-registry, region-default, or replication-template changes.

Closes #577, #578, #579
Refs #576, #571