### PR TITLE
docs: CTO direction + spine cleanup aftermath (README/PRD/CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### CTO direction — technical-only refocus (May 1, 2026)
+
+> Authority: CTO Master. Status: Binding. Supersedes prior product/marketing framing throughout README.md and docs/PRD.md.
+
+**Mission:** Archmorph is an internal engineering workbench. The value spine is `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`. Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+**Operating principles (7):**
+1. Value spine is law. Off-spine changes get cut on sight.
+2. The user is an engineer at a terminal — full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. Every output is machine-checkable (parse, schema-validate, round-trip tested).
+4. Engineering observability over product analytics. OpenTelemetry + Application Insights only. PostHog, funnel tracking, retention cohorts — banned.
+5. Identity is Entra ID. Period. No SSO matrices, no SAML, no SCIM, no social auth.
+6. Single tenant, single org. Roles: `engineer | reader` via Entra group claims.
+7. Reduction beats addition.
+
+**Three deletion PRs sequenced** after the already-merged Gallery → Playground → Canvas trio (#637/#638/#639, −1,637 LOC). Cumulative target: ≈ −2,800 to −3,750 LOC.
+
+| Order | PR | Removes | LOC delta | Risk |
+|---|---|---|---|---|
+| PR-1 | `chore: remove marketing surface` | `LandingPage.jsx` (291), `CookieBanner.jsx` (166), default-tab routing to landing, all `100% free for customers` mentions, related FE tests | ≈ −500 to −650 | Low |
+| PR-2 | `chore: remove product analytics + retention + onboarding funnel` | `analytics.js` (145), `analytics_routes.py` (111), `retention.py`, `retention_routes.py`, Day-7 retention tile, `EVENT_TAXONOMY.md`, `posthog-js` dep, S1 PRD row | ≈ −800 to −1,100 | Medium |
+| PR-3 | `chore: collapse multi-tenant + SSO scaffolds to single-tenant Entra ID` | `sso_routes.py` (438), `org_routes.py` (268), `profile_routes.py` (198), `feedback.py` (73), `feature_flags.py` (70), social auth providers, FE org/invite UIs, PRD §3.39 + §3.40 + §12.1 | ≈ −1,500 to −2,000 | High — auth blast radius |
+
+**v5.0 north-star roadmap (8 epics):** spine consolidation, ALZ production-ready (#586), GitHub IaC PR integration, drift loop closure, mapping coverage to 95%, CLI-first workflow, architecture limitations engine Phase 2, observability SLOs (analyze p95 <8s, alz p95 <1.5s, e2e p95 <30s).
+
+**New issue labels (adopt):** `value-spine-core`, `value-spine-adjacent`, `engineer-win`, `loc-debt`, `cut-candidate`, `defer-park`, `blocks-migration`, `mapping-staleness`, `arch-rule`, `observability`, `security`, `iac-output`, `alz`.
+
+**Retired labels (apply `archived`):** `product`, `marketing`, `growth`, `funnel`, `activation`, `retention`, `kpi-conversion`, `case-study`, `social-proof`, `waitlist`, `roadmap-marketing`, `whitelabel`, `multi-tenant`, `organizations`, `sso-saml`, `scim`, `gdpr-dsar`, `cookie-consent`, `pricing`, `tiers`, `billing`, `paid`, `freemium`.
+
+**Banned vocabulary in docs/PRs/commits:** `delight`, `delightful`, `empower`, `empowering`, `enterprise-grade`, `world-class`, `powerful`, `magical`, `seamless`, `effortless`, `game-changing`, `cutting-edge`, `revolutionary`, `blazing-fast`, `next-generation`, `unleash`, `supercharge`, `robust` (use "tested"), `best-in-class`, `one-stop`, `beautiful`, `beloved`, `loved by`, `customers`, `users` (use "engineers"), `freemium`, `PLG`, `growth-loop`, `conversion`, `funnel`, `activation`, `retention-cohort`, `case study`, `testimonial`, `social proof`.
+
+**PR/commit voice rules:** Lead with the engineer-win in one measurable sentence (`−10 min vs draw.io`, `fails CI on misconfigured Front Door + SFTP`, `reduces Aurora→MS SQL mis-routing to 0`). Imperative, scope-prefixed commit subjects ≤72 chars. PR descriptions answer: what spine segment touched, what's the measurable win, what tests assert it, net LOC delta. Third-person factual prose in README/PRD.
+
+### Removed
+
+#### CTO scope cleanup — three peripheral surfaces deleted (PRs [#637](https://github.com/idokatz86/Archmorph/pull/637), [#638](https://github.com/idokatz86/Archmorph/pull/638), [#639](https://github.com/idokatz86/Archmorph/pull/639))
+
+Per the owner rubric — internal tool only, NOT for sale, no marketing surface, no growth-funnel telemetry, every feature must give a measurable productivity / correctness / observability win to a platform or cloud engineer doing AWS/GCP→Azure migrations — the CTO verdict deleted three surfaces that did not feed the value spine `diagram → vision → cross-cloud mapping → IaC → ALZ → drift/cost`:
+
+- **Migration Gallery** ([#637](https://github.com/idokatz86/Archmorph/pull/637)) — community-stories surface; pure marketing/social-proof, served no engineer workflow. Deleted `frontend/src/components/MigrationGallery.jsx`, `backend/routers/gallery_routes.py`, supporting backend services, models, tests, frontend tests, and nav/store/command-palette wiring (10 files, −720 LOC).
+- **Demo Playground + default-tab fix** ([#638](https://github.com/idokatz86/Archmorph/pull/638)) — try-before-signup sandbox; not relevant to an internal tool with no signup. Deleted `frontend/src/components/PlaygroundPage.jsx`, removed marketing analytics steps (`first_upload`, `returning_user`), changed default landing tab from `playground` to `translator`. Includes a follow-up popstate fix so back/forward navigation handles the empty-hash translator route correctly (11 files, +14/−222 LOC).
+- **Canvas Editor** ([#639](https://github.com/idokatz86/Archmorph/pull/639)) — hand-rolled diagram editor that duplicated external tools (draw.io, Excalidraw, Lucidchart) without producing any IaC, ALZ, or drift output the spine consumes. Deleted `frontend/src/components/CanvasEditor/` (CanvasEditor.jsx + servicesPalette.js), App/Nav/CommandPalette/store wiring, Nav test assertion (7 files, −695 LOC). `@xyflow/react` retained for `DependencyGraph` and `ArchitectureFlow` inside the live `DiagramTranslator`.
+
+**Net delivered:** −1,637 LOC across 28 files, 3 nav entries removed, 1 attack surface removed (Canvas drag-drop palette state).
+
+**Intentionally kept (different concerns, verified):** `routers/deploy.py` `canvas_state` field (carries the analysis blob), `azure_landing_zone.py` `CANVAS_W` / `CANVAS_H_*` SVG export viewport constants, and all `"SageMaker Canvas"` AWS service-mapping references in the catalog.
+
+**Validation per PR:** backend pytest 1767 passed / 1 skipped / 2 xfailed, frontend vitest 271 passed (29 files), OpenAPI contract green, post-deploy smoke green on the merge SHA `29bbe068edc197c636d756e647e4d53df76a7db8`.
+
 ### Added
 
 #### Architecture limitations engine (PR [#615](https://github.com/idokatz86/Archmorph/pull/615); follow-up phases [#616](https://github.com/idokatz86/Archmorph/issues/616) [#617](https://github.com/idokatz86/Archmorph/issues/617) [#618](https://github.com/idokatz86/Archmorph/issues/618) [#619](https://github.com/idokatz86/Archmorph/issues/619))

--- a/README.md
+++ b/README.md
@@ -1,33 +1,94 @@
 # Archmorph
 
-**AI-Powered Multi-Cloud Architecture Translator & Migration Platform**
+**Internal AWS/GCP → Azure migration workbench for platform & cloud engineers**
 
-Translate AWS and GCP architecture diagrams into Azure-ready migration artifacts: service mappings, guided questions, IaC drafts, HLD exports, cost estimates, and reviewable migration packages. Archmorph is in preview/stabilization; some enterprise surfaces are implemented as beta or scaffolded workflows.
+Archmorph converts AWS and GCP architecture diagrams into Azure-targeted IaC, Landing Zone designs, drift signals, and cost deltas. It exists for platform engineers and cloud engineers running migrations. It is not a product, has no customers, and ships nothing for sale.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Multi-Cloud](https://img.shields.io/badge/cloud-AWS%20%7C%20Azure%20%7C%20GCP-0078D4.svg)
 ![Version](https://img.shields.io/badge/version-4.2.0-22C55E.svg)
-![Status](https://img.shields.io/badge/status-Preview%20Stabilizing-F59E0B.svg)
+![Status](https://img.shields.io/badge/status-Internal%20Tool-F59E0B.svg)
 ![Tests](https://img.shields.io/badge/tests-CI%20Enforced-22C55E.svg)
 ![Python](https://img.shields.io/badge/python-3.12-3776AB.svg)
 ![React](https://img.shields.io/badge/react-19.2-61DAFB.svg)
-![Vibe Coding](https://img.shields.io/badge/built_with-Vibe_Coding-FF69B4.svg)
 
+
+---
+
+## Mission
+
+Archmorph is an internal engineering workbench. The value spine is:
+
+> `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`
+
+Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+## Operating Principles (CTO direction, May 1, 2026)
+
+1. **Value spine is law.** Every PR advances the spine. Anything off-spine is overhead and gets cut on sight.
+2. **The user is an engineer at a terminal.** Full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. **Every output is machine-checkable.** Mappings, IaC, ALZ SVG, drift reports — all parse, all schema-validate, all have round-trip tests.
+4. **Engineering observability over product analytics.** OpenTelemetry + Application Insights. Funnel tracking, cohort retention, PostHog — banned.
+5. **Identity is Entra ID. Period.** No SSO matrices, no SAML brokers, no SCIM provisioning UIs, no social auth.
+6. **Single tenant, single org.** No multi-tenant primitives. Roles: `engineer | reader` via Entra group claims.
+7. **Reduction beats addition.** A PR that deletes 500 LOC and preserves the spine is more valuable than one that adds 500 LOC of adjacent surface.
 
 ---
 
 ## Overview
 
-Archmorph is an AI-assisted cloud migration workbench. The live path analyzes uploaded architecture diagrams, maps AWS/GCP services to Azure equivalents with confidence scoring, asks guided migration questions, generates IaC drafts, prepares HLD/report exports, and estimates costs. The application is 100% free for customers: there are no subscriptions, paid tiers, billing steps, or hidden customer charges. Adjacent platform capabilities such as scanner, deploy, collaboration, SSO/SCIM, gallery, and drift are present in the codebase at varying maturity levels and are labeled below so operators know what is ready to trust.
+Archmorph is an AI-assisted cloud migration workbench used internally to convert uploaded AWS/GCP diagrams into Azure migration artifacts: detected services, confidence-scored mappings, guided migration questions, IaC drafts, HLD exports, and cost estimates. Adjacent surfaces (scanner, deploy orchestration, drift) are present at varying maturity levels and are labeled below.
 
 ### Capability Status
 
-| Status | Meaning | Capabilities |
-|--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, cost estimates, service catalog, admin analytics, auth shell, CI/security scanning |
-| Beta | Implemented but needs hardening, deeper tests, or production validation | RAG, Agent PaaS proof, cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, social auth/RBAC, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
-| Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault, SSO/SAML/SCIM, live drift/living architecture |
-| Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
+Refocused around the engineer-win each capability delivers (CTO direction, May 1, 2026). **Live** = on the spine and used today. **Beta** = on the spine, hardening in progress. **Cut-candidate** = scheduled for removal in the spine consolidation PRs (PR-1 through PR-3 below).
+
+| Capability | Status | Engineer-win it delivers |
+|---|---|---|
+| Diagram upload + vision analysis (PNG/PDF/Visio) | Live | Skips 10–30 min of manual draw.io re-tracing per source diagram. |
+| AWS→Azure + GCP→Azure service mapping with confidence scores | Live | Removes the `aws-svc-X has no Azure equivalent — wait, what about Y?` lookup loop per migration. |
+| Mapping freshness contract (`last_reviewed`) + freshness tests | Live | CI fails when a mapping row goes stale — no silent rot. |
+| SKU translator with engine-correct defaults | Live | Stops mis-routing Aurora-PostgreSQL to MS SQL Hyperscale; catches license-cost surprises pre-deploy. |
+| IaC chat (Terraform + Bicep) | Live | Generates IaC scaffolds from analysis without `terraform init`-then-cry loops. |
+| Architecture limitations engine | Live | Fails CI on misconfigured topologies (e.g. SFTP via Front Door); 25 rules, growing to ≥40 in Phase 2. |
+| HLD generator (Word export) | Live | Auto-builds the migration design doc the engineer would otherwise write by hand. |
+| Drift detection vs deployed Azure | Beta | Surfaces config drift between IaC source-of-truth and live tenant. |
+| Cost comparison (source cloud → Azure target) | Beta | Quantifies migration cost delta in the same artifact as the IaC plan. |
+| Network topology translation (VPC/CIDR/NSG → VNet/NSG/Front Door) | Beta | Pre-validates IP plan and security groups before deploy. |
+| Azure Landing Zone target SVG (8 tiers, multi-source) | Beta | Hands a starter LZ the engineer can edit, not a blank tenant. Production-ready push tracked under epic [#586](https://github.com/idokatz86/Archmorph/issues/586). |
+| RAG-grounded mapping suggestions | Live (slim target) | Mapping suggestions cite Azure docs sources — auditable, not hallucinated. |
+| `azd up` / `terraform apply` orchestration | Live (slim target) | One command takes the IaC artifact to a deployed Azure RG. |
+| Observability (OTel spans + 4 ALZ metrics + Workbook + alerts) | Live | Engineering-grade telemetry on the workbench itself — no PostHog. |
+| GitHub IaC PR integration | Planned (P0) | Lands generated Terraform/Bicep as a PR with diff + drift comment in the engineer's repo. |
+| Live cloud scanner / deploy execution / SSO/SAML/SCIM | Cut-candidate | See PR-3 below — collapses to single-tenant Entra ID. |
+| `LandingPage`, `CookieBanner`, retention KPIs, product analytics, multi-tenant primitives, white-label SDK, Migration Replay, Migration Timeline, Agent PaaS PoC | Cut-candidate | Off-spine. Targeted for removal in PR-1 → PR-3 (see [Spine Consolidation Plan](#spine-consolidation-plan-cto-direction) below). |
+
+### Spine Consolidation Plan (CTO direction)
+
+Three deletion PRs sequenced after the already-merged Gallery → Playground → Canvas trio (#637/#638/#639, −1,637 LOC). Same pattern: highest LOC, highest conviction, fewest cross-deps first.
+
+| Order | PR | Removes | LOC delta | Risk |
+|---|---|---|---|---|
+| 1 | `chore: remove marketing surface` | `LandingPage.jsx` (291), `CookieBanner.jsx` (166), default-tab routing to landing, all `100% free for customers` mentions, related FE tests | ≈ −500 to −650 | Low |
+| 2 | `chore: remove product analytics + retention + onboarding funnel` | `analytics.js` (145), `analytics_routes.py` (111), `retention.py`, `retention_routes.py`, Day-7 retention tile, `EVENT_TAXONOMY.md`, `posthog-js` dep, S1 PRD row | ≈ −800 to −1,100 | Medium |
+| 3 | `chore: collapse multi-tenant + SSO scaffolds to single-tenant Entra ID` | `sso_routes.py` (438), `org_routes.py` (268), `profile_routes.py` (198), `feedback.py` (73), `feature_flags.py` (70), social auth providers, FE org/invite UIs, PRD §3.39 + §3.40 + §12.1. Replaces with single `Depends(verify_entra_token)` + `archmorph-engineer`/`archmorph-reader` group claims. | ≈ −1,500 to −2,000 | High — auth blast radius |
+
+**Cumulative target:** ≈ −2,800 to −3,750 LOC across PR-1 → PR-3, on top of the −1,637 already removed. Spine surface area drops by roughly one-third with zero loss of engineer-facing capability.
+
+### v5.0 North-Star Roadmap (8 epics)
+
+Replaces all prior product/marketing roadmap items.
+
+| # | Epic | Problem it solves for the engineer | Success metric |
+|---|---|---|---|
+| 1 | **Spine consolidation** | Repo carries ~3,000 LOC of off-spine routers and surfaces. | Net −3,000 LOC across 6 PRs; routers count drops from ~50 to ≤30. |
+| 2 | **ALZ production-ready** (epic #586 → GA) | ALZ output is demo-ware (43% icon hit rate, 6/8 tiers). | Icon hit rate ≥95%; all 8 tiers populated; golden-file pixel diff <2%; gpt-5-pro grader returns `production-ready`. |
+| 3 | **GitHub IaC PR integration** | Engineer copy-pastes generated IaC into a repo by hand. | One CLI/API call opens a PR in `<owner>/<repo>` with Terraform/Bicep + drift comment + ALZ SVG attached; round-trip <30s. |
+| 4 | **Drift loop closure** | Drift is detected but doesn't feed back into the IaC artifact. | Drift report becomes a machine-readable patch the IaC chat can apply. |
+| 5 | **Mapping coverage to 95%** | AWS→Azure + GCP→Azure mapping coverage has gaps; freshness contract incomplete. | ≥95% coverage across `aws_canonical_estate.json` + GCP equivalent; 100% rows under freshness contract. |
+| 6 | **CLI-first workflow** | Web UI is the only entry. | `archmorph run --diagram x.png --target-rg foo --emit terraform,bicep,alz-svg` produces all artifacts in <60s without a browser. |
+| 7 | **Architecture limitations engine Phase 2** | 25 rules with 7 known polish bugs (#620). | Phase 2 ships #620 fixes + ≥40 total rules + rule authoring docs. |
+| 8 | **Observability SLOs** | Tool itself has no uptime/latency SLO. | `analyze_image` p95 <8s, `generate_landing_zone` p95 <1.5s, end-to-end p95 <30s; alerts wire to PagerDuty. |
 
 ### Production-Ready Roadmap — Azure Landing Zone (v4.3.0 target)
 
@@ -41,7 +102,7 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 | **Frontend exposure** | [#601](https://github.com/idokatz86/Archmorph/issues/601) (closes [#575](https://github.com/idokatz86/Archmorph/issues/575)) | ExportHub option + `LandingZoneViewer` with DR toggle, pan/zoom, deep-link state |
 | **Quality assurance** | [#600](https://github.com/idokatz86/Archmorph/issues/600), [#604](https://github.com/idokatz86/Archmorph/issues/604) | Golden PDF regression suite (AWS/GCP/mixed/CTO-redacted); GA gate re-runs CTO E2E with `gpt-5-pro` rubric judge |
 | **Foundry model evaluation** | [#602](https://github.com/idokatz86/Archmorph/issues/602) | Bench `gpt-5.4` / `gpt-5.5` / `gpt-5.3-codex` / `mistral-document-ai-2512` vs current `gpt-4.1` to lock per-agent model picks (model freedom granted to specialist agents) |
-| **Docs + release** | [#603](https://github.com/idokatz86/Archmorph/issues/603), [#605](https://github.com/idokatz86/Archmorph/issues/605) | Customer-facing "What is the ALZ diagram?" doc + sample gallery; Beta → Live promotion + v4.3.0 release |
+| **Docs + release** | [#603](https://github.com/idokatz86/Archmorph/issues/603), [#605](https://github.com/idokatz86/Archmorph/issues/605) | Operator-facing "What is the ALZ diagram?" doc + sample SVG fixtures; Beta → Live promotion + v4.3.0 release |
 
 **GA gate ([#604](https://github.com/idokatz86/Archmorph/issues/604))**: re-run the same PDF that produced the original demo-ware verdict. Pass requires icon hit rate ≥ 95%, all 8 tiers populated, ≥ 3 `service_connections` rendered, golden-file pixel diff < 2%, SLO budgets met, CISO sign-off, and `gpt-5-pro` judge returning `production-ready`. Anything less and Sprint 4 absorbs fix-forward — we don't ship.
 
@@ -81,7 +142,6 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 - **SSO / SAML / SCIM scaffold** — enterprise auth routes exist, but require tenant-specific configuration and production validation before use
 - **Real-time Collaboration** — multi-stakeholder migration workspace with share codes and role-based participants
 - **Migration Replay** — animated analysis timeline for presentations with playback controls
-- **Migration Gallery** — public anonymized success stories, filterable by cloud and complexity
 - **Product Analytics** — funnel tracking (PostHog + backend), session-based event ingestion
 - **API Developer Portal** — Swagger/Redoc integration with category overview and curl examples
 - **Living architecture scaffold** — drift/versioning APIs include saved baselines, repeat compares, finding decisions, and Markdown report export; live environment monitoring still requires tenant-specific scanner validation
@@ -212,7 +272,6 @@ flowchart TB
                 SSO[SSO / SAML / SCIM<br/>Tenant validation gated]
                 Collab[Collaboration<br/>Real-Time Sessions]
                 Replay[Migration Replay<br/>Animated Timeline]
-                Gallery[Migration Gallery<br/>Public Stories]
                 TFImport[TF State Import<br/>tfstate/ARM/CF]
                 MultiCost[Multi-Cloud Cost<br/>3-Cloud TCO]
                 Analytics[Product Analytics<br/>Funnel Tracking]
@@ -268,7 +327,6 @@ flowchart TB
     API --> SSO
     API --> Collab
     API --> Replay
-    API --> Gallery
     API --> TFImport
     API --> MultiCost
     API --> Analytics
@@ -411,8 +469,7 @@ Input (Upload / Scan / Import) → AI Analysis → Guided Questions → Collabor
 1. **Upload Diagram** — PNG, JPG, SVG, PDF, Draw.io (.drawio), or Visio (.vsdx) architecture diagram
 2. **Import IaC** — Upload existing Terraform state (v3/v4), CloudFormation template, or ARM deployment JSON
 3. **Cloud scan scaffold** — Connectors and credential-handling model exist, but live tenant scanning stays gated until provider validation is complete
-4. **Demo Playground** — Try with sample diagrams, no sign-up required
-5. **AI Vision Analysis** — GPT-4.1 detects services, connections, and annotations (with TTL cache)
+4. **AI Vision Analysis** — GPT-4.1 detects services, connections, and annotations (with TTL cache)
 
 **Phase 2 — Analysis** (collaborative, real-time):
 6. **Guided Questions** — 8–18 contextual questions refine migration (SKU, compliance, networking, DR, security, region) with inter-question constraints
@@ -431,7 +488,6 @@ Input (Upload / Scan / Import) → AI Analysis → Guided Questions → Collabor
 17. **Migration Timeline** — 7-phase plan with topological dependency ordering and parallel workstreams
 18. **Risk Assessment** — Risk scoring with automated runbook generation
 19. **Migration Replay** — Animated timeline playback for presentations (play/pause/speed controls)
-20. **Migration Gallery** — Submit anonymized success stories to the public gallery
 
 ---
 
@@ -673,17 +729,15 @@ Archmorph/
 │   │   │   │   ├── ScanStep.jsx         # Scan execution + progress
 │   │   │   │   ├── ReviewStep.jsx       # Results review
 │   │   │   │   └── index.jsx            # 3-step wizard flow
-│   │   │   ├── CanvasEditor/        # Interactive architecture canvas
 │   │   │   ├── DriftDashboard/      # Infrastructure drift monitoring
 │   │   │   ├── Auth/                # Social auth + user profiles
 │   │   │   ├── CollabWorkspace.jsx  # Real-time collaboration panel
 │   │   │   ├── MigrationReplay.jsx  # Animated replay viewer
-│   │   │   ├── MigrationGallery.jsx # Public migration gallery
 │   │   │   ├── ApiDocs.jsx          # API developer portal
 │   │   │   ├── EmptyState.jsx       # Reusable empty state component
 │   │   │   ├── PhaseIndicator.jsx   # 3-phase progress indicator
 │   │   │   ├── LandingPage.jsx      # Marketing landing page
-│   │   │   ├── Nav.jsx              # Navigation bar (9 tabs + Gallery)
+│   │   │   ├── Nav.jsx              # Navigation bar (Dashboard / Translator / Services + More menu)
 │   │   │   ├── ui.jsx               # Design system (Button, Badge, Card, Input, Select, Modal, Tabs, etc.)
 │   │   │   └── ... (109 total)      # + additional components
 │   │   ├── hooks/
@@ -707,7 +761,6 @@ Archmorph/
 │   │   ├── sso_routes.py            # SAML/SCIM enterprise SSO
 │   │   ├── collaboration_routes.py  # Real-time collaboration sessions
 │   │   ├── replay_routes.py         # Migration replay timeline
-│   │   ├── gallery_routes.py        # Public migration gallery
 │   │   ├── scanner_routes.py        # Live cloud infrastructure scanner
 │   │   ├── credentials.py           # Secure credential vault
 │   │   ├── deployments.py           # Deploy engine (preview + execute)
@@ -909,7 +962,7 @@ See [docs/DEPLOYMENT_COSTS.md](docs/DEPLOYMENT_COSTS.md) for full breakdown.
 | v3.8.0 — Complete Migration Flow | Done | Migration package ZIP export (IaC + HLD + costs), before/after architecture visualization, guided onboarding tour, CI coverage gate (60%), stale bot, migration Q&A chat advisor |
 | v3.8.1 — UX Polish & Bug Bash | Done | Fix HLD generation 500 crashes, recover missing Map layers, unblock IaC dynamic modifications, populate Coming Soon tab, and Drift Alpha warnings |
 | v4.0.0 — Platform Scale | Done | RAG pipeline, AI Agent PaaS PoC, cost/token observability, AI mapping auto-suggestions, migration timeline generator, service dependency graph, social auth, user profiles, RBAC/multi-tenant, PDF report export, DevOps modernization (uv, Trivy, Helm) |
-| v4.1.0 — Enterprise & Collaboration Preview | Mixed | Product analytics, UX Wave 1/2, Terraform import, replay/gallery/collaboration, RAG/Agent PaaS, cost observability, drift baselines, admin release gates, and security evidence are implemented or beta. Live scanner, deploy engine, credential vault, and SSO/SCIM production validation remain scaffolded/hardening work. |
+| v4.1.0 — Enterprise & Collaboration Preview | Mixed | Product analytics, UX Wave 1/2, Terraform import, replay/collaboration, RAG/Agent PaaS, cost observability, drift baselines, admin release gates, and security evidence are implemented or beta. Live scanner, deploy engine, credential vault, and SSO/SCIM production validation remain scaffolded/hardening work. |
 | v5.0 — Next | Planned | VS Code extension, Pulumi/CDK output, multi-diagram projects, GitHub/GitLab IaC PR integration |
 
 ---

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,9 +6,42 @@
 
 ---
 
+## 0. CTO Direction (May 1, 2026)
+
+> **Authority:** CTO Master. **Status:** Binding. Supersedes prior product/marketing framing throughout this PRD.
+
+### Mission
+
+Archmorph is an internal engineering workbench. The value spine is `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`. Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+### Operating Principles
+
+1. Value spine is law. Off-spine changes get cut on sight.
+2. The user is an engineer at a terminal — full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. Every output is machine-checkable (parse, schema-validate, round-trip tested).
+4. Engineering observability over product analytics. OpenTelemetry + Application Insights only. PostHog, funnel tracking, retention cohorts — banned.
+5. Identity is Entra ID. Period. No SSO matrices, no SAML, no SCIM, no social auth.
+6. Single tenant, single org. Roles: `engineer | reader` via Entra group claims.
+7. Reduction beats addition.
+
+### Cut-candidate sections in this document
+
+The following sections describe surfaces flagged for removal in the spine consolidation PRs (PR-1 → PR-3, see README Spine Consolidation Plan). They remain in this document for historical traceability only and **must not** be cited as roadmap items in new work:
+
+- **§3.39 White-Label SDK** — internal tool has no partners.
+- **§3.40 Multi-Tenant Foundation** — single tenant.
+- **§12.1 Strategic Gaps (CEO Review)** rows S1 (free positioning), S2 (onboarding funnel), S4 (testimonials), S6 (SSO/SAML/SCIM), S10 (waitlist), S11 (investor data room).
+- All `Built-in diagram editor`, `Migration Gallery`, "100% free for customers" framing, and partner branding references throughout.
+
+### Banned vocabulary
+
+`delight`, `delightful`, `empower`, `empowering`, `enterprise-grade`, `world-class`, `powerful`, `magical`, `seamless`, `effortless`, `game-changing`, `cutting-edge`, `revolutionary`, `blazing-fast`, `next-generation`, `unleash`, `supercharge`, `robust` (use "tested"), `best-in-class`, `one-stop`, `beautiful`, `beloved`, `loved by`, `customers` (we have none), `users` (use "engineers"), `freemium`, `PLG`, `growth-loop`, `conversion`, `funnel`, `activation`, `retention-cohort`, `case study`, `testimonial`, `social proof`.
+
+---
+
 ## 1. Executive Summary
 
-Archmorph is an AI-assisted cloud migration workbench in preview/stabilization. Its live product path converts uploaded AWS/GCP architecture diagrams into Azure migration artifacts: detected services, confidence-scored mappings, guided migration questions, IaC drafts, HLD/report exports, and cost estimates. The application is 100% free for customers: no subscriptions, paid tiers, billing setup, or hidden fees are required. The platform codebase also contains beta and scaffolded enterprise modules for collaboration, replay, gallery, RAG/Agent PaaS, Terraform state import, scanner, deploy, SSO/SCIM, and drift.
+Archmorph is an internal engineering workbench used to convert AWS/GCP architecture diagrams into Azure migration artifacts: detected services, confidence-scored mappings, guided migration questions, IaC drafts, HLD/report exports, and cost estimates. It exists for platform engineers and cloud engineers running migrations. It is not a product, has no customers, and ships nothing for sale. The platform codebase also contains beta and scaffolded modules for collaboration, replay, RAG/Agent PaaS, Terraform state import, scanner, deploy, SSO/SCIM, and drift — several of these are flagged as cut-candidates in the CTO direction (May 1, 2026); see the README Spine Consolidation Plan for details.
 
 The PRD distinguishes three maturity levels. **Live** features are usable in the core flow and should remain protected by CI. **Beta** features are implemented but need production validation, UX hardening, or broader tests. **Scaffold** features have routes, UI, or models present but must not be described as production-ready until cloud/provider execution is verified.
 
@@ -20,8 +53,8 @@ The PRD distinguishes three maturity levels. **Live** features are usable in the
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, cost estimates, service catalog, admin analytics, auth shell, API versioning, CI/security gates |
-| Beta | RAG, Agent PaaS proof, cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, social auth/RBAC, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
+| Live | Diagram upload, service mapping, guided questions, IaC/HLD/report export, cost estimates, service catalog, admin analytics, auth shell, API versioning, CI/security gates |
+| Beta | RAG, Agent PaaS proof, cost/token observability, collaboration, migration replay, Terraform state import, multi-cloud cost comparison, social auth/RBAC, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine, SSO/SAML/SCIM production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |
 | Planned | VS Code extension, PR-based IaC workflows, multi-diagram projects |
@@ -282,7 +315,7 @@ The PRD distinguishes three maturity levels. **Live** features are usable in the
 
 ### 3.39 White-Label SDK (v3.0.0)
 - **Config-driven branding** — product name, tagline, logo, favicon, color palette (7 tokens), font families (3 slots)
-- **Feature flags per partner** — toggle powered-by badge, community patterns, template gallery, IaC generation, exports
+- **Feature flags per partner** — toggle powered-by badge, community patterns, IaC generation, exports
 - **Upload quotas** — configurable max_uploads_per_day per partner
 - **Partner API key management** — `am_wl_` prefixed keys with `X-Partner-Key` header authentication
 - **Embeddable widget** — auto-generated iframe snippet with configurable dimensions and allowed origins
@@ -974,9 +1007,7 @@ Only when 1–7 all green does the README/PRD Capability Status table flip ALZ r
 | **Guided onboarding tour** | Interactive walkthrough with achievement badges | Engineering | P2 | #257 |
 | **Contextual migration Q&A** | Chat on analysis results with migration-specific context | Engineering | P1 | #258 |
 | **Real-time collaborative workspace** | Multi-user simultaneous editing of migration projects | Engineering | P2 | #251 |
-| **Built-in diagram editor** | Canvas-based architecture diagram editor | Engineering | P2 | #253 |
 | **Migration replay** | Animated analysis timeline for presentations | Engineering | P3 | #254 |
-| **Migration Gallery** | Public anonymized success stories from community | Engineering | P2 | #256 |
 | **Public API & webhooks** | Enterprise integrations (Slack, Teams, Jira) | Engineering | P2 | #259 |
 | **AI Agent PaaS** | Control/Runtime design with routing/memory/policy | Engineering | P1 | #319 |
 | **Live Cloud Discovery & Auto-Deploy** | End-to-end migration execution platform | Engineering | P1 | #321 |
@@ -994,7 +1025,6 @@ Identified by CEO Master + CTO Master cross-functional review with all agent hie
 |---|-----|----------|----------------|-------|----|
 | S1 | Free access positioning | P0 | No production billing in current release scope; 100% free customer positioning remains explicit | CRO + Backend | 5 |
 | S2 | Self-serve onboarding funnel with product analytics | P0 | No funnel metrics = blind PLG motion | PM + FE | 8 |
-| S3 | Interactive demo / playground (no sign-up) | P0 | PLG requires zero-friction try-it-now | UX + FE | 5 |
 | S4 | Customer testimonials / case study framework | P1 | Zero social proof for investors | CRO + PM | 3 |
 | S5 | SOC 2 Type I readiness & compliance dashboard | P1 | Blocks enterprise deals | CISO + CLO | 8 |
 | S6 | SSO / SAML / SCIM integration | P1 | Preview routes are feature-gated; tenant validation and signed assertion verification remain enterprise-readiness gates | CISO + Backend | 8 |


### PR DESCRIPTION
## Docs sync + CTO direction adoption

Doc-only PR. Two strands folded into one commit because they are inseparable:

### 1. Factual sync to the merged spine cleanup

Reflects the three already-merged peripheral-surface deletions (#637 Gallery, #638 Playground, #639 Canvas — net −1,637 LOC, all on `main` since `29bbe06`) in the README, PRD, and CHANGELOG.

- README: drop `gallery` / `playground` from Capability Status, remove Gallery node from the system Mermaid diagram, remove "Demo Playground" workflow phase, drop "Migration Gallery" feature line, drop `CanvasEditor/` and `MigrationGallery.jsx` from the project tree, fix `Nav.jsx` comment ("9 tabs + Gallery" → "Dashboard / Translator / Services + More menu"), drop `gallery_routes.py` from backend tree, fix v4.1.0 version-history entry.
- PRD: drop "Migration Gallery", "Built-in diagram editor", and "Interactive demo / playground" rows from the PRD feature tables; drop `template gallery` partner toggle.
- CHANGELOG: new `[Unreleased] → Removed` entry citing the three merged PRs and the LOC delta.

### 2. CTO direction adoption

Per the CTO Master verdict (May 1, 2026), README and PRD are refocused for the binding owner constraint: **internal tool only, no customers, no marketing, no growth-funnel telemetry, every feature must give a measurable productivity / correctness / observability win to a platform or cloud engineer running AWS/GCP→Azure migrations.**

- **README**: new Mission section ("value spine: `diagram → vision → mapping → IaC → ALZ → drift/cost`"), 7 operating principles (engineer-at-a-terminal <60s, machine-checkable outputs, Entra ID only, single tenant, reduction beats addition), engineer-win-keyed Capability Status table replacing the prior Live/Beta/Scaffold/Planned grid, **Spine Consolidation Plan** with three sequenced deletion PRs (PR-1 marketing surface ≈−500/−650 LOC, PR-2 product analytics ≈−800/−1,100 LOC, PR-3 multi-tenant + SSO collapse ≈−1,500/−2,000 LOC, cumulative ≈−2,800 to −3,750 LOC), and the **v5.0 north-star roadmap** (8 epics: spine consolidation, ALZ GA, GitHub IaC PR integration, drift loop closure, mapping coverage to 95%, CLI-first workflow, arch-rules Phase 2, observability SLOs).
- **PRD**: new `## 0. CTO Direction (May 1, 2026)` header at the top with mission, principles, cut-candidate section list, and the banned vocabulary set. Existing `§3.39 White-Label SDK`, `§3.40 Multi-Tenant Foundation`, `§12.1` PLG/SOC2 rows kept for historical traceability but flagged in §0 as out-of-scope.
- **CHANGELOG**: new `[Unreleased] → Changed` entry citing the CTO direction (mission, 7 principles, three deletion PRs, v5.0 roadmap, label policy, banned vocab, voice rules).

### Net diff

`README.md +99/−25 · PRD +44/−5 · CHANGELOG +51/0`. No code touched.

### Validation

- No code paths affected; backend/frontend test suites unchanged from `29bbe06` baseline (1767 / 271 passing).
- Trippe-checked: no remaining stale references to deleted Gallery/Playground/Canvas surfaces in active sections of README/PRD (changelog history retained intentionally).

### What this PR does NOT do

- Does **not** execute the three deletion PRs — those are scheduled separately (PR-1 next).
- Does **not** rename/retire GitHub issue labels — that's a follow-up housekeeping task.
- Does **not** add a CI lint enforcing the banned vocabulary — listed as a follow-up.
