### PR TITLE
fix(migration-chat): coerce related_services items to strings (React error #31)

### DIFF
--- a/backend/iac_chat.py
+++ b/backend/iac_chat.py
@@ -82,38 +82,12 @@ ALWAYS respond with a JSON object containing exactly these fields:
 IAC_CHAT_SESSIONS: TTLCache = TTLCache(maxsize=200, ttl=7200)
 
 
-def _coerce_to_str_list(items: Any) -> List[str]:
-    """Coerce ``changes_summary`` / ``services_added`` to a flat list of strings.
-
-    The system prompt asks GPT for string arrays, but the model occasionally
-    returns objects (e.g. ``{"type": "add", "message": "Added VNet"}``).
-    The frontend renders these items directly in JSX, so non-string values
-    crash React with error #31 ("Objects are not valid as a React child").
-    Normalize at the API boundary so the contract is honoured regardless of
-    model behaviour.
-    """
-    if not isinstance(items, list):
-        return []
-    out: List[str] = []
-    for item in items:
-        if item is None:
-            continue
-        if isinstance(item, str):
-            out.append(item)
-        elif isinstance(item, (int, float, bool)):
-            out.append(str(item))
-        elif isinstance(item, dict):
-            for key in ("message", "text", "name", "label", "value", "description"):
-                val = item.get(key)
-                if isinstance(val, str) and val:
-                    out.append(val)
-                    break
-            else:
-                # Last resort — serialize so the frontend never sees an object.
-                out.append(json.dumps(item, ensure_ascii=False))
-        else:
-            out.append(str(item))
-    return out
+# Coercion of GPT JSON-mode arrays to flat string lists. The shared
+# implementation lives in ``utils.chat_coercion`` so other chat routers
+# (e.g. ``/migration-chat``) can reuse the same defence without coupling
+# to this module's internals. The private alias is kept for backward
+# compatibility with existing imports/tests.
+from utils.chat_coercion import coerce_to_str_list as _coerce_to_str_list  # noqa: E402,F401
 
 
 def process_iac_chat(

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -23,6 +23,7 @@ from services.azure_pricing import estimate_services_cost
 from terraform_preview import preview_terraform_plan
 from migration_risk import compute_risk_score
 from compliance_mapper import assess_compliance
+from iac_chat import _coerce_to_str_list
 from iac_generator import generate_iac_code
 
 logger = logging.getLogger(__name__)
@@ -451,7 +452,11 @@ Diagram type: {analysis.get('diagram_type', 'unknown')}"""
         result = _json.loads(raw)
         return {
             "reply": result.get("reply", "I couldn't generate a response. Please try rephrasing."),
-            "related_services": result.get("related_services", []),
+            # Coerce to strings — GPT JSON mode occasionally returns objects
+            # (e.g. {type, message}) instead of strings; rendering those
+            # directly in JSX crashes React with error #31. Mirror the
+            # iac-chat fix (#623) at the API boundary.
+            "related_services": _coerce_to_str_list(result.get("related_services", [])),
         }
     except Exception as exc:
         logger.error("Migration chat failed: %s", str(exc).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -23,7 +23,7 @@ from services.azure_pricing import estimate_services_cost
 from terraform_preview import preview_terraform_plan
 from migration_risk import compute_risk_score
 from compliance_mapper import assess_compliance
-from iac_chat import _coerce_to_str_list
+from utils.chat_coercion import coerce_to_str_list
 from iac_generator import generate_iac_code
 
 logger = logging.getLogger(__name__)
@@ -456,7 +456,7 @@ Diagram type: {analysis.get('diagram_type', 'unknown')}"""
             # (e.g. {type, message}) instead of strings; rendering those
             # directly in JSX crashes React with error #31. Mirror the
             # iac-chat fix (#623) at the API boundary.
-            "related_services": _coerce_to_str_list(result.get("related_services", [])),
+            "related_services": coerce_to_str_list(result.get("related_services", [])),
         }
     except Exception as exc:
         logger.error("Migration chat failed: %s", str(exc).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom

--- a/backend/tests/test_migration_chat_coercion.py
+++ b/backend/tests/test_migration_chat_coercion.py
@@ -29,11 +29,12 @@ def analyzed_diagram(client):
     IMAGE_STORE.clear()
 
     content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-    resp = client.post(
+    upload_resp = client.post(
         "/api/projects/proj-mchat/diagrams",
         files={"file": ("arch.png", io.BytesIO(content), "image/png")},
     )
-    diagram_id = resp.json()["diagram_id"]
+    assert upload_resp.status_code == 200, upload_resp.text
+    diagram_id = upload_resp.json()["diagram_id"]
 
     mock_analysis = {
         "diagram_type": "Test", "source_provider": "aws", "target_provider": "azure",
@@ -47,7 +48,8 @@ def analyzed_diagram(client):
         "confidence_summary": {"high": 1, "medium": 0, "low": 0, "average": 0.9},
     }
     with patch("routers.diagrams.analyze_image", return_value=mock_analysis):
-        client.post(f"/api/diagrams/{diagram_id}/analyze")
+        analyze_resp = client.post(f"/api/diagrams/{diagram_id}/analyze")
+    assert analyze_resp.status_code == 200, analyze_resp.text
 
     yield diagram_id
     SESSION_STORE.clear()

--- a/backend/tests/test_migration_chat_coercion.py
+++ b/backend/tests/test_migration_chat_coercion.py
@@ -1,0 +1,115 @@
+"""Regression test for React error #31 on the migration-chat endpoint.
+
+Mirrors the iac-chat fix (#623). When the LLM returns ``related_services``
+as objects (e.g. ``[{"type": "azure", "message": "Azure SQL"}]``) instead
+of strings, the API boundary must flatten them to strings so the frontend
+can render the badges without crashing.
+"""
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture
+def analyzed_diagram(client):
+    from main import SESSION_STORE, IMAGE_STORE
+    SESSION_STORE.clear()
+    IMAGE_STORE.clear()
+
+    content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    resp = client.post(
+        "/api/projects/proj-mchat/diagrams",
+        files={"file": ("arch.png", io.BytesIO(content), "image/png")},
+    )
+    diagram_id = resp.json()["diagram_id"]
+
+    mock_analysis = {
+        "diagram_type": "Test", "source_provider": "aws", "target_provider": "azure",
+        "architecture_patterns": [], "services_detected": 1,
+        "zones": [{"id": 1, "name": "Web", "number": 1, "services": [
+            {"aws": "RDS", "azure": "Azure SQL", "confidence": 0.9},
+        ]}],
+        "mappings": [{"source_service": "RDS", "source_provider": "aws",
+                      "azure_service": "Azure SQL", "confidence": 0.9}],
+        "warnings": [],
+        "confidence_summary": {"high": 1, "medium": 0, "low": 0, "average": 0.9},
+    }
+    with patch("routers.diagrams.analyze_image", return_value=mock_analysis):
+        client.post(f"/api/diagrams/{diagram_id}/analyze")
+
+    yield diagram_id
+    SESSION_STORE.clear()
+    IMAGE_STORE.clear()
+
+
+def _make_completion(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    response.choices[0].finish_reason = "stop"
+    return response
+
+
+class TestMigrationChatCoercion:
+    @patch("openai_client.get_openai_client")
+    def test_object_related_services_are_flattened(
+        self, mock_get_client, client, analyzed_diagram
+    ):
+        # Simulate the misbehaving model response that triggered React #31.
+        bad_payload = {
+            "reply": "You should consider Azure SQL and Cosmos DB.",
+            "related_services": [
+                {"type": "database", "message": "Azure SQL"},
+                {"name": "Cosmos DB"},
+                "Azure Cache for Redis",
+            ],
+        }
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_completion(bad_payload)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            f"/api/diagrams/{analyzed_diagram}/migration-chat",
+            json={"message": "What database should I use?"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Every item must be a string — never an object — so the frontend
+        # cannot crash with React error #31.
+        assert all(isinstance(s, str) for s in body["related_services"]), body
+        assert body["related_services"] == [
+            "Azure SQL",
+            "Cosmos DB",
+            "Azure Cache for Redis",
+        ]
+
+    @patch("openai_client.get_openai_client")
+    def test_string_related_services_pass_through(
+        self, mock_get_client, client, analyzed_diagram
+    ):
+        good_payload = {
+            "reply": "Use Azure SQL.",
+            "related_services": ["Azure SQL", "Azure Cache for Redis"],
+        }
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_completion(good_payload)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            f"/api/diagrams/{analyzed_diagram}/migration-chat",
+            json={"message": "What database should I use?"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["related_services"] == ["Azure SQL", "Azure Cache for Redis"]

--- a/backend/utils/chat_coercion.py
+++ b/backend/utils/chat_coercion.py
@@ -1,0 +1,54 @@
+"""Shared coercion helpers for chat-API responses.
+
+Several chat endpoints (e.g. ``/iac-chat``, ``/migration-chat``) ask GPT
+JSON-mode for arrays of strings, but the model occasionally returns
+objects (e.g. ``{"type": "add", "message": "Added VNet"}``). The
+frontend renders these items directly in JSX, which crashes React with
+error #31 ("Objects are not valid as a React child").
+
+Centralising the coercion here keeps the contract consistent across
+endpoints without coupling unrelated routers to ``iac_chat`` internals.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+
+def coerce_to_str_list(items: Any) -> List[str]:
+    """Coerce a model-returned list to a flat list of strings.
+
+    - Strings pass through.
+    - Numbers/bools are stringified.
+    - ``None`` items are dropped.
+    - Dicts are mapped via known string keys
+      (``message``, ``text``, ``name``, ``label``, ``value``,
+      ``description``); if none match, the dict is JSON-serialised so
+      the frontend never sees a raw object.
+    - Anything else falls back to ``str(item)``.
+
+    Non-list inputs return an empty list — defence-in-depth so a single
+    misbehaving response cannot break the API contract.
+    """
+    if not isinstance(items, list):
+        return []
+    out: List[str] = []
+    for item in items:
+        if item is None:
+            continue
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, (int, float, bool)):
+            out.append(str(item))
+        elif isinstance(item, dict):
+            for key in ("message", "text", "name", "label", "value", "description"):
+                val = item.get(key)
+                if isinstance(val, str) and val:
+                    out.append(val)
+                    break
+            else:
+                # Last resort — serialize so the frontend never sees an object.
+                out.append(json.dumps(item, ensure_ascii=False))
+        else:
+            out.append(str(item))
+    return out

--- a/frontend/src/components/DiagramTranslator/MigrationChat.jsx
+++ b/frontend/src/components/DiagramTranslator/MigrationChat.jsx
@@ -3,6 +3,30 @@ import { MessageSquare, Send, X, Loader2, Sparkles, ChevronDown, ChevronUp } fro
 import { Button, Card, Badge } from '../ui';
 import api from '../../services/apiClient';
 
+// Coerce arbitrary chat-API list items to a renderable string. Mirrors
+// `_coerce_to_str_list()` in backend/iac_chat.py and the helper in
+// IaCViewer.jsx — keep in sync. Defence-in-depth so legacy cached/in-memory
+// chat history with object items (e.g. `{type, message}` from GPT JSON mode)
+// cannot crash React with error #31.
+const toRenderableString = (item) => {
+  if (item == null) return '';
+  if (typeof item === 'string') return item;
+  if (typeof item === 'number' || typeof item === 'boolean') return String(item);
+  if (Array.isArray(item)) return item.map(toRenderableString).filter(Boolean).join(', ');
+  if (typeof item === 'object') {
+    for (const key of ['message', 'text', 'name', 'label', 'value', 'description']) {
+      const val = item[key];
+      if (typeof val === 'string' && val) return val;
+    }
+    try {
+      return JSON.stringify(item);
+    } catch {
+      return String(item);
+    }
+  }
+  return String(item);
+};
+
 const SUGGESTED_QUESTIONS = [
   'What are the biggest risks in this migration?',
   'Which services need the most rework?',
@@ -96,9 +120,13 @@ export default function MigrationChat({ diagramId }) {
               )}
               {Array.isArray(m.services) && m.services.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-1.5">
-                  {m.services.map((s, j) => (
-                    <Badge key={j} variant="azure" className="text-[9px]">{s}</Badge>
-                  ))}
+                  {m.services.map((s, j) => {
+                    const text = toRenderableString(s);
+                    if (!text) return null;
+                    return (
+                      <Badge key={j} variant="azure" className="text-[9px]">{text}</Badge>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/src/components/DiagramTranslator/__tests__/MigrationChat.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/MigrationChat.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock the api client BEFORE importing the component so the module
+// graph picks up the mock.
+vi.mock('../../../services/apiClient', () => ({
+  default: { post: vi.fn() },
+}))
+
+import api from '../../../services/apiClient'
+import MigrationChat from '../MigrationChat'
+
+describe('MigrationChat — React #31 guard', () => {
+  beforeEach(() => {
+    api.post.mockReset()
+  })
+
+  it('renders extracted strings when backend returns object-shaped related_services', async () => {
+    // Simulate a misbehaving backend response (the exact shape that
+    // crashed production with React error #31 before #635).
+    api.post.mockResolvedValueOnce({
+      reply: 'Use Azure SQL and Cosmos DB.',
+      related_services: [
+        { type: 'database', message: 'Azure SQL' },
+        { name: 'Cosmos DB' },
+        'Azure Cache for Redis',
+      ],
+    })
+
+    const user = userEvent.setup()
+    render(<MigrationChat diagramId="diag-1" />)
+
+    // Open the chat panel.
+    await user.click(screen.getByLabelText('Open Migration Advisor'))
+
+    // Send a question.
+    const input = screen.getByPlaceholderText(/ask about/i)
+    await user.type(input, 'What database should I use?')
+    await user.keyboard('{Enter}')
+
+    // No crash + the extracted strings render as <Badge>s.
+    await waitFor(() => {
+      expect(screen.getByText('Azure SQL')).toBeInTheDocument()
+      expect(screen.getByText('Cosmos DB')).toBeInTheDocument()
+      expect(screen.getByText('Azure Cache for Redis')).toBeInTheDocument()
+    })
+  })
+
+  it('renders strings unchanged when backend returns plain strings', async () => {
+    api.post.mockResolvedValueOnce({
+      reply: 'Use Azure SQL.',
+      related_services: ['Azure SQL', 'Azure Cache for Redis'],
+    })
+
+    const user = userEvent.setup()
+    render(<MigrationChat diagramId="diag-2" />)
+
+    await user.click(screen.getByLabelText('Open Migration Advisor'))
+    const input = screen.getByPlaceholderText(/ask about/i)
+    await user.type(input, 'Q?')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('Azure SQL')).toBeInTheDocument()
+      expect(screen.getByText('Azure Cache for Redis')).toBeInTheDocument()
+    })
+  })
+
+  it('skips items with no extractable string instead of crashing', async () => {
+    api.post.mockResolvedValueOnce({
+      reply: 'OK.',
+      related_services: [
+        { unrelated: 'meta' }, // no known key — falls back to JSON.stringify
+        '',                    // empty string is dropped
+        null,                  // null is dropped
+        'Azure Functions',
+      ],
+    })
+
+    const user = userEvent.setup()
+    render(<MigrationChat diagramId="diag-3" />)
+
+    await user.click(screen.getByLabelText('Open Migration Advisor'))
+    const input = screen.getByPlaceholderText(/ask about/i)
+    await user.type(input, 'Q?')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('Azure Functions')).toBeInTheDocument()
+    })
+    // Component did not throw — assertion above implies render succeeded.
+  })
+})


### PR DESCRIPTION
## Why

The merged fix in #623 covered the `/iac-chat` endpoint, but the user is **still hitting React error #31 in production** because the **`/migration-chat` endpoint has the same bug class on a different code path**:

- Backend `POST /api/diagrams/{id}/migration-chat` (`backend/routers/insights.py`) returns `related_services` straight from GPT JSON mode without coercion.
- Frontend `MigrationChat.jsx` (the bottom-left "Migration Advisor" chat) renders each item directly: `<Badge>{s}</Badge>`. When GPT returns objects like `{type, message}`, React crashes with #31.

This is exactly the `{type, message}` shape the user reported in the production stack trace.

## Fix

**Backend** (`backend/routers/insights.py`): reuse the existing `iac_chat._coerce_to_str_list` helper at the migration-chat API boundary so `related_services` is always a list of strings.

**Frontend** (`MigrationChat.jsx`): defence-in-depth — add a local `toRenderableString` helper mirroring the one in `IaCViewer.jsx` and the backend coercion. Wrap the badge render so any cached / in-flight non-string item also renders safely.

**Tests**: new `backend/tests/test_migration_chat_coercion.py` exercises the endpoint with the exact `{type, message}` shape that triggered the production crash and asserts the response is a list of strings. Plus a pass-through test for already-string responses.

## Files

- `backend/routers/insights.py` — apply `_coerce_to_str_list` to `related_services`.
- `frontend/src/components/DiagramTranslator/MigrationChat.jsx` — add `toRenderableString` helper, use in badge render.
- `backend/tests/test_migration_chat_coercion.py` — new regression test.

## Related

- #623 — same bug class on `/iac-chat` (already merged).
- This PR closes the parallel gap on `/migration-chat`.