### PR TITLE
fix(iac-chat): coerce changes/services items to strings (React error #31)

### DIFF
--- a/backend/iac_chat.py
+++ b/backend/iac_chat.py
@@ -82,6 +82,40 @@ ALWAYS respond with a JSON object containing exactly these fields:
 IAC_CHAT_SESSIONS: TTLCache = TTLCache(maxsize=200, ttl=7200)
 
 
+def _coerce_to_str_list(items: Any) -> List[str]:
+    """Coerce ``changes_summary`` / ``services_added`` to a flat list of strings.
+
+    The system prompt asks GPT for string arrays, but the model occasionally
+    returns objects (e.g. ``{"type": "add", "message": "Added VNet"}``).
+    The frontend renders these items directly in JSX, so non-string values
+    crash React with error #31 ("Objects are not valid as a React child").
+    Normalize at the API boundary so the contract is honoured regardless of
+    model behaviour.
+    """
+    if not isinstance(items, list):
+        return []
+    out: List[str] = []
+    for item in items:
+        if item is None:
+            continue
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, (int, float, bool)):
+            out.append(str(item))
+        elif isinstance(item, dict):
+            for key in ("message", "text", "name", "label", "value", "description"):
+                val = item.get(key)
+                if isinstance(val, str) and val:
+                    out.append(val)
+                    break
+            else:
+                # Last resort — serialize so the frontend never sees an object.
+                out.append(json.dumps(item, ensure_ascii=False))
+        else:
+            out.append(str(item))
+    return out
+
+
 def process_iac_chat(
     diagram_id: str,
     message: str,
@@ -222,8 +256,8 @@ def process_iac_chat(
                 code = re.sub(r"\n```$", "", code)
                 code = code.strip()
 
-        changes = result.get("changes_summary", [])
-        services = result.get("services_added", [])
+        changes = _coerce_to_str_list(result.get("changes_summary", []))
+        services = _coerce_to_str_list(result.get("services_added", []))
 
     except json.JSONDecodeError as exc:
         logger.error("Failed to parse IaC chat JSON: %s\nText snippet: %s", exc, raw_text[-500:])

--- a/backend/tests/test_iac_chat.py
+++ b/backend/tests/test_iac_chat.py
@@ -318,3 +318,80 @@ class TestIacChatEndpoints:
         resp = client.delete("/api/diagrams/nonexistent-diagram/iac-chat")
         assert resp.status_code == 200
         assert resp.json()["cleared"] is False
+
+
+# ====================================================================
+# 4. Defensive coercion of changes_summary / services_added
+#    (Regression for React error #31 on {type, message} objects)
+# ====================================================================
+
+from iac_chat import _coerce_to_str_list
+
+
+class TestCoerceToStrList:
+    def test_strings_pass_through(self):
+        assert _coerce_to_str_list(["a", "b"]) == ["a", "b"]
+
+    def test_dict_with_message_key(self):
+        # The exact shape that triggered React error #31 in production.
+        out = _coerce_to_str_list([{"type": "add", "message": "Added VNet"}])
+        assert out == ["Added VNet"]
+
+    def test_dict_with_text_or_name_or_label_or_value(self):
+        assert _coerce_to_str_list([{"text": "x"}]) == ["x"]
+        assert _coerce_to_str_list([{"name": "Azure SQL"}]) == ["Azure SQL"]
+        assert _coerce_to_str_list([{"label": "lbl"}]) == ["lbl"]
+        assert _coerce_to_str_list([{"value": "v"}]) == ["v"]
+
+    def test_dict_with_no_known_key_serializes(self):
+        out = _coerce_to_str_list([{"foo": "bar"}])
+        assert out == ['{"foo": "bar"}']
+
+    def test_drops_none_keeps_falsy_strings(self):
+        assert _coerce_to_str_list([None, "", "x"]) == ["", "x"]
+
+    def test_non_list_input_returns_empty(self):
+        assert _coerce_to_str_list(None) == []
+        assert _coerce_to_str_list("not a list") == []
+        assert _coerce_to_str_list({"k": "v"}) == []
+
+    def test_numbers_and_bools_coerced(self):
+        assert _coerce_to_str_list([1, 2.5, True, False]) == ["1", "2.5", "True", "False"]
+
+    def test_nested_lists_stringified(self):
+        out = _coerce_to_str_list([["nested"]])
+        assert isinstance(out[0], str)
+
+    @patch("iac_chat.cached_chat_completion")
+    def test_process_iac_chat_normalizes_object_items(self, mock_completion):
+        # Simulate a misbehaving model returning {type, message} objects.
+        bad_response = {
+            "message": "Updated.",
+            "code": SAMPLE_TF_CODE,
+            "changes_summary": [
+                {"type": "add", "message": "Added VNet"},
+                {"type": "modify", "message": "Resized subnet"},
+                "plain string",
+            ],
+            "services_added": [{"name": "VNet"}, {"name": "NSG"}],
+        }
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(bad_response)
+        mock_response.choices[0].finish_reason = "stop"
+        mock_completion.return_value = mock_response
+
+        result = process_iac_chat(
+            diagram_id="coerce-test",
+            message="Add a VNet",
+            current_code=SAMPLE_TF_CODE,
+            iac_format="terraform",
+        )
+
+        assert result["error"] is False
+        # Every item must be a string (renderable in JSX without crashing React).
+        assert all(isinstance(c, str) for c in result["changes_summary"])
+        assert all(isinstance(s, str) for s in result["services_added"])
+        assert result["changes_summary"] == ["Added VNet", "Resized subnet", "plain string"]
+        assert result["services_added"] == ["VNet", "NSG"]
+

--- a/frontend/src/components/DiagramTranslator/IaCViewer.jsx
+++ b/frontend/src/components/DiagramTranslator/IaCViewer.jsx
@@ -8,6 +8,30 @@ import {
 import { Button, Card } from '../ui';
 import { ContextualHint } from '../OnboardingTour';
 
+// Coerce arbitrary chat-API list items to a renderable string. The backend's
+// JSON-mode prompt asks GPT for string arrays in `changes_summary` /
+// `services_added`, but the model occasionally returns objects (e.g. `{type,
+// message}`) which would otherwise crash React with error #31.
+// Key set mirrors `_coerce_to_str_list()` in backend/iac_chat.py — keep in sync.
+const toRenderableString = (item) => {
+  if (item == null) return '';
+  if (typeof item === 'string') return item;
+  if (typeof item === 'number' || typeof item === 'boolean') return String(item);
+  if (Array.isArray(item)) return item.map(toRenderableString).filter(Boolean).join(', ');
+  if (typeof item === 'object') {
+    for (const key of ['message', 'text', 'name', 'label', 'value', 'description']) {
+      const val = item[key];
+      if (typeof val === 'string' && val) return val;
+    }
+    try {
+      return JSON.stringify(item);
+    } catch {
+      return String(item);
+    }
+  }
+  return String(item);
+};
+
 const QUICK_ACTIONS = [
   { label: 'Add VNet & Subnets', msg: 'Add a Virtual Network with 3 subnets: frontend (10.0.1.0/24), backend (10.0.2.0/24), and data (10.0.3.0/24). Include NSGs for each subnet with appropriate rules.' },
   { label: 'Add Public IPs', msg: 'Add public IP addresses for the load balancer and application gateway. Use Standard SKU with static allocation.' },
@@ -185,7 +209,7 @@ export default function IaCViewer({
                         </p>
                         <ul className="space-y-0.5">
                           {msg.changes.map((c, ci) => (
-                            <li key={ci} className="text-[10px] text-text-muted flex items-start gap-1"><span className="text-cta mt-0.5">+</span> {c}</li>
+                            <li key={ci} className="text-[10px] text-text-muted flex items-start gap-1"><span className="text-cta mt-0.5">+</span> {toRenderableString(c)}</li>
                           ))}
                         </ul>
                       </div>
@@ -193,7 +217,7 @@ export default function IaCViewer({
                     {msg.services && msg.services.length > 0 && (
                       <div className="mt-1.5 flex flex-wrap gap-1">
                         {msg.services.map((s, si) => (
-                          <span key={si} className="inline-flex items-center px-1.5 py-0.5 text-[9px] font-medium rounded bg-cta/10 text-cta border border-cta/20">{s}</span>
+                          <span key={si} className="inline-flex items-center px-1.5 py-0.5 text-[9px] font-medium rounded bg-cta/10 text-cta border border-cta/20">{toRenderableString(s)}</span>
                         ))}
                       </div>
                     )}

--- a/frontend/src/components/DiagramTranslator/__tests__/IaCViewer.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/IaCViewer.test.jsx
@@ -94,4 +94,34 @@ describe('IaCViewer', () => {
     render(<IaCViewer {...defaultProps} iacChatOpen={true} />)
     expect(screen.getByText('Hello')).toBeInTheDocument()
   })
+
+  // Regression: React error #31 — backend chat handler occasionally returns
+  // changes/services as objects (e.g. {type, message}) instead of strings.
+  // Rendering them directly would crash with "Objects are not valid as a
+  // React child". The component must coerce safely.
+  it('renders changes/services even when items are objects (React #31 guard)', () => {
+    const messageWithObjects = {
+      role: 'assistant',
+      content: 'Updated.',
+      changes: [
+        { type: 'add', message: 'Added VNet' },
+        'plain string',
+        { name: 'Subnet' },
+      ],
+      services: [{ message: 'Azure VNet' }, 'NSG'],
+    }
+    render(
+      <IaCViewer
+        {...defaultProps}
+        iacChatOpen={true}
+        iacChatMessages={[messageWithObjects]}
+      />
+    )
+    // No crash + the extracted strings are visible.
+    expect(screen.getByText('Added VNet')).toBeInTheDocument()
+    expect(screen.getByText('plain string')).toBeInTheDocument()
+    expect(screen.getByText('Subnet')).toBeInTheDocument()
+    expect(screen.getByText('Azure VNet')).toBeInTheDocument()
+    expect(screen.getByText('NSG')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a production React error #31 (`Objects are not valid as a React child`) crashing the IaC Chat panel after the assistant responds.

## Root cause

The backend [`iac_chat.py`](backend/iac_chat.py) returns `changes_summary` and `services_added` from the model's JSON response without normalising the shape. The system prompt asks GPT-4o for **string arrays**, but the model occasionally returns **objects** like `{"type": "add", "message": "Added VNet"}`. The frontend [`IaCViewer.jsx`](frontend/src/components/DiagramTranslator/IaCViewer.jsx) then renders those items directly inside JSX (`<li>… {c}</li>` / `<span>{s}</span>`), which crashes React with error #31.

```
Error: Minified React error #31; visit https://react.dev/errors/31?args[]=object%20with%20keys%20%7Btype%2C%20message%7D
```

## Fix (defence in depth)

**Backend** — `iac_chat.py`:
- New `_coerce_to_str_list()` that maps objects via known string keys (`message`/`text`/`name`/`label`/`value`/`description`) with `json.dumps()` fallback.
- Applied to both `changes_summary` and `services_added` at the response boundary so the contract holds regardless of model output.

**Frontend** — `IaCViewer.jsx`:
- `toRenderableString()` helper extracts the same key set client-side.
- Wraps the two JSX call sites where objects could leak through legacy in-memory chat history.

## Tests

| Layer | New tests | Result |
|---|---|---|
| Backend | `TestCoerceToStrList` (9 tests) — strings/dicts/numbers/bools/None/nested + an integration test that mocks the model returning `{type, message}` objects and asserts the response contains only strings. | `25/25 passing` |
| Frontend | `IaCViewer › renders changes/services even when items are objects (React #31 guard)` — feeds mixed object+string items into the component and asserts no crash + extracted strings render. | `12/12 passing` |

## Risk

- **Local-only changes.** No DB, IaC, or contract surface changes.
- Output is normalised to a stricter contract. Frontend code paths consuming `changes_summary` / `services_added` only ever expected strings — they get the previously-promised type now.
- Empty/None items are dropped (was: rendered as crashed component); falsy strings (`""`) preserved.

## Manual repro path (post-merge)

Open the IaC Assistant chat → ask `"Add a Virtual Network with 3 subnets"` → assistant response no longer crashes the panel even when the model returns object-shaped change items.
