### PR TITLE
feat: architecture limitations engine (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-#### Architecture limitations engine ([#610](https://github.com/idokatz86/Archmorph/issues/610))
+#### Architecture limitations engine (PR [#615](https://github.com/idokatz86/Archmorph/pull/615); follow-up phases [#616](https://github.com/idokatz86/Archmorph/issues/616) [#617](https://github.com/idokatz86/Archmorph/issues/617) [#618](https://github.com/idokatz86/Archmorph/issues/618) [#619](https://github.com/idokatz86/Archmorph/issues/619))
 
 A deterministic rule engine that flags structurally invalid Azure compositions during analysis — the worked example being SFTP-via-Front-Door (Front Door is HTTP/HTTPS-only and cannot proxy port-22 SSH traffic to a storage SFTP endpoint).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Architecture limitations engine ([#610](https://github.com/idokatz86/Archmorph/issues/610))
+
+A deterministic rule engine that flags structurally invalid Azure compositions during analysis — the worked example being SFTP-via-Front-Door (Front Door is HTTP/HTTPS-only and cannot proxy port-22 SSH traffic to a storage SFTP endpoint).
+
+- **25 curated rules** across 7 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature) authored from Microsoft Learn references.
+- **Predicate library** with 8 reusable matchers (service presence, connection protocols, path-via mismatches, category co-occurrence, count thresholds).
+- **YAML-driven rules** at [backend/data/architecture_rules.yaml](backend/data/architecture_rules.yaml); override path via `ARCHMORPH_ARCH_RULES_PATH`.
+- **Three severities**: `blocker` (IaC will be wrong), `warning` (works but has gaps), `info` (best-practice nudges).
+- **Analysis enrichment**: every analysis result now carries `architecture_issues[]` and `architecture_issues_summary{blocker, warning, info, total}`.
+- **IaC generation gate**: `POST /api/diagrams/{id}/generate` (and `/generate-async`) returns 409 when blockers exist; pass `?force=true` to override (logged via `iac_blockers_overridden` event).
+- 38 unit + integration tests covering predicates, YAML schema validation, golden scenarios, and the IaC blocker gate.
+
+Phase 2-5 follow-ups (AI fallback, admin review queue, frontend Architecture Health panel, rule library expansion to 60-100) tracked separately.
+
 ### Changed
 
 #### Infrastructure consolidation (May 2026)

--- a/README.md
+++ b/README.md
@@ -468,6 +468,18 @@ Full mapping database: 405+ services across AWS, Azure, and GCP with 122 mapping
 
 ---
 
+## Architecture Limitations Engine
+
+Deterministic rule engine that flags structurally invalid Azure compositions during analysis — for example, an SFTP client connecting to Azure Storage's SFTP endpoint **through Azure Front Door** (Front Door is HTTP/HTTPS only and cannot tunnel SSH). The diagram and Terraform would deploy cleanly; the runtime traffic would never connect.
+
+- 25 curated rules across 7 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature)
+- YAML-driven rule library at [`backend/data/architecture_rules.yaml`](backend/data/architecture_rules.yaml); override via `ARCHMORPH_ARCH_RULES_PATH`
+- Three severities: `blocker` (IaC will be wrong), `warning` (works but has gaps), `info` (best-practice nudges)
+- IaC generation refuses with `409` when blockers exist; pass `?force=true` to override
+- Full design + extensibility guide: [`docs/ARCHITECTURE_RULES.md`](docs/ARCHITECTURE_RULES.md)
+
+---
+
 ## Cost Estimation
 
 Dynamic pricing powered by the [Azure Retail Prices API](https://prices.azure.com/api/retail/prices):

--- a/backend/architecture_rules/__init__.py
+++ b/backend/architecture_rules/__init__.py
@@ -1,0 +1,26 @@
+"""
+Architecture Limitations Engine — Issue #610.
+
+Detects architecturally invalid Azure compositions (protocol mismatches,
+SKU prerequisites, network topology constraints, etc.) by evaluating a
+curated rule library against an analysis result.
+
+Public API:
+    evaluate(analysis) -> List[ArchitectureIssue]
+    has_blocker(issues) -> bool
+    list_rules() -> List[Rule]
+    reload_rules() -> None
+"""
+
+from .engine import evaluate, has_blocker, list_rules, reload_rules
+from .models import ArchitectureIssue, Rule, Severity
+
+__all__ = [
+    "ArchitectureIssue",
+    "Rule",
+    "Severity",
+    "evaluate",
+    "has_blocker",
+    "list_rules",
+    "reload_rules",
+]

--- a/backend/architecture_rules/engine.py
+++ b/backend/architecture_rules/engine.py
@@ -1,0 +1,239 @@
+"""
+Architecture-limitations rule engine (Issue #610).
+
+Loads rules from a YAML library (default: ``backend/data/architecture_rules.yaml``,
+overridable via ``ARCHMORPH_ARCH_RULES_PATH``) and evaluates them against an
+analysis result.
+
+Public API (re-exported from the package ``__init__``):
+    * evaluate(analysis) -> List[ArchitectureIssue]
+    * has_blocker(issues) -> bool
+    * list_rules() -> List[Rule]
+    * reload_rules() -> None
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from .models import ArchitectureIssue, Rule, Severity, severity_rank
+from .predicates import PredicateMatch, get_predicate, list_predicate_names
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema constants
+# ---------------------------------------------------------------------------
+
+_REQUIRED_FIELDS = (
+    "id",
+    "title",
+    "severity",
+    "category",
+    "message",
+    "remediation",
+    "docs_url",
+    "predicate",
+)
+
+_VALID_SEVERITIES = {s.value for s in Severity}
+
+
+def _default_rules_path() -> Path:
+    """Default location of the rule library, relative to this file."""
+    here = Path(__file__).resolve().parent
+    return here.parent / "data" / "architecture_rules.yaml"
+
+
+def _resolve_rules_path() -> Path:
+    override = os.environ.get("ARCHMORPH_ARCH_RULES_PATH")
+    if override:
+        return Path(override)
+    return _default_rules_path()
+
+
+# ---------------------------------------------------------------------------
+# YAML → Rule
+# ---------------------------------------------------------------------------
+
+
+def _coerce_rule(raw: Dict[str, Any], *, source_path: str) -> Rule:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{source_path}: rule entry is not a mapping: {raw!r}")
+
+    for field in _REQUIRED_FIELDS:
+        if field not in raw or raw[field] is None or raw[field] == "":
+            raise ValueError(f"{source_path}: rule missing required field {field!r}: {raw!r}")
+
+    severity_str = str(raw["severity"]).strip().lower()
+    if severity_str not in _VALID_SEVERITIES:
+        raise ValueError(
+            f"{source_path}: rule {raw.get('id')!r} has invalid severity {severity_str!r}; "
+            f"expected one of {sorted(_VALID_SEVERITIES)}"
+        )
+
+    predicate_name = str(raw["predicate"]).strip()
+    if get_predicate(predicate_name) is None:
+        raise ValueError(
+            f"{source_path}: rule {raw.get('id')!r} references unknown predicate "
+            f"{predicate_name!r}; available: {list_predicate_names()}"
+        )
+
+    return Rule(
+        id=str(raw["id"]).strip(),
+        title=str(raw["title"]).strip(),
+        severity=Severity(severity_str),
+        category=str(raw["category"]).strip(),
+        message=str(raw["message"]).rstrip(),
+        remediation=str(raw["remediation"]).rstrip(),
+        docs_url=str(raw["docs_url"]).strip(),
+        predicate=predicate_name,
+        predicate_args=dict(raw.get("predicate_args") or {}),
+        references=list(raw.get("references") or []),
+        tags=list(raw.get("tags") or []),
+    )
+
+
+def _load_rules_from_path(path: str) -> List[Rule]:
+    p = Path(path)
+    if not p.exists():
+        logger.warning("architecture_rules: YAML library not found at %s", p)
+        return []
+
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"architecture_rules: failed to parse {p}: {exc}") from exc
+
+    if not isinstance(data, dict) or "rules" not in data:
+        raise ValueError(f"{p}: top-level YAML must be a mapping with a 'rules' list")
+
+    raw_rules = data.get("rules") or []
+    if not isinstance(raw_rules, list):
+        raise ValueError(f"{p}: 'rules' must be a list, got {type(raw_rules).__name__}")
+
+    rules: List[Rule] = []
+    seen_ids: set = set()
+    for raw in raw_rules:
+        rule = _coerce_rule(raw, source_path=str(p))
+        if rule.id in seen_ids:
+            raise ValueError(f"{p}: duplicate rule id {rule.id!r}")
+        seen_ids.add(rule.id)
+        rules.append(rule)
+
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Lazy thread-safe singleton store
+# ---------------------------------------------------------------------------
+
+_LOCK = threading.RLock()
+_RULES_CACHE: Optional[List[Rule]] = None
+_LOADED_FROM: Optional[Path] = None
+
+
+def _ensure_loaded() -> List[Rule]:
+    global _RULES_CACHE, _LOADED_FROM
+    with _LOCK:
+        if _RULES_CACHE is None:
+            path = _resolve_rules_path()
+            _RULES_CACHE = _load_rules_from_path(str(path))
+            _LOADED_FROM = path
+            logger.info(
+                "architecture_rules: loaded %d rules from %s",
+                len(_RULES_CACHE),
+                path,
+            )
+        return _RULES_CACHE
+
+
+def reload_rules() -> None:
+    """Force the next call to ``evaluate`` / ``list_rules`` to re-read the YAML."""
+    global _RULES_CACHE, _LOADED_FROM
+    with _LOCK:
+        _RULES_CACHE = None
+        _LOADED_FROM = None
+
+
+def list_rules() -> List[Rule]:
+    return list(_ensure_loaded())
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_one(rule: Rule, analysis: Dict[str, Any]) -> Optional[ArchitectureIssue]:
+    fn = get_predicate(rule.predicate)
+    if fn is None:
+        logger.warning("architecture_rules: rule %s skipped — unknown predicate %s",
+                       rule.id, rule.predicate)
+        return None
+
+    try:
+        result = fn(analysis, **rule.predicate_args)
+    except Exception as exc:  # never let one bad rule break the whole evaluation
+        logger.warning(
+            "architecture_rules: predicate %s failed for rule %s: %s",
+            rule.predicate, rule.id, exc,
+        )
+        return None
+
+    if result is None:
+        return None
+
+    if not isinstance(result, PredicateMatch):
+        logger.warning(
+            "architecture_rules: predicate %s for rule %s returned %r, expected PredicateMatch",
+            rule.predicate, rule.id, type(result).__name__,
+        )
+        return None
+
+    return ArchitectureIssue(
+        rule_id=rule.id,
+        severity=rule.severity,
+        category=rule.category,
+        title=rule.title,
+        message=rule.message,
+        remediation=rule.remediation,
+        docs_url=rule.docs_url,
+        affected_services=list(result.affected_services),
+        source="curated",
+        evidence=dict(result.evidence) if result.evidence else None,
+    )
+
+
+def evaluate(analysis: Dict[str, Any]) -> List[ArchitectureIssue]:
+    """Run every loaded rule against ``analysis``.
+
+    Returns issues sorted by severity (blocker > warning > info), then by
+    category, then by rule id — stable ordering for snapshot tests and UI.
+    """
+    if not isinstance(analysis, dict):
+        return []
+
+    rules = _ensure_loaded()
+    issues: List[ArchitectureIssue] = []
+    for rule in rules:
+        issue = _evaluate_one(rule, analysis)
+        if issue is not None:
+            issues.append(issue)
+
+    issues.sort(
+        key=lambda i: (-severity_rank(i.severity), i.category, i.rule_id),
+    )
+    return issues
+
+
+def has_blocker(issues: List[ArchitectureIssue]) -> bool:
+    return any(i.severity == Severity.BLOCKER for i in issues)

--- a/backend/architecture_rules/models.py
+++ b/backend/architecture_rules/models.py
@@ -1,0 +1,90 @@
+"""Data models for the architecture limitations engine (Issue #610)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class Severity(str, Enum):
+    """Severity tiers for architecture issues.
+
+    blocker  — the architecture cannot work as drawn. Generated IaC will be
+               wrong or non-functional. IaC generation is gated on this.
+    warning  — the architecture works but has a significant gap (cost,
+               reliability, security, or migration effort).
+    info     — informational. Best-practice nudge, alternative tier, etc.
+    """
+
+    BLOCKER = "blocker"
+    WARNING = "warning"
+    INFO = "info"
+
+
+_SEVERITY_RANK = {Severity.BLOCKER: 3, Severity.WARNING: 2, Severity.INFO: 1}
+
+
+def severity_rank(s: Severity) -> int:
+    """Numeric rank used for sorting issues highest-first."""
+    return _SEVERITY_RANK[s]
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single architecture-limitation rule.
+
+    Loaded from YAML. The ``predicate`` field references a function
+    registered in ``predicates.py`` via the ``@register_predicate`` decorator.
+    """
+
+    id: str
+    title: str
+    severity: Severity
+    category: str
+    message: str
+    remediation: str
+    docs_url: str
+    predicate: str
+    predicate_args: Dict[str, Any] = field(default_factory=dict)
+    references: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ArchitectureIssue:
+    """A single rule-firing on a specific analysis result.
+
+    Returned by ``engine.evaluate()`` — these are the structured findings
+    surfaced to API responses, the frontend Architecture Health panel,
+    and the IaC generation gate.
+
+    ``source`` records provenance: ``curated`` (hand-written), ``ai``
+    (Phase 2 AI-fallback), ``admin_approved`` (Phase 3 review queue).
+    """
+
+    rule_id: str
+    severity: Severity
+    category: str
+    title: str
+    message: str
+    remediation: str
+    docs_url: str
+    affected_services: List[str] = field(default_factory=list)
+    source: str = "curated"
+    evidence: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize for inclusion in the analysis result JSON."""
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity.value,
+            "category": self.category,
+            "title": self.title,
+            "message": self.message,
+            "remediation": self.remediation,
+            "docs_url": self.docs_url,
+            "affected_services": list(self.affected_services),
+            "source": self.source,
+            "evidence": self.evidence,
+        }

--- a/backend/architecture_rules/predicates.py
+++ b/backend/architecture_rules/predicates.py
@@ -1,0 +1,388 @@
+"""
+Predicate registry for architecture-limitations rules (Issue #610).
+
+A predicate is a function ``(analysis: dict, **kwargs) -> Optional[PredicateMatch]``
+that decides whether a rule fires against a given analysis result. Predicates
+are registered by name via the ``@register_predicate`` decorator and looked
+up at YAML-load time by the engine.
+
+Authoring guidance:
+    * Be tolerant of missing/malformed analysis fields. Return None on any
+      uncertainty rather than raising.
+    * When a rule fires, populate ``PredicateMatch.affected_services`` with
+      the human-readable service names that triggered the match — these
+      surface in the UI and to the IaC blocker gate.
+    * Keep matching loose (substring + normalisation). The vision pipeline
+      produces noisy service names ("Azure Front Door (Standard)",
+      "front-door-prod", "AFD"…); strict equality misses real architectures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PredicateMatch:
+    """A predicate's positive answer.
+
+    affected_services — service names from the analysis that triggered the rule.
+    evidence          — small dict surfaced in the issue's ``evidence`` field.
+    """
+
+    affected_services: List[str] = field(default_factory=list)
+    evidence: Dict[str, Any] = field(default_factory=dict)
+
+
+PredicateFn = Callable[..., Optional[PredicateMatch]]
+_REGISTRY: Dict[str, PredicateFn] = {}
+
+
+def register_predicate(name: str) -> Callable[[PredicateFn], PredicateFn]:
+    """Decorator: register a predicate function under ``name``."""
+
+    def _decorate(fn: PredicateFn) -> PredicateFn:
+        if name in _REGISTRY:
+            raise ValueError(f"predicate already registered: {name}")
+        _REGISTRY[name] = fn
+        return fn
+
+    return _decorate
+
+
+def get_predicate(name: str) -> Optional[PredicateFn]:
+    return _REGISTRY.get(name)
+
+
+def list_predicate_names() -> List[str]:
+    return sorted(_REGISTRY.keys())
+
+
+# ---------------------------------------------------------------------------
+# Helpers — analysis shape adapters
+# ---------------------------------------------------------------------------
+
+
+def _services_in_analysis(analysis: Dict[str, Any]) -> List[str]:
+    """Collect every service-name string from common analysis shapes.
+
+    Looks at:
+      * identified_services   — list of strings or {"name": ...} dicts
+      * service_to_resource_mapping  — list of {"service": ...} dicts
+      * mappings              — {"source_service": ..., "azure_service": ...}
+    """
+    out: List[str] = []
+    for s in analysis.get("identified_services") or []:
+        if isinstance(s, str):
+            out.append(s)
+        elif isinstance(s, dict):
+            n = s.get("name") or s.get("service") or s.get("title")
+            if isinstance(n, str):
+                out.append(n)
+
+    for m in analysis.get("service_to_resource_mapping") or []:
+        if isinstance(m, dict):
+            n = m.get("service")
+            if isinstance(n, str):
+                out.append(n)
+
+    for m in analysis.get("mappings") or []:
+        if isinstance(m, dict):
+            n = m.get("azure_service") or m.get("source_service")
+            if isinstance(n, str):
+                out.append(n)
+
+    return out
+
+
+def _connections(analysis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw = analysis.get("service_connections") or []
+    return [c for c in raw if isinstance(c, dict)]
+
+
+def _mapping_for(analysis: Dict[str, Any], service_name: str) -> Optional[Dict[str, Any]]:
+    for m in analysis.get("service_to_resource_mapping") or []:
+        if isinstance(m, dict) and _service_matches(m.get("service", ""), service_name):
+            return m
+    return None
+
+
+def _category_of(analysis: Dict[str, Any], service_name: str) -> Optional[str]:
+    for s in analysis.get("identified_services") or []:
+        if isinstance(s, dict) and _service_matches(s.get("name", ""), service_name):
+            cat = s.get("category")
+            if isinstance(cat, str):
+                return cat
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Loose service-name matching
+# ---------------------------------------------------------------------------
+
+
+def _normalize(name: str) -> str:
+    """Lowercase, strip Azure/AWS/Amazon prefixes, normalise dashes/spaces."""
+    if not isinstance(name, str):
+        return ""
+    n = name.lower().strip()
+    for prefix in ("azure ", "aws ", "amazon "):
+        if n.startswith(prefix):
+            n = n[len(prefix):]
+    n = n.replace("-", " ").replace("_", " ")
+    while "  " in n:
+        n = n.replace("  ", " ")
+    return n
+
+
+def _service_matches(actual: str, expected: str) -> bool:
+    """Loose substring match with provider-prefix tolerance.
+
+    "Azure Front Door (Standard)" matches "front door".
+    "front-door-prod" matches "Front Door".
+    Empty/None on either side returns False.
+    """
+    if not actual or not expected:
+        return False
+    a = _normalize(actual)
+    e = _normalize(expected)
+    if not a or not e:
+        return False
+    return e in a or a in e
+
+
+def _has_service(analysis: Dict[str, Any], expected: str) -> List[str]:
+    """Return service names from the analysis that match ``expected``."""
+    matches: List[str] = []
+    for n in _services_in_analysis(analysis):
+        if _service_matches(n, expected):
+            matches.append(n)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Registered predicates
+# ---------------------------------------------------------------------------
+
+
+@register_predicate("service_present")
+def service_present(analysis: Dict[str, Any], *, name: str) -> Optional[PredicateMatch]:
+    """Fire when a service whose name fuzzy-matches ``name`` is present."""
+    hits = _has_service(analysis, name)
+    if not hits:
+        return None
+    return PredicateMatch(affected_services=hits, evidence={"matched": hits})
+
+
+@register_predicate("services_all_present")
+def services_all_present(
+    analysis: Dict[str, Any], *, names: List[str]
+) -> Optional[PredicateMatch]:
+    """Fire only when ALL ``names`` are present (in any combination)."""
+    if not names:
+        return None
+    affected: List[str] = []
+    for needle in names:
+        hits = _has_service(analysis, needle)
+        if not hits:
+            return None
+        affected.extend(hits)
+    # de-dupe while preserving order
+    seen: set = set()
+    deduped = [s for s in affected if not (s in seen or seen.add(s))]
+    return PredicateMatch(affected_services=deduped, evidence={"required": names})
+
+
+@register_predicate("service_pair_connected")
+def service_pair_connected(
+    analysis: Dict[str, Any], *, a: str, b: str
+) -> Optional[PredicateMatch]:
+    """Fire when the analysis has a connection that touches both ``a`` and ``b``."""
+    for c in _connections(analysis):
+        f = str(c.get("from", ""))
+        t = str(c.get("to", ""))
+        if (
+            (_service_matches(f, a) and _service_matches(t, b))
+            or (_service_matches(f, b) and _service_matches(t, a))
+        ):
+            return PredicateMatch(
+                affected_services=[f, t],
+                evidence={"from": f, "to": t, "type": c.get("type")},
+            )
+    return None
+
+
+@register_predicate("connection_uses_protocol")
+def connection_uses_protocol(
+    analysis: Dict[str, Any], *, protocols: List[str]
+) -> Optional[PredicateMatch]:
+    """Fire when any connection has a ``type`` matching one of the protocols."""
+    if not protocols:
+        return None
+    wanted = {p.lower() for p in protocols}
+    for c in _connections(analysis):
+        t = str(c.get("type", "")).lower()
+        if any(p in t for p in wanted):
+            return PredicateMatch(
+                affected_services=[str(c.get("from", "")), str(c.get("to", ""))],
+                evidence={"protocol": c.get("type"), "from": c.get("from"), "to": c.get("to")},
+            )
+    return None
+
+
+@register_predicate("service_count_at_least")
+def service_count_at_least(
+    analysis: Dict[str, Any], *, keywords: List[str], threshold: int = 2
+) -> Optional[PredicateMatch]:
+    """Fire when at least ``threshold`` services match any of ``keywords``."""
+    if not keywords or threshold < 1:
+        return None
+    matched: List[str] = []
+    for n in _services_in_analysis(analysis):
+        if any(_service_matches(n, k) for k in keywords):
+            matched.append(n)
+    if len(matched) < threshold:
+        return None
+    return PredicateMatch(
+        affected_services=matched,
+        evidence={"keywords": keywords, "count": len(matched), "threshold": threshold},
+    )
+
+
+@register_predicate("category_present_without_companion")
+def category_present_without_companion(
+    analysis: Dict[str, Any], *, category: str, companions: List[str]
+) -> Optional[PredicateMatch]:
+    """Fire when a service in ``category`` is present but no service matching
+    any of ``companions`` is also present.
+
+    Example: ``category=integration`` (Event Grid) without any
+    ``companions=[Storage, Blob]`` (potential dead-letter targets) → fire.
+    """
+    in_category: List[str] = []
+    for s in analysis.get("identified_services") or []:
+        if isinstance(s, dict):
+            cat = (s.get("category") or "").lower()
+            if category and category.lower() in cat:
+                n = s.get("name")
+                if isinstance(n, str):
+                    in_category.append(n)
+
+    if not in_category:
+        return None
+
+    for companion in companions or []:
+        if _has_service(analysis, companion):
+            return None  # companion present — rule does not fire.
+
+    return PredicateMatch(
+        affected_services=in_category,
+        evidence={"category": category, "missing_companions": companions},
+    )
+
+
+@register_predicate("service_in_category_with_other")
+def service_in_category_with_other(
+    analysis: Dict[str, Any], *, category: str, other: str
+) -> Optional[PredicateMatch]:
+    """Fire when a service in ``category`` co-exists with a service matching ``other``."""
+    in_category: List[str] = []
+    for s in analysis.get("identified_services") or []:
+        if isinstance(s, dict):
+            cat = (s.get("category") or "").lower()
+            if category and category.lower() in cat:
+                n = s.get("name")
+                if isinstance(n, str):
+                    in_category.append(n)
+    if not in_category:
+        return None
+    other_hits = _has_service(analysis, other)
+    if not other_hits:
+        return None
+    return PredicateMatch(
+        affected_services=in_category + other_hits,
+        evidence={"category": category, "other": other},
+    )
+
+
+@register_predicate("path_uses_service_with_protocol_mismatch")
+def path_uses_service_with_protocol_mismatch(
+    analysis: Dict[str, Any],
+    *,
+    via: str,
+    allowed_protocols: List[str],
+    disallowed_hint: List[str] | None = None,
+) -> Optional[PredicateMatch]:
+    """Primary predicate for SFTP-via-Front-Door style mismatches.
+
+    Fires when there's a connection touching the in-path service ``via``
+    whose protocol is **not** in ``allowed_protocols``. As a fallback (when
+    connection-level protocol metadata is missing), also fires if any
+    connection in the analysis uses a protocol from ``disallowed_hint``
+    AND the in-path service is present in the architecture — this catches
+    architectures where the diagram lacks explicit edge-protocol labels.
+    """
+    if not via:
+        return None
+
+    via_hits = _has_service(analysis, via)
+    if not via_hits:
+        return None
+
+    allowed_lower = {p.lower() for p in (allowed_protocols or [])}
+    disallowed_lower = {p.lower() for p in (disallowed_hint or [])}
+
+    # 1) Strong signal: a connection touching `via` with a non-allowed protocol.
+    for c in _connections(analysis):
+        f = str(c.get("from", ""))
+        t = str(c.get("to", ""))
+        proto = str(c.get("type", "")).lower().strip()
+
+        touches_via = _service_matches(f, via) or _service_matches(t, via)
+        if not touches_via or not proto:
+            continue
+
+        # Normalise proto: "SFTP/SSH" -> tokens {"sftp", "ssh"}
+        tokens = {tok.strip() for tok in proto.replace("/", " ").replace(",", " ").split() if tok.strip()}
+
+        in_allowed = any(tok in allowed_lower for tok in tokens) or any(
+            a in proto for a in allowed_lower
+        )
+        in_disallowed = any(tok in disallowed_lower for tok in tokens) or any(
+            d in proto for d in disallowed_lower
+        )
+
+        if in_disallowed and not in_allowed:
+            return PredicateMatch(
+                affected_services=[f, t],
+                evidence={"via": via, "protocol": c.get("type"), "from": f, "to": t},
+            )
+        # Strict rule: if proto is set, has tokens, and none of the tokens
+        # are allowed → still a mismatch even without an explicit disallowed
+        # hint. This catches diagrams that say "FTP" without our hint list
+        # ever mentioning FTP.
+        if tokens and not in_allowed and not disallowed_lower:
+            return PredicateMatch(
+                affected_services=[f, t],
+                evidence={"via": via, "protocol": c.get("type"), "from": f, "to": t},
+            )
+
+    # 2) Fallback: disallowed protocol seen anywhere AND `via` is in the architecture.
+    if disallowed_lower:
+        for c in _connections(analysis):
+            proto = str(c.get("type", "")).lower()
+            if not proto:
+                continue
+            if any(d in proto for d in disallowed_lower):
+                return PredicateMatch(
+                    affected_services=via_hits,
+                    evidence={"via": via, "hint_protocol": c.get("type"), "fallback": True},
+                )
+
+    return None

--- a/backend/data/architecture_rules.yaml
+++ b/backend/data/architecture_rules.yaml
@@ -1,0 +1,658 @@
+# Architecture Limitations Rule Library — Phase 1 seed (Issue #610).
+#
+# Each rule is evaluated by the engine in `backend/architecture_rules/engine.py`
+# against an analysis result produced by `vision_analyzer.py`. A rule fires
+# when its `predicate` returns a match; the resulting `ArchitectureIssue` is
+# attached to the analysis under `architecture_issues[]`.
+#
+# Rule schema:
+#   id              — stable kebab-case identifier (used by tests + UI)
+#   title           — short human-readable headline
+#   severity        — blocker | warning | info
+#   category        — protocol | network-topology | sku-prereq | identity-auth
+#                     | data-plane | region | tier-feature
+#   message         — markdown body (multi-line OK)
+#   remediation     — what to do instead
+#   docs_url        — authoritative Microsoft Learn link
+#   predicate       — name registered in predicates.py
+#   predicate_args  — kwargs passed to the predicate
+#   tags            — optional grouping
+#
+# Severity guidance:
+#   blocker — generated IaC will be wrong / non-functional. IaC gate fires.
+#   warning — works but has a significant gap.
+#   info    — best-practice / awareness nudge.
+#
+# When you add a rule:
+#   1. Pick or implement a predicate in predicates.py.
+#   2. Author the card here.
+#   3. Add at least one fixture-based unit test in
+#      tests/test_architecture_rules.py asserting the rule fires (or doesn't).
+
+rules:
+  # ────────────────────────────────────────────────────────────
+  # Category 1 — Protocol incompatibility
+  # ────────────────────────────────────────────────────────────
+
+  - id: front-door-protocol-mismatch
+    title: Azure Front Door only supports HTTP/HTTPS traffic
+    severity: blocker
+    category: protocol
+    message: |
+      Azure Front Door is an HTTP/HTTPS Layer-7 service. It cannot proxy
+      SFTP, SSH, FTP, SMTP, AMQP, MQTT, raw TCP, or any non-HTTP protocol.
+      The architecture as drawn shows traffic crossing Front Door over a
+      protocol it does not support — clients will not be able to reach
+      the backend.
+    remediation: |
+      • For SFTP traffic to Azure Storage: bypass Front Door and connect
+        the client directly to the storage account's SFTP endpoint. Use
+        a Private Endpoint or NAT Gateway / firewall for IP allow-listing.
+      • For raw TCP/UDP load balancing: use Standard Load Balancer.
+      • For non-HTTP protocols at the edge: use Azure Firewall, an NVA,
+        or expose the backend service directly with appropriate network
+        controls.
+    docs_url: https://learn.microsoft.com/azure/frontdoor/front-door-faq
+    predicate: path_uses_service_with_protocol_mismatch
+    predicate_args:
+      via: Front Door
+      allowed_protocols:
+        - http
+        - https
+        - websocket
+        - ws
+        - wss
+      disallowed_hint:
+        - sftp
+        - ssh
+        - ftp
+        - smtp
+        - amqp
+        - mqtt
+    tags: [frontdoor, protocol, l7]
+
+  - id: app-gateway-protocol-mismatch
+    title: Azure Application Gateway is HTTP/HTTPS only (L7)
+    severity: blocker
+    category: protocol
+    message: |
+      Azure Application Gateway is a Layer-7 HTTP/HTTPS reverse proxy
+      and Web Application Firewall. It does not handle SFTP, SSH, raw
+      TCP/UDP, AMQP, MQTT, or other non-HTTP protocols. Routing those
+      protocols through Application Gateway will fail.
+    remediation: |
+      • Use Standard Load Balancer for L4 (TCP/UDP) traffic.
+      • Use Azure Firewall or an NVA for protocol-agnostic edge traffic.
+      • For SFTP to Azure Storage, expose the storage SFTP endpoint
+        directly (private endpoint + NSG/firewall recommended).
+    docs_url: https://learn.microsoft.com/azure/application-gateway/overview
+    predicate: path_uses_service_with_protocol_mismatch
+    predicate_args:
+      via: Application Gateway
+      allowed_protocols:
+        - http
+        - https
+        - websocket
+        - ws
+        - wss
+      disallowed_hint:
+        - sftp
+        - ssh
+        - ftp
+        - smtp
+        - amqp
+        - mqtt
+    tags: [appgateway, protocol, l7]
+
+  - id: load-balancer-l4-only-info
+    title: Azure Load Balancer is L4 — no HTTP routing or path rules
+    severity: info
+    category: protocol
+    message: |
+      Azure Standard Load Balancer operates at Layer 4 (TCP/UDP) only.
+      It cannot inspect HTTP headers, perform path-based routing,
+      terminate TLS at the application layer, or apply WAF rules.
+      If your design relies on path/host routing, TLS termination, or
+      Web Application Firewall, Standard Load Balancer is the wrong tool.
+    remediation: |
+      • For HTTP path/host routing → Application Gateway (regional) or
+        Front Door (global).
+      • For WAF protection → Application Gateway WAF SKU or
+        Front Door Premium with WAF.
+      • For TLS offload at L7 → Application Gateway / Front Door.
+    docs_url: https://learn.microsoft.com/azure/load-balancer/load-balancer-overview
+    predicate: service_present
+    predicate_args:
+      name: Load Balancer
+    tags: [loadbalancer, l4, protocol]
+
+  - id: front-door-sftp-storage-blocker
+    title: Front Door cannot front Azure Storage SFTP — storage SFTP is SSH on port 22
+    severity: blocker
+    category: protocol
+    message: |
+      Azure Storage SFTP support exposes a Secure Shell File Transfer
+      Protocol endpoint (TCP 22, SSH-based). Azure Front Door is an
+      HTTP/HTTPS-only edge service and cannot proxy SSH/SFTP traffic.
+      Placing Front Door in front of a storage account's SFTP endpoint
+      means SFTP clients cannot reach the storage backend through it.
+    remediation: |
+      • Connect SFTP clients directly to the storage account's SFTP
+        endpoint: ``<account>.blob.core.windows.net`` on TCP/22.
+      • For network controls, use the storage account firewall, a
+        Private Endpoint inside a VNet, or an Azure Firewall in front
+        of the storage account — not Front Door.
+      • If you also need HTTPS (Blob REST) on the same account, that
+        path *can* go through Front Door; only SFTP traffic must
+        bypass Front Door.
+    docs_url: https://learn.microsoft.com/azure/storage/blobs/secure-file-transfer-protocol-support
+    predicate: services_all_present
+    predicate_args:
+      names:
+        - Front Door
+        - SFTP
+    tags: [frontdoor, storage, sftp, protocol]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 2 — Network topology
+  # ────────────────────────────────────────────────────────────
+
+  - id: vnet-peering-non-transitive-warning
+    title: VNet peering is not transitive — hub-spoke needs explicit routes
+    severity: warning
+    category: network-topology
+    message: |
+      Multiple Virtual Networks were detected. Azure VNet peering is
+      **not transitive**: if VNet-A peers with VNet-B and VNet-B peers
+      with VNet-C, traffic from A still cannot reach C without explicit
+      routing through B.
+      Hub-and-spoke designs must route spoke-to-spoke traffic through
+      a Network Virtual Appliance, Azure Firewall, or VPN Gateway in
+      the hub.
+    remediation: |
+      • Confirm whether your design needs spoke-to-spoke connectivity.
+      • If yes, place an Azure Firewall (or NVA) in the hub and add
+        User-Defined Routes on each spoke pointing to it.
+      • Or use Azure Virtual WAN, which provides transitive routing.
+    docs_url: https://learn.microsoft.com/azure/virtual-network/virtual-network-peering-overview
+    predicate: service_count_at_least
+    predicate_args:
+      keywords:
+        - virtual network
+        - vnet
+      threshold: 2
+    tags: [vnet, peering, hub-spoke]
+
+  - id: apim-consumption-tier-vnet-info
+    title: API Management Consumption tier cannot join a VNet
+    severity: info
+    category: network-topology
+    message: |
+      Azure API Management was detected. The **Consumption** tier (the
+      cheapest, serverless option) does *not* support VNet integration
+      — there is no internal mode and no inbound private endpoint. If
+      your APIs need to reach private backends (or be reachable only
+      from inside a VNet), the Consumption tier is not viable.
+    remediation: |
+      • Choose Developer / Basic / Standard / Premium / Standard v2 for
+        VNet-injected scenarios.
+      • Premium and Standard v2 support both external and internal VNet
+        modes; Developer is the cheapest tier with VNet support but is
+        single-instance and not for production.
+    docs_url: https://learn.microsoft.com/azure/api-management/api-management-features
+    predicate: service_present
+    predicate_args:
+      name: API Management
+    tags: [apim, vnet, sku]
+
+  - id: functions-consumption-tier-vnet-info
+    title: Functions Consumption plan cannot integrate with a VNet
+    severity: info
+    category: network-topology
+    message: |
+      Azure Functions on the **Consumption** plan does not support
+      regional VNet integration or inbound private endpoints. If the
+      function needs to reach a private database, key vault, or other
+      service that is restricted to a VNet, the Consumption plan will
+      not work.
+    remediation: |
+      • Use the **Flex Consumption** or **Premium** plan for VNet
+        integration.
+      • For inbound private access to the function, use the Premium
+        or Dedicated plan plus a Private Endpoint.
+    docs_url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    predicate: service_present
+    predicate_args:
+      name: Azure Functions
+    tags: [functions, vnet, sku]
+
+  - id: container-apps-vnet-workload-profile-info
+    title: Container Apps VNet integration requires a workload-profile environment
+    severity: info
+    category: network-topology
+    message: |
+      Azure Container Apps was detected. To deploy into a VNet, the
+      Container Apps **Environment** must be created with a workload
+      profile (or as an internal Consumption-only environment with VNet
+      pre-provisioning). Existing environments cannot be retro-fitted
+      with a VNet — it is set at creation time.
+    remediation: |
+      • Create the Environment with `--infrastructure-subnet-resource-id`
+        and a workload profile if you need VNet integration.
+      • If the Environment already exists without a VNet, plan a
+        migration: stand up a new Environment, redeploy the apps,
+        cut over the ingress.
+    docs_url: https://learn.microsoft.com/azure/container-apps/networking
+    predicate: service_present
+    predicate_args:
+      name: Container Apps
+    tags: [containerapps, vnet, workload-profile]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 3 — SKU prerequisites
+  # ────────────────────────────────────────────────────────────
+
+  - id: storage-sftp-requires-hns-info
+    title: Storage SFTP requires Hierarchical Namespace (ADLS Gen2)
+    severity: info
+    category: sku-prereq
+    message: |
+      To enable the SFTP endpoint on an Azure Storage account, the
+      account must have **Hierarchical Namespace** turned on (i.e., be
+      a Data Lake Storage Gen2 account). HNS cannot be enabled after
+      account creation. SFTP is also unavailable on Premium block-blob
+      accounts in some configurations and requires the local-user
+      authentication model.
+    remediation: |
+      • Create a new Standard general-purpose v2 storage account with
+        `--enable-hierarchical-namespace true` from the start.
+      • Configure local users (SFTP-specific) and key/password auth.
+      • Migrate existing data from the old account if needed.
+    docs_url: https://learn.microsoft.com/azure/storage/blobs/secure-file-transfer-protocol-support
+    predicate: services_all_present
+    predicate_args:
+      names:
+        - Storage
+        - SFTP
+    tags: [storage, sftp, hns]
+
+  - id: front-door-private-link-premium-info
+    title: Front Door Private Link origins require the Premium SKU
+    severity: info
+    category: sku-prereq
+    message: |
+      Azure Front Door + a Private Endpoint origin (e.g., a private
+      App Service, Storage account, or Application Gateway) requires
+      **Front Door Premium**. Standard SKU cannot connect to Private
+      Link origins; only public-IP origins are supported.
+    remediation: |
+      • Upgrade to Front Door Premium if you need Private Link origins.
+      • Or, if cost is a concern, expose the origin publicly with
+        IP allow-listing keyed on Front Door's `X-Azure-FDID` header
+        and the `AzureFrontDoor.Backend` service tag.
+    docs_url: https://learn.microsoft.com/azure/frontdoor/private-link
+    predicate: services_all_present
+    predicate_args:
+      names:
+        - Front Door
+        - Private
+    tags: [frontdoor, privatelink, sku]
+
+  - id: cosmos-db-free-tier-singleton-info
+    title: Azure Cosmos DB free tier is one per subscription
+    severity: info
+    category: sku-prereq
+    message: |
+      Azure Cosmos DB free tier (1000 RU/s + 25 GB free) is limited
+      to **one account per Azure subscription**. If a second Cosmos DB
+      account is created in the same subscription, free tier cannot
+      be applied to it.
+    remediation: |
+      • Decide which Cosmos account gets free tier and apply it
+        deliberately.
+      • For multi-environment work (dev/test/prod), put each in a
+        separate subscription if you want each to get free tier.
+      • Use serverless capacity for low-throughput workloads as an
+        alternative cost-control mechanism.
+    docs_url: https://learn.microsoft.com/azure/cosmos-db/free-tier
+    predicate: service_present
+    predicate_args:
+      name: Cosmos DB
+    tags: [cosmos, free-tier, sku]
+
+  - id: app-service-deployment-slots-tier-info
+    title: App Service deployment slots require Standard or higher
+    severity: info
+    category: sku-prereq
+    message: |
+      App Service **deployment slots** (used for blue/green deploys
+      and slot swaps) are not available on Free, Shared, or Basic
+      plans. Standard offers up to 5 slots, Premium offers 20.
+    remediation: |
+      • Use at minimum the Standard plan if you need slots.
+      • Premium V3 is recommended for production VNet-integrated
+        workloads with slot-based deployments.
+    docs_url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+    predicate: service_present
+    predicate_args:
+      name: App Service
+    tags: [appservice, slots, sku]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 4 — Identity / auth gaps
+  # ────────────────────────────────────────────────────────────
+
+  - id: storage-account-key-vs-rbac-info
+    title: Prefer Microsoft Entra (RBAC) over storage account keys
+    severity: info
+    category: identity-auth
+    message: |
+      Azure Storage was detected. Account keys grant full access to
+      the storage account and cannot be scoped to a single container,
+      blob, or operation. They are a frequent root cause of breach
+      blast-radius incidents when leaked. Microsoft Entra
+      authentication (RBAC + managed identity) is the recommended
+      mechanism for modern workloads.
+    remediation: |
+      • Disable shared-key access on the storage account where
+        feasible: ``az storage account update --allow-shared-key-access false``.
+      • Use system-assigned or user-assigned managed identities on
+        the calling services and assign the least-privilege built-in
+        role (``Storage Blob Data Contributor``, ``Storage Blob Data Reader``, etc.).
+      • Where SAS is unavoidable (browser uploads, partner integrations),
+        prefer **user-delegation SAS** signed by an Entra identity.
+    docs_url: https://learn.microsoft.com/azure/storage/common/authorize-data-access
+    predicate: service_present
+    predicate_args:
+      name: Storage
+    tags: [storage, identity, rbac]
+
+  - id: cosmos-mi-data-plane-warning
+    title: Cosmos DB data-plane RBAC needs explicit role assignment
+    severity: warning
+    category: identity-auth
+    message: |
+      Cosmos DB is detected. Managed identity for Cosmos DB
+      **data-plane** access (read/write documents) is not granted by
+      Reader / Contributor / Owner — those are control-plane only.
+      You must assign one of the **Cosmos DB built-in data-plane
+      roles** (e.g., ``Cosmos DB Built-in Data Reader`` or
+      ``Cosmos DB Built-in Data Contributor``) using
+      ``az cosmosdb sql role assignment create``.
+      Forgetting this is a common cause of 401/403 at runtime even
+      after the managed identity is correctly configured.
+    remediation: |
+      • Assign the Cosmos data-plane role to the application's
+        managed identity. Example for an API:
+        ``az cosmosdb sql role assignment create --account-name <acct> --resource-group <rg> --scope "/" --principal-id <objId> --role-definition-id 00000000-0000-0000-0000-000000000002``
+      • In Bicep/Terraform, model the role assignment alongside the
+        Cosmos account.
+      • Disable account keys after MI is wired and verified.
+    docs_url: https://learn.microsoft.com/azure/cosmos-db/how-to-setup-rbac
+    predicate: service_present
+    predicate_args:
+      name: Cosmos DB
+    tags: [cosmos, identity, rbac, data-plane]
+
+  - id: keyvault-rbac-vs-policy-info
+    title: Key Vault — prefer RBAC permission model over Access Policies
+    severity: info
+    category: identity-auth
+    message: |
+      Key Vault is detected. Microsoft now recommends the **Azure
+      RBAC** permission model over the legacy access-policies model.
+      Mixing the two within an organization is a common cause of
+      access-denied errors after refactors.
+    remediation: |
+      • Create new Key Vaults with `--enable-rbac-authorization true`.
+      • Assign built-in roles (``Key Vault Secrets User``,
+        ``Key Vault Crypto User``, etc.) to managed identities.
+      • Migrate existing access-policy vaults at a known maintenance
+        window — the model is per-vault and cannot be partially
+        applied.
+    docs_url: https://learn.microsoft.com/azure/key-vault/general/rbac-guide
+    predicate: service_present
+    predicate_args:
+      name: Key Vault
+    tags: [keyvault, identity, rbac]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 5 — Data plane / message limits
+  # ────────────────────────────────────────────────────────────
+
+  - id: service-bus-message-size-info
+    title: Service Bus message size — 256 KB Standard, 100 MB Premium
+    severity: info
+    category: data-plane
+    message: |
+      Azure Service Bus enforces hard message-size limits:
+      • **Standard** tier: 256 KB per message.
+      • **Premium** tier: 100 MB per message.
+      Workloads that need to send larger payloads via Service Bus
+      Standard will fail with ``MessageSizeExceededException``. The
+      common pattern for this is the **Claim Check** integration
+      pattern: store the body in Blob Storage and send only a
+      reference through Service Bus.
+    remediation: |
+      • Adopt the Claim Check pattern (Blob + Service Bus reference
+        message).
+      • Or upgrade the namespace to Premium if 100 MB is enough.
+      • Compress payloads where appropriate.
+    docs_url: https://learn.microsoft.com/azure/service-bus-messaging/service-bus-quotas
+    predicate: service_present
+    predicate_args:
+      name: Service Bus
+    tags: [servicebus, message-size, data-plane]
+
+  - id: storage-queue-vs-service-bus-info
+    title: Storage Queue is 64 KB / message — consider Service Bus for richer scenarios
+    severity: info
+    category: data-plane
+    message: |
+      Azure Storage Queue is detected. Storage Queue messages are
+      capped at **64 KB** (48 KB if Base64-encoded), have no FIFO
+      guarantee, no sessions, no transactions, and limited dead-letter
+      semantics. For most application messaging needs, Azure Service
+      Bus is the more capable choice.
+    remediation: |
+      • For simple, very-high-volume work-queue scenarios with small
+        messages, Storage Queue is fine and cheap.
+      • For ordered delivery, sessions, transactions, dead-lettering,
+        topic/sub fan-out, or message sizes > 64 KB, switch to
+        Service Bus (Queues for unicast, Topics + Subscriptions for
+        fan-out).
+    docs_url: https://learn.microsoft.com/azure/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted
+    predicate: service_present
+    predicate_args:
+      name: Storage Queue
+    tags: [storage-queue, servicebus, data-plane]
+
+  - id: event-grid-without-deadletter-warning
+    title: Event Grid without a dead-letter destination loses events after retries
+    severity: warning
+    category: data-plane
+    message: |
+      Event Grid is detected without a clearly co-located storage
+      account or queue that could be used as a dead-letter target.
+      Event Grid retries failed deliveries for up to **24 hours by
+      default** (configurable on the subscription). After that,
+      events that still cannot be delivered are dropped — unless a
+      **dead-letter destination** (Blob Storage container) is
+      configured on the subscription.
+    remediation: |
+      • Provision a dedicated Storage Account container for
+        dead-lettering and configure it on every Event Grid
+        subscription that handles business-critical events.
+      • Build alerting on dead-letter blob count > 0.
+      • Document the retention policy of the DLQ container.
+    docs_url: https://learn.microsoft.com/azure/event-grid/manage-event-delivery
+    predicate: category_present_without_companion
+    predicate_args:
+      category: integration
+      companions:
+        - Storage
+        - Blob
+    tags: [eventgrid, dlq, data-plane]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 6 — Region / sovereignty
+  # ────────────────────────────────────────────────────────────
+
+  - id: openai-region-availability-info
+    title: Azure OpenAI is region- and model-restricted — verify availability
+    severity: info
+    category: region
+    message: |
+      Azure OpenAI Service was detected. Different models, deployment
+      types (Standard / Provisioned / Global), and capacity tiers are
+      available in different regions. A model your code calls today
+      may not be deployable in your preferred region tomorrow.
+    remediation: |
+      • Check region & model availability before pinning a deployment
+        region (and revisit before contract renewal): Microsoft Learn
+        publishes a regularly-updated availability matrix.
+      • For latency-sensitive workloads, use the **Standard Global**
+        deployment type, which routes to capacity worldwide.
+      • For PTU (provisioned throughput), confirm the region has
+        capacity *before* committing.
+    docs_url: https://learn.microsoft.com/azure/ai-services/openai/concepts/models
+    predicate: service_present
+    predicate_args:
+      name: OpenAI
+    tags: [openai, region, model-availability]
+
+  - id: confidential-compute-region-info
+    title: Confidential Computing SKUs are limited to specific regions
+    severity: info
+    category: region
+    message: |
+      Azure Confidential Computing (Confidential VMs, Confidential
+      Containers on AKS, DCsv3/ECsv5 SKUs) is available only in a
+      subset of Azure regions and only on specific VM families. If
+      your design requires confidential compute, lock down the region
+      decision early.
+    remediation: |
+      • Verify region availability for the specific SKU you plan to
+        use (DCsv3, ECsv5, etc.) on Microsoft Learn.
+      • For AKS Confidential Containers, also verify the AKS
+        Confidential Containers preview/GA status in your region.
+    docs_url: https://learn.microsoft.com/azure/confidential-computing/overview-azure-products
+    predicate: service_present
+    predicate_args:
+      name: Confidential
+    tags: [confidential-computing, region, sku]
+
+  - id: azure-government-feature-gap-info
+    title: Azure Government has feature & service-availability gaps vs commercial
+    severity: info
+    category: region
+    message: |
+      Azure Government is mentioned. Azure Government clouds (US Gov
+      Virginia, Arizona, Texas — and the equivalent China /
+      sovereign clouds) lag the commercial cloud on **service
+      availability** and **feature flags** by weeks-to-months. Many
+      services that ship in commercial are not available, or are
+      available only in older API versions, in Government clouds.
+    remediation: |
+      • Cross-check every service in this design against the Azure
+        Government services-by-region matrix before committing.
+      • For services that exist in both, verify the API version and
+        regional endpoint match what your code expects (the endpoint
+        suffix differs from commercial: ``.usgovcloudapi.net``).
+    docs_url: https://learn.microsoft.com/azure/azure-government/documentation-government-services-supportedservices
+    predicate: service_present
+    predicate_args:
+      name: Government
+    tags: [government, sovereign, region]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 7 — Tier feature dependencies
+  # ────────────────────────────────────────────────────────────
+
+  - id: sql-serverless-no-read-replicas-info
+    title: Azure SQL Serverless has no read-only replicas
+    severity: info
+    category: tier-feature
+    message: |
+      Azure SQL Database is detected. The **Serverless** compute tier
+      (Gen5 only) does not support read-only secondary replicas the
+      way Provisioned Hyperscale and Business Critical do. Workloads
+      that depend on offloading read traffic to a replica cannot use
+      Serverless without redesign.
+    remediation: |
+      • If read-replica offload is essential, use **Hyperscale**
+        (named replicas) or **Business Critical** (built-in HA
+        replicas + read-scale).
+      • If autopause is the main reason for picking Serverless,
+        consider Hyperscale's pause-resume capability instead.
+    docs_url: https://learn.microsoft.com/azure/azure-sql/database/serverless-tier-overview
+    predicate: service_present
+    predicate_args:
+      name: SQL Database
+    tags: [sql, serverless, replicas, tier]
+
+  - id: front-door-custom-domain-cert-tier-info
+    title: Front Door managed certificates require Standard or Premium SKU
+    severity: info
+    category: tier-feature
+    message: |
+      Front Door is detected. **Azure-managed TLS certificates** for
+      custom domains are available only on Front Door Standard /
+      Premium. The classic / Basic tier requires you to bring your
+      own certificate and manage rotation yourself.
+    remediation: |
+      • Use Front Door Standard or Premium and let Azure issue and
+        rotate certs automatically.
+      • If you must stay on classic, integrate with Key Vault and
+        automate cert renewal via a pipeline.
+    docs_url: https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain
+    predicate: service_present
+    predicate_args:
+      name: Front Door
+    tags: [frontdoor, tls, tier]
+
+  - id: functions-private-endpoint-tier-warning
+    title: Function Apps that consume private services should be on Premium / Flex Consumption
+    severity: warning
+    category: tier-feature
+    message: |
+      Azure Functions is detected alongside services typically used
+      with Private Endpoints (Storage, Cosmos DB, Service Bus, SQL).
+      The default **Consumption** plan cannot integrate with a VNet
+      and therefore cannot reach those private endpoints. Designs
+      that pair Functions with private services almost always need
+      **Flex Consumption** or **Premium**.
+    remediation: |
+      • Use the Flex Consumption plan if available in your region
+        (newer, cheaper than Premium for many workloads).
+      • Otherwise use the Premium plan with regional VNet integration.
+      • For pure public ingestion with no backend access, Consumption
+        is fine — but rare.
+    docs_url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    predicate: services_all_present
+    predicate_args:
+      names:
+        - Azure Functions
+        - Private
+    tags: [functions, vnet, tier]
+
+  - id: service-bus-sessions-tier-info
+    title: Service Bus message sessions require Standard or Premium
+    severity: info
+    category: tier-feature
+    message: |
+      Service Bus is detected. **Message sessions** (FIFO ordering
+      per session-id, request-response correlation, etc.) are
+      available on Standard and Premium tiers but not on the Basic
+      tier. Most application-level messaging patterns that rely on
+      ordering or correlation need sessions.
+    remediation: |
+      • Use at least the Standard tier if your application requires
+        sessions, transactions, topics & subscriptions, or auto-forward.
+      • Premium adds resource isolation, larger messages (100 MB),
+        and predictable latency.
+    docs_url: https://learn.microsoft.com/azure/service-bus-messaging/message-sessions
+    predicate: service_present
+    predicate_args:
+      name: Service Bus
+    tags: [servicebus, sessions, tier]

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -10668,7 +10668,7 @@
     },
     "/api/diagrams/{diagram_id}/generate": {
       "post": {
-        "description": "Generate Infrastructure as Code from the architecture analysis.",
+        "description": "Generate Infrastructure as Code from the architecture analysis.\n\n``force=true`` overrides the architecture-blocker gate (Issue #610).",
         "operationId": "generate_iac_api_diagrams__diagram_id__generate_post",
         "parameters": [
           {
@@ -10688,6 +10688,16 @@
               "default": "terraform",
               "title": "Format",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Force",
+              "type": "boolean"
             }
           }
         ],
@@ -10721,7 +10731,7 @@
     },
     "/api/diagrams/{diagram_id}/generate-async": {
       "post": {
-        "description": "Start async IaC code generation. Returns 202 with job_id.",
+        "description": "Start async IaC code generation. Returns 202 with job_id.\n\n``force=true`` overrides the architecture-blocker gate (Issue #610).",
         "operationId": "generate_iac_async_api_diagrams__diagram_id__generate_async_post",
         "parameters": [
           {
@@ -10741,6 +10751,16 @@
               "default": "terraform",
               "title": "Format",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Force",
+              "type": "boolean"
             }
           }
         ],
@@ -23046,7 +23066,7 @@
     },
     "/api/v1/diagrams/{diagram_id}/generate": {
       "post": {
-        "description": "Generate Infrastructure as Code from the architecture analysis.",
+        "description": "Generate Infrastructure as Code from the architecture analysis.\n\n``force=true`` overrides the architecture-blocker gate (Issue #610).",
         "operationId": "generate_iac_v1_api_v1_diagrams__diagram_id__generate_post",
         "parameters": [
           {
@@ -23066,6 +23086,16 @@
               "default": "terraform",
               "title": "Format",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Force",
+              "type": "boolean"
             }
           }
         ],
@@ -23102,7 +23132,7 @@
     },
     "/api/v1/diagrams/{diagram_id}/generate-async": {
       "post": {
-        "description": "Start async IaC code generation. Returns 202 with job_id.",
+        "description": "Start async IaC code generation. Returns 202 with job_id.\n\n``force=true`` overrides the architecture-blocker gate (Issue #610).",
         "operationId": "generate_iac_async_v1_api_v1_diagrams__diagram_id__generate_async_post",
         "parameters": [
           {
@@ -23122,6 +23152,16 @@
               "default": "terraform",
               "title": "Format",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Force",
+              "type": "boolean"
             }
           }
         ],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,6 +37,7 @@ redis
 python-docx>=1.2.0
 fpdf2
 python-pptx
+PyYAML>=6.0.2  # architecture limitations rule library (Issue #610)
 
 # Security-pinned dependencies
 cryptography>=47.0.0

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -33,6 +33,7 @@ from auth import get_user_from_request_headers
 from analysis_history import maybe_save_from_session
 from sku_translator import get_sku_translator
 from confidence_provenance import build_provenance
+from architecture_rules import evaluate as evaluate_architecture_rules
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,38 @@ def _enrich_with_provenance(result: dict) -> dict:
     return result
 
 
+def _enrich_with_architecture_issues(result: dict) -> dict:
+    """Run the architecture-limitations engine against the analysis (Issue #610).
+
+    Adds two top-level keys to the result:
+      - architecture_issues: list of issue dicts (rule_id, severity, message, ...)
+      - architecture_issues_summary: { blocker, warning, info, total }
+
+    Failures are swallowed and logged: a broken rule must never break analysis.
+    """
+    try:
+        issues = evaluate_architecture_rules(result)
+        issue_dicts = [i.to_dict() for i in issues]
+        summary = {"blocker": 0, "warning": 0, "info": 0, "total": len(issue_dicts)}
+        for d in issue_dicts:
+            sev = d.get("severity")
+            if sev in summary:
+                summary[sev] += 1
+        result["architecture_issues"] = issue_dicts
+        result["architecture_issues_summary"] = summary
+    except Exception as exc:
+        logger.warning(
+            "architecture_rules evaluation failed: %s",
+            str(exc).replace("\n", " ").replace("\r", " "),
+        )
+        result.setdefault("architecture_issues", [])
+        result.setdefault(
+            "architecture_issues_summary",
+            {"blocker": 0, "warning": 0, "info": 0, "total": 0, "engine_error": True},
+        )
+    return result
+
+
 def _normalize_analysis(result: dict) -> dict:
     """Normalize GPT vision output so downstream code always sees consistent fields.
 
@@ -100,6 +133,7 @@ def _normalize_analysis(result: dict) -> dict:
 
     result = _enrich_with_sku(result)
     result = _enrich_with_provenance(result)
+    result = _enrich_with_architecture_issues(result)
     return result
 
 

--- a/backend/routers/iac_routes.py
+++ b/backend/routers/iac_routes.py
@@ -23,6 +23,73 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# ─────────────────────────────────────────────────────────────
+# Architecture-blocker gate (Issue #610)
+# ─────────────────────────────────────────────────────────────
+def _check_architecture_blockers(diagram_id: str, session: dict, force: bool) -> None:
+    """Refuse IaC generation when unresolved architecture blockers exist.
+
+    Reads ``session["architecture_issues"]`` (set by the analysis enrichment
+    pipeline). If any issue has severity=blocker:
+
+    - ``force=False`` → raise 409 with the blocker list and an override hint.
+    - ``force=True`` → log a warning and proceed (admin/expert override).
+    - No issues / no blockers → return silently.
+
+    Failures while inspecting the session are swallowed so the gate can never
+    break IaC generation for sessions that pre-date the engine.
+    """
+    try:
+        issues = session.get("architecture_issues") or []
+    except Exception:
+        return
+
+    blockers = [i for i in issues if isinstance(i, dict) and i.get("severity") == "blocker"]
+    if not blockers:
+        return
+
+    if force:
+        logger.warning(
+            "iac_blockers_overridden diagram=%s blocker_count=%d ids=%s",
+            str(diagram_id).replace("\n", "").replace("\r", ""),
+            len(blockers),
+            ",".join(b.get("rule_id", "?") for b in blockers),
+        )
+        record_event(
+            "iac_blockers_overridden",
+            {
+                "diagram_id": diagram_id,
+                "blocker_count": len(blockers),
+                "rule_ids": [b.get("rule_id") for b in blockers],
+            },
+        )
+        return
+
+    raise ArchmorphException(
+        409,
+        detail={
+            "error": "architecture_blocker_unresolved",
+            "message": (
+                "IaC generation is blocked because the architecture has "
+                f"{len(blockers)} unresolved blocker issue(s). "
+                "Resolve the issues, or pass ?force=true to override."
+            ),
+            "blockers": [
+                {
+                    "rule_id": b.get("rule_id"),
+                    "title": b.get("title"),
+                    "message": b.get("message"),
+                    "remediation": b.get("remediation"),
+                    "docs_url": b.get("docs_url"),
+                    "affected_services": b.get("affected_services", []),
+                }
+                for b in blockers
+            ],
+            "override_hint": "Append ?force=true to the request URL to generate anyway.",
+        },
+    )
+
+
 class IaCChatMessage(BaseModel):
     """Request body for IaC chat messages."""
     message: str = Field(..., min_length=1, max_length=5000)
@@ -35,13 +102,18 @@ class IaCChatMessage(BaseModel):
 # ─────────────────────────────────────────────────────────────
 @router.post("/api/diagrams/{diagram_id}/generate")
 @limiter.limit("5/minute")
-async def generate_iac(request: Request, diagram_id: str, format: str = "terraform", _auth=Depends(verify_api_key)):
-    """Generate Infrastructure as Code from the architecture analysis."""
+async def generate_iac(request: Request, diagram_id: str, format: str = "terraform", force: bool = False, _auth=Depends(verify_api_key)):
+    """Generate Infrastructure as Code from the architecture analysis.
+
+    ``force=true`` overrides the architecture-blocker gate (Issue #610).
+    """
     if format not in ["terraform", "bicep", "cloudformation"]:
         raise ArchmorphException(400, "Format must be 'terraform', 'bicep', or 'cloudformation'")
 
     session = SESSION_STORE.get(diagram_id, {})
     iac_params = session.get("iac_parameters", {})
+
+    _check_architecture_blockers(diagram_id, session, force)
 
     try:
         code = await asyncio.to_thread(
@@ -113,11 +185,17 @@ async def iac_chat_clear(request: Request, diagram_id: str):
 @router.post("/api/diagrams/{diagram_id}/generate-async")
 @limiter.limit("5/minute")
 async def generate_iac_async(
-    request: Request, diagram_id: str, format: str = "terraform", _auth=Depends(verify_api_key),
+    request: Request, diagram_id: str, format: str = "terraform", force: bool = False, _auth=Depends(verify_api_key),
 ):
-    """Start async IaC code generation. Returns 202 with job_id."""
+    """Start async IaC code generation. Returns 202 with job_id.
+
+    ``force=true`` overrides the architecture-blocker gate (Issue #610).
+    """
     if format not in ["terraform", "bicep", "cloudformation"]:
         raise ArchmorphException(400, "Format must be 'terraform', 'bicep', or 'cloudformation'")
+
+    session = SESSION_STORE.get(diagram_id, {})
+    _check_architecture_blockers(diagram_id, session, force)
 
     job = job_manager.submit("generate_iac", diagram_id=diagram_id)
     asyncio.create_task(_run_iac_job(job.job_id, diagram_id, format))

--- a/backend/tests/test_architecture_rules.py
+++ b/backend/tests/test_architecture_rules.py
@@ -1,0 +1,423 @@
+"""Tests for the architecture-limitations rule library (Issue #610)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure backend root is on sys.path so `architecture_rules` resolves.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from architecture_rules import (  # noqa: E402
+    ArchitectureIssue,
+    Severity,
+    evaluate,
+    has_blocker,
+    list_rules,
+    reload_rules,
+)
+from architecture_rules import predicates as preds  # noqa: E402
+from architecture_rules import engine as engine_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def empty_analysis():
+    return {"identified_services": [], "service_connections": []}
+
+
+@pytest.fixture
+def sftp_frontdoor_analysis():
+    """The user's motivating example.
+
+    SFTP client → Azure Front Door → Azure Storage (SFTP) over SFTP/SSH.
+    Front Door is HTTP/HTTPS-only, so this composition cannot work.
+    """
+    return {
+        "identified_services": [
+            {"name": "SFTP Client", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Azure Storage (SFTP)", "category": "Storage"},
+        ],
+        "service_connections": [
+            {"from": "SFTP Client", "to": "Azure Front Door", "type": "SFTP/SSH"},
+            {"from": "Azure Front Door", "to": "Azure Storage (SFTP)", "type": "SFTP"},
+        ],
+        "service_to_resource_mapping": [
+            {
+                "service": "Azure Front Door",
+                "resource_type": "Microsoft.Network/frontDoors",
+            },
+            {
+                "service": "Azure Storage (SFTP)",
+                "resource_type": "Microsoft.Storage/storageAccounts",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sane_web_analysis():
+    return {
+        "identified_services": [
+            {"name": "Browser", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Azure App Service", "category": "Compute"},
+        ],
+        "service_connections": [
+            {"from": "Browser", "to": "Azure Front Door", "type": "HTTPS"},
+            {"from": "Azure Front Door", "to": "Azure App Service", "type": "HTTPS"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestServiceHelpers:
+    def test_service_matches_handles_azure_prefix(self):
+        assert preds._service_matches("Azure Front Door", "front door")
+        assert preds._service_matches("front door", "Azure Front Door")
+
+    def test_service_matches_case_insensitive(self):
+        assert preds._service_matches("AZURE STORAGE", "azure storage")
+
+    def test_service_matches_dash_space(self):
+        assert preds._service_matches("front-door", "front door")
+
+    def test_service_matches_negative(self):
+        assert not preds._service_matches("Azure Storage", "Cosmos DB")
+
+    def test_services_in_analysis_collects_names(self, sftp_frontdoor_analysis):
+        names = preds._services_in_analysis(sftp_frontdoor_analysis)
+        assert any("Front Door" in n for n in names)
+        assert any("SFTP Client" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Path-protocol-mismatch predicate (the SFTP/Front Door scenario)
+# ---------------------------------------------------------------------------
+
+
+class TestPathProtocolMismatch:
+    def test_fires_on_sftp_via_front_door(self, sftp_frontdoor_analysis):
+        match = preds.path_uses_service_with_protocol_mismatch(
+            sftp_frontdoor_analysis,
+            via="Azure Front Door",
+            allowed_protocols=["http", "https"],
+            disallowed_hint=["sftp", "ssh"],
+        )
+        assert match is not None
+        assert any("Front Door" in s for s in match.affected_services)
+
+    def test_does_not_fire_on_pure_https(self, sane_web_analysis):
+        match = preds.path_uses_service_with_protocol_mismatch(
+            sane_web_analysis,
+            via="Azure Front Door",
+            allowed_protocols=["http", "https"],
+            disallowed_hint=["sftp", "ssh"],
+        )
+        assert match is None
+
+    def test_does_not_fire_when_via_absent(self, empty_analysis):
+        match = preds.path_uses_service_with_protocol_mismatch(
+            empty_analysis,
+            via="Azure Front Door",
+            allowed_protocols=["http", "https"],
+            disallowed_hint=["sftp"],
+        )
+        assert match is None
+
+
+# ---------------------------------------------------------------------------
+# Simple registered predicates
+# ---------------------------------------------------------------------------
+
+
+class TestSimplePredicates:
+    def test_service_present(self, sftp_frontdoor_analysis):
+        match = preds.service_present(sftp_frontdoor_analysis, name="Azure Front Door")
+        assert match is not None
+
+    def test_service_present_negative(self, empty_analysis):
+        match = preds.service_present(empty_analysis, name="Azure Front Door")
+        assert match is None
+
+    def test_service_pair_connected(self, sftp_frontdoor_analysis):
+        match = preds.service_pair_connected(
+            sftp_frontdoor_analysis, a="Azure Front Door", b="Azure Storage"
+        )
+        assert match is not None
+
+    def test_services_all_present_negative(self, sane_web_analysis):
+        match = preds.services_all_present(
+            sane_web_analysis, names=["Azure Front Door", "Cosmos DB"]
+        )
+        assert match is None
+
+    def test_connection_uses_protocol(self, sftp_frontdoor_analysis):
+        match = preds.connection_uses_protocol(
+            sftp_frontdoor_analysis, protocols=["sftp"]
+        )
+        assert match is not None
+
+    def test_get_predicate_unknown_returns_none(self):
+        assert preds.get_predicate("does-not-exist") is None
+
+    def test_register_predicate_dup_raises(self):
+        with pytest.raises(ValueError):
+
+            @preds.register_predicate("service_present")
+            def _dupe(*_a, **_kw):
+                return None
+
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLLoader:
+    def test_parse_minimal_yaml(self, tmp_path):
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text(
+            """
+rules:
+  - id: test-rule
+    title: Test rule
+    severity: warning
+    category: testing
+    message: Test message
+    remediation: Do nothing
+    docs_url: https://example.com
+    predicate: service_present
+    predicate_args:
+      name: Azure Front Door
+""".strip()
+        )
+        rules = engine_mod._load_rules_from_path(str(rules_yaml))
+        assert len(rules) == 1
+        rule = rules[0]
+        assert rule.id == "test-rule"
+        assert rule.severity == Severity.WARNING
+        assert rule.predicate == "service_present"
+
+    def test_invalid_severity_rejected(self, tmp_path):
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text(
+            """
+rules:
+  - id: test-rule
+    title: Test rule
+    severity: critical-meltdown
+    category: testing
+    message: msg
+    remediation: rem
+    docs_url: https://example.com
+    predicate: service_present
+""".strip()
+        )
+        with pytest.raises(ValueError, match="severity"):
+            engine_mod._load_rules_from_path(str(rules_yaml))
+
+    def test_missing_required_field_rejected(self, tmp_path):
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text(
+            """
+rules:
+  - severity: warning
+    category: testing
+    message: msg
+    remediation: rem
+    docs_url: https://example.com
+    predicate: service_present
+""".strip()
+        )
+        with pytest.raises(ValueError, match="id"):
+            engine_mod._load_rules_from_path(str(rules_yaml))
+
+    def test_unknown_predicate_rejected(self, tmp_path):
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text(
+            """
+rules:
+  - id: test-rule
+    title: Test rule
+    severity: warning
+    category: testing
+    message: msg
+    remediation: rem
+    docs_url: https://example.com
+    predicate: nonexistent_predicate
+""".strip()
+        )
+        with pytest.raises(ValueError, match="unknown predicate"):
+            engine_mod._load_rules_from_path(str(rules_yaml))
+
+    def test_duplicate_id_rejected(self, tmp_path):
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text(
+            """
+rules:
+  - id: dup
+    title: A
+    severity: info
+    category: testing
+    message: m
+    remediation: r
+    docs_url: https://example.com
+    predicate: service_present
+    predicate_args:
+      name: Foo
+  - id: dup
+    title: B
+    severity: info
+    category: testing
+    message: m
+    remediation: r
+    docs_url: https://example.com
+    predicate: service_present
+    predicate_args:
+      name: Bar
+""".strip()
+        )
+        with pytest.raises(ValueError, match="duplicate"):
+            engine_mod._load_rules_from_path(str(rules_yaml))
+
+
+class TestYAMLLoaderFromDisk:
+    def test_default_rules_load(self):
+        rules = list_rules()
+        assert len(rules) >= 25
+
+    def test_default_rules_have_unique_ids(self):
+        rules = list_rules()
+        ids = [r.id for r in rules]
+        assert len(ids) == len(set(ids)), "duplicate rule IDs detected"
+
+    def test_default_rules_reference_known_predicates(self):
+        rules = list_rules()
+        for r in rules:
+            assert preds.get_predicate(r.predicate) is not None, (
+                f"rule {r.id} references unknown predicate {r.predicate}"
+            )
+
+    def test_default_rules_have_docs_url(self):
+        rules = list_rules()
+        for r in rules:
+            assert r.docs_url.startswith("http"), f"{r.id} missing docs_url"
+
+
+# ---------------------------------------------------------------------------
+# Engine end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestEngineEndToEnd:
+    def test_evaluate_returns_list(self, empty_analysis):
+        issues = evaluate(empty_analysis)
+        assert isinstance(issues, list)
+
+    def test_evaluate_issue_shape(self, sftp_frontdoor_analysis):
+        issues = evaluate(sftp_frontdoor_analysis)
+        assert len(issues) >= 1
+        issue = issues[0]
+        assert isinstance(issue, ArchitectureIssue)
+        d = issue.to_dict()
+        for key in (
+            "rule_id",
+            "severity",
+            "category",
+            "title",
+            "message",
+            "remediation",
+            "docs_url",
+            "affected_services",
+            "source",
+        ):
+            assert key in d
+
+    def test_has_blocker_helper(self, sftp_frontdoor_analysis):
+        issues = evaluate(sftp_frontdoor_analysis)
+        assert has_blocker(issues) is True
+
+    def test_no_blockers_on_sane_arch(self, sane_web_analysis):
+        issues = evaluate(sane_web_analysis)
+        # warnings/info ok, but no BLOCKERs
+        blockers = [i for i in issues if i.severity == Severity.BLOCKER]
+        assert blockers == []
+
+    def test_evaluate_sorted_by_severity(self, sftp_frontdoor_analysis):
+        issues = evaluate(sftp_frontdoor_analysis)
+        ranks = [
+            {Severity.BLOCKER: 3, Severity.WARNING: 2, Severity.INFO: 1}[i.severity]
+            for i in issues
+        ]
+        assert ranks == sorted(ranks, reverse=True)
+
+    def test_evaluate_handles_non_dict_input(self):
+        assert evaluate(None) == []  # type: ignore[arg-type]
+        assert evaluate("not a dict") == []  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Golden scenarios — the user's headline example
+# ---------------------------------------------------------------------------
+
+
+class TestGoldenScenarios:
+    def test_sftp_via_front_door_fires_blocker(self, sftp_frontdoor_analysis):
+        issues = evaluate(sftp_frontdoor_analysis)
+        blocker_ids = {i.rule_id for i in issues if i.severity == Severity.BLOCKER}
+        # Either the dedicated SFTP-specific rule or the generic Front Door
+        # protocol rule is acceptable; ideally both fire.
+        assert blocker_ids & {
+            "front-door-sftp-storage-blocker",
+            "front-door-protocol-mismatch",
+        }, (
+            f"Expected SFTP/FrontDoor blocker rule to fire. Got: {blocker_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# YAML override path
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLOverride:
+    def test_env_override(self, tmp_path, monkeypatch):
+        custom = tmp_path / "custom.yaml"
+        custom.write_text(
+            """
+rules:
+  - id: custom-only-rule
+    title: Custom rule
+    severity: info
+    category: testing
+    message: msg
+    remediation: rem
+    docs_url: https://example.com
+    predicate: service_present
+    predicate_args:
+      name: Azure Front Door
+""".strip()
+        )
+        monkeypatch.setenv("ARCHMORPH_ARCH_RULES_PATH", str(custom))
+        try:
+            reload_rules()
+            rules = list_rules()
+            assert len(rules) == 1
+            assert rules[0].id == "custom-only-rule"
+        finally:
+            monkeypatch.delenv("ARCHMORPH_ARCH_RULES_PATH", raising=False)
+            reload_rules()

--- a/backend/tests/test_iac_blocker_gate.py
+++ b/backend/tests/test_iac_blocker_gate.py
@@ -1,0 +1,200 @@
+"""Tests for the IaC architecture-blocker gate (Issue #610)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure backend root is on sys.path.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from main import app  # noqa: E402
+from routers.shared import SESSION_STORE  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _put_session_with_blocker(diagram_id: str) -> None:
+    SESSION_STORE.set(
+        diagram_id,
+        {
+            "diagram_id": diagram_id,
+            "identified_services": [
+                {"name": "Azure Front Door"},
+                {"name": "Azure Storage (SFTP)"},
+            ],
+            "service_connections": [
+                {"from": "Azure Front Door", "to": "Azure Storage (SFTP)", "type": "SFTP"}
+            ],
+            "architecture_issues": [
+                {
+                    "rule_id": "front-door-sftp-storage-blocker",
+                    "severity": "blocker",
+                    "category": "protocol",
+                    "title": "Front Door cannot front SFTP storage",
+                    "message": "Front Door is HTTP/HTTPS-only.",
+                    "remediation": "Use Public IP or VNet-integrated path.",
+                    "docs_url": "https://learn.microsoft.com/azure/frontdoor/",
+                    "affected_services": ["Azure Front Door", "Azure Storage (SFTP)"],
+                    "source": "curated",
+                }
+            ],
+            "architecture_issues_summary": {
+                "blocker": 1,
+                "warning": 0,
+                "info": 0,
+                "total": 1,
+            },
+        },
+    )
+
+
+def _put_session_without_blockers(diagram_id: str) -> None:
+    SESSION_STORE.set(
+        diagram_id,
+        {
+            "diagram_id": diagram_id,
+            "identified_services": [{"name": "Azure App Service"}],
+            "service_connections": [],
+            "architecture_issues": [
+                {
+                    "rule_id": "info-rule",
+                    "severity": "info",
+                    "category": "tier-feature",
+                    "title": "Just FYI",
+                    "message": "An info note.",
+                    "remediation": "n/a",
+                    "docs_url": "https://learn.microsoft.com/",
+                    "affected_services": [],
+                    "source": "curated",
+                }
+            ],
+            "architecture_issues_summary": {
+                "blocker": 0,
+                "warning": 0,
+                "info": 1,
+                "total": 1,
+            },
+        },
+    )
+
+
+def _put_session_with_warning_only(diagram_id: str) -> None:
+    SESSION_STORE.set(
+        diagram_id,
+        {
+            "diagram_id": diagram_id,
+            "identified_services": [{"name": "Azure App Service"}],
+            "service_connections": [],
+            "architecture_issues": [
+                {
+                    "rule_id": "warn-rule",
+                    "severity": "warning",
+                    "category": "network-topology",
+                    "title": "warn",
+                    "message": "warning msg",
+                    "remediation": "n/a",
+                    "docs_url": "https://learn.microsoft.com/",
+                    "affected_services": [],
+                    "source": "curated",
+                }
+            ],
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_session():
+    seeded: list[str] = []
+    yield seeded
+    for did in seeded:
+        try:
+            SESSION_STORE.delete(did)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Sync endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestIaCGateSync:
+    def test_blocker_refuses_generation(self, client, _cleanup_session):
+        diagram_id = "test-blocker-refuses"
+        _put_session_with_blocker(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=terraform")
+        assert resp.status_code == 409, resp.text
+        # Just make sure the rule id appears in the response body somewhere.
+        assert "front-door-sftp-storage-blocker" in resp.text
+
+    def test_force_true_bypasses_gate(self, client, _cleanup_session):
+        diagram_id = "test-force-bypasses"
+        _put_session_with_blocker(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        with patch("routers.iac_routes.generate_iac_code", return_value="# stubbed\n"):
+            resp = client.post(
+                f"/api/diagrams/{diagram_id}/generate?format=terraform&force=true"
+            )
+        assert resp.status_code == 200, resp.text
+        assert "stubbed" in resp.json().get("code", "")
+
+    def test_no_blockers_passes_through(self, client, _cleanup_session):
+        diagram_id = "test-no-blockers"
+        _put_session_without_blockers(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        with patch("routers.iac_routes.generate_iac_code", return_value="# ok\n"):
+            resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=terraform")
+        assert resp.status_code == 200, resp.text
+
+    def test_warning_severity_does_not_gate(self, client, _cleanup_session):
+        diagram_id = "test-warning-only"
+        _put_session_with_warning_only(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        with patch("routers.iac_routes.generate_iac_code", return_value="# ok\n"):
+            resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=terraform")
+        assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Async endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestIaCGateAsync:
+    def test_async_blocker_refuses_generation(self, client, _cleanup_session):
+        diagram_id = "test-async-blocker"
+        _put_session_with_blocker(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        resp = client.post(
+            f"/api/diagrams/{diagram_id}/generate-async?format=terraform"
+        )
+        assert resp.status_code == 409, resp.text
+
+    def test_async_force_true_bypasses_gate(self, client, _cleanup_session):
+        diagram_id = "test-async-force"
+        _put_session_with_blocker(diagram_id)
+        _cleanup_session.append(diagram_id)
+
+        resp = client.post(
+            f"/api/diagrams/{diagram_id}/generate-async?format=terraform&force=true"
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body.get("status") == "queued"
+        assert body.get("job_id")

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -1,0 +1,90 @@
+# Architecture Limitations Engine
+
+> Status: Phase 1 (curated rules + IaC blocker gate) — [#610](https://github.com/idokatz86/Archmorph/issues/610)
+
+## Why this exists
+
+Archmorph turns natural-language descriptions and screenshots into Azure architectures, then generates IaC. Without guardrails the LLM happily produces compositions that look reasonable on paper but cannot work in Azure. The motivating example: an SFTP client connecting to Azure Storage's SFTP endpoint **through Azure Front Door**. Front Door is an HTTP/HTTPS Layer-7 reverse proxy — it does not speak SSH. The architecture diagram looks fine; the generated Terraform will deploy cleanly; the runtime traffic will never connect.
+
+The architecture limitations engine catches these cases deterministically before IaC generation, with curated rules grounded in Microsoft Learn documentation.
+
+## How it works
+
+```
+analysis_result (services + connections + mappings)
+    ↓
+architecture_rules.evaluate()
+    ↓
+for each rule: run predicate(analysis, **predicate_args)
+    ↓
+collect ArchitectureIssue list (sorted by severity desc)
+    ↓
+attach to analysis as `architecture_issues[]` + summary
+    ↓
+on POST /generate: if any severity == "blocker" → 409 unless ?force=true
+```
+
+## Components
+
+| File | Purpose |
+| --- | --- |
+| [backend/architecture_rules/models.py](../backend/architecture_rules/models.py) | `Severity`, `Rule`, `ArchitectureIssue` dataclasses. |
+| [backend/architecture_rules/predicates.py](../backend/architecture_rules/predicates.py) | 8 reusable predicates + decorator-based registry. |
+| [backend/architecture_rules/engine.py](../backend/architecture_rules/engine.py) | YAML loader, schema validation, lazy thread-safe singleton, `evaluate()`. |
+| [backend/data/architecture_rules.yaml](../backend/data/architecture_rules.yaml) | 25 curated rules. |
+| [backend/routers/diagrams.py](../backend/routers/diagrams.py) | Wires `evaluate()` into the analysis enrichment pipeline. |
+| [backend/routers/iac_routes.py](../backend/routers/iac_routes.py) | 409 gate on blockers; `?force=true` override. |
+| [backend/tests/test_architecture_rules.py](../backend/tests/test_architecture_rules.py) | Engine + golden scenario tests. |
+| [backend/tests/test_iac_blocker_gate.py](../backend/tests/test_iac_blocker_gate.py) | IaC gate behaviour tests. |
+
+## Rule schema
+
+```yaml
+- id: front-door-sftp-storage-blocker          # unique, kebab-case
+  title: Front Door cannot proxy SFTP to Azure Storage
+  severity: blocker                              # blocker | warning | info
+  category: protocol                             # for grouping in UI
+  message: >
+    Azure Front Door is HTTP/HTTPS-only and cannot tunnel SSH/SFTP traffic.
+  remediation: >
+    Connect SFTP clients directly to the storage account's SFTP endpoint,
+    or front it with an Azure Load Balancer / NVA that forwards TCP port 22.
+  docs_url: https://learn.microsoft.com/azure/frontdoor/front-door-overview
+  predicate: path_uses_service_with_protocol_mismatch
+  predicate_args:
+    via: Azure Front Door
+    allowed_protocols: [http, https]
+    disallowed_hint: [sftp, ssh]
+  references:
+    - https://learn.microsoft.com/azure/storage/blobs/secure-file-transfer-protocol-support
+  tags: [front-door, sftp, storage]
+```
+
+## Severity semantics
+
+| Severity | Meaning | Behaviour |
+| --- | --- | --- |
+| `blocker` | The composition cannot work as drawn. Generated IaC will deploy but runtime traffic will fail. | `POST /generate` → 409 unless `?force=true`. |
+| `warning` | Works in some configurations but has a known gap (non-transitive peering, region-feature mismatch, ungoverned dead-lettering). | Surfaced in UI, does not block IaC. |
+| `info` | Best-practice nudge or tier prerequisite reminder (storage SFTP requires hierarchical namespace, Cosmos free tier is one-per-subscription, etc.). | Surfaced in UI for awareness. |
+
+## Adding a rule
+
+1. Pick or write a predicate in [predicates.py](../backend/architecture_rules/predicates.py). Reuse existing ones where possible — most architecture limits boil down to "service present", "service pair connected", or "path via X uses protocol Y".
+2. Add a YAML entry in [architecture_rules.yaml](../backend/data/architecture_rules.yaml).
+3. Add a golden test in [test_architecture_rules.py](../backend/tests/test_architecture_rules.py) that exercises a positive **and** a negative case (over-firing on sane architectures is a worse failure mode than under-firing).
+4. Confirm `python -m pytest tests/test_architecture_rules.py` passes.
+
+## Override path
+
+`ARCHMORPH_ARCH_RULES_PATH=/path/to/custom.yaml` replaces the default rule set entirely (used in tests and to A/B different rule libraries in dev).
+
+## Phase roadmap
+
+| Phase | Scope |
+| --- | --- |
+| 1 (this PR) | Curated YAML rules + Python predicates + IaC blocker gate. |
+| 2 | GPT-4o fallback when no curated rule fires — review queue for human approval. |
+| 3 | Admin UI to approve / reject AI-suggested rules into the curated library. |
+| 4 | Frontend "Architecture Health" panel surfacing blockers/warnings/info inline. |
+| 5 | Backfill curated library from 25 to 60-100 rules across the long tail. |

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -1,6 +1,6 @@
 # Architecture Limitations Engine
 
-> Status: Phase 1 (curated rules + IaC blocker gate) — [#610](https://github.com/idokatz86/Archmorph/issues/610)
+> Status: Phase 1 (curated rules + IaC blocker gate) — landed in PR [#615](https://github.com/idokatz86/Archmorph/pull/615). Subsequent phases tracked at [#616](https://github.com/idokatz86/Archmorph/issues/616) (AI fallback), [#617](https://github.com/idokatz86/Archmorph/issues/617) (admin review queue), [#618](https://github.com/idokatz86/Archmorph/issues/618) (frontend panel), [#619](https://github.com/idokatz86/Archmorph/issues/619) (rule-library expansion).
 
 ## Why this exists
 


### PR DESCRIPTION
## Summary

Closes the highest-impact correctness gap in Archmorph's IaC pipeline: structurally invalid Azure compositions sliding through analysis into deployable-but-broken Terraform.

The motivating example (from the issue): an SFTP client → **Azure Front Door** → Azure Storage SFTP endpoint. Front Door is an HTTP/HTTPS Layer-7 reverse proxy — it cannot tunnel SSH/port-22 traffic. The diagram looks fine, the Terraform deploys cleanly, and the runtime traffic never connects. There are dozens of variants of this class of problem across networking, protocol, region, identity, and tier-feature axes.

This PR ships **Phase 1**: a deterministic, YAML-driven rule engine with 25 curated rules and an IaC blocker gate.

## What's included

### New module: `backend/architecture_rules/`

| File | Lines | Purpose |
| --- | --- | --- |
| `models.py` | 90 | `Severity` (blocker/warning/info), `Rule`, `ArchitectureIssue` dataclasses |
| `predicates.py` | 388 | 8 reusable predicates + decorator-based registry |
| `engine.py` | ~240 | YAML loader with schema validation, lazy thread-safe singleton, `evaluate()` |
| `__init__.py` | 26 | Public API |

### Curated rule library: `backend/data/architecture_rules.yaml`

25 rules across 7 categories, all citing Microsoft Learn:

- **Protocol** — Front Door / App Gateway L7-only, Load Balancer L4-only, Front Door + SFTP storage (the issue's example)
- **Network topology** — VNet peering non-transitivity, APIM/Functions Consumption tier VNet limits, Container Apps VNet workload profile
- **SKU prerequisite** — Storage SFTP requires HNS, Front Door + Private Link requires Premium, App Service slots tier
- **Identity / auth** — Storage account-key vs RBAC, Cosmos MI data-plane, Key Vault RBAC vs policy
- **Data plane** — Service Bus message size, queue vs Service Bus, Event Grid without dead-letter
- **Region** — OpenAI region availability, confidential compute regions, Azure Government feature gaps
- **Tier feature** — SQL serverless no read replicas, Front Door custom domain certs, Functions private endpoint tier, Service Bus sessions tier

### Pipeline integration

- `routers/diagrams.py` — analysis enrichment now appends `architecture_issues[]` and `architecture_issues_summary{blocker, warning, info, total}`
- `routers/iac_routes.py` — `POST /api/diagrams/{id}/generate(-async)` returns **409** when blockers exist; pass `?force=true` to override (logged via `iac_blockers_overridden` event)

### Tests

- `tests/test_architecture_rules.py` — 32 tests: predicate behaviour, YAML schema validation (severity, missing fields, unknown predicate, duplicate id), engine end-to-end (sort order, non-dict input, has_blocker), golden scenarios (the SFTP+FrontDoor case), env-override path
- `tests/test_iac_blocker_gate.py` — 6 tests: sync + async endpoints × (blocker refuses / force bypasses / no blockers / warning doesn't gate)

**Result:** 47/47 pass, ruff clean.

### Docs

- `README.md` — new "Architecture Limitations Engine" section
- `docs/ARCHITECTURE_RULES.md` — full design + extensibility guide
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Added`

### Dependency

- `backend/requirements.txt` — `PyYAML>=6.0.2`

## How to extend

1. Add a predicate in `predicates.py` (or reuse one of the 8).
2. Add a YAML entry in `architecture_rules.yaml` with severity, message, remediation, docs_url, predicate, predicate_args.
3. Add a golden test (positive AND negative case — over-firing on sane architectures is worse than under-firing).
4. `pytest tests/test_architecture_rules.py`.

## Phase roadmap

| Phase | Scope | Status |
| --- | --- | --- |
| 1 | Curated YAML rules + IaC blocker gate | **this PR** |
| 2 | GPT-4o fallback when no curated rule fires | [#616](https://github.com/idokatz86/Archmorph/issues/616) |
| 3 | Admin review queue for AI-suggested rules | [#617](https://github.com/idokatz86/Archmorph/issues/617) |
| 4 | Frontend "Architecture Health" panel | [#618](https://github.com/idokatz86/Archmorph/issues/618) |
| 5 | Backfill curated library to 60-100 rules | [#619](https://github.com/idokatz86/Archmorph/issues/619) |

Refs #610
