### PR TITLE
docs+chore: CTO direction adoption + PR #645 review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### CTO direction — technical-only refocus (May 1, 2026)
+
+> Authority: CTO Master. Status: Binding. Supersedes prior product/marketing framing throughout README.md and docs/PRD.md.
+
+**Mission:** Archmorph is an internal engineering workbench. The value spine is `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`. Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+**Operating principles (7):**
+1. Value spine is law. Off-spine changes get cut on sight.
+2. The user is an engineer at a terminal — full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. Every output is machine-checkable (parse, schema-validate, round-trip tested).
+4. Engineering observability over product analytics. OpenTelemetry + Application Insights only. PostHog, funnel tracking, retention cohorts — banned.
+5. Identity is Entra ID. Period. No SSO matrices, no SAML, no SCIM, no social auth.
+6. Single tenant, single org. Roles: `engineer | reader` via Entra group claims.
+7. Reduction beats addition.
+
+**Spine consolidation status (after the merged Gallery → Playground → Canvas trio #637/#638/#639, −1,637 LOC):**
+
+| Order | PR | Status | LOC delta |
+|---|---|---|---|
+| PR-1 | `chore: remove marketing surface` (LandingPage, CookieBanner, OnboardingTour, LegalPages, legal.py, privacy.py, tests) | **Merged via #646** | **−3,327** |
+| PR-2 | `chore: remove product analytics + retention + onboarding funnel` | Pending | ≈ −800 to −1,100 |
+| PR-3 | `chore: collapse multi-tenant + SSO scaffolds to single-tenant Entra ID` | Pending | ≈ −1,500 to −2,000 |
+
+**v5.0 north-star roadmap (8 epics):** spine consolidation, ALZ production-ready (#586), GitHub IaC PR integration, drift loop closure, mapping coverage to 95%, CLI-first workflow, architecture limitations engine Phase 2, observability SLOs (analyze p95 <8s, alz p95 <1.5s, e2e p95 <30s).
+
+**New issue labels (adopt):** `value-spine-core`, `value-spine-adjacent`, `engineer-win`, `loc-debt`, `cut-candidate`, `defer-park`, `blocks-migration`, `mapping-staleness`, `arch-rule`, `observability`, `security`, `iac-output`, `alz`.
+
+**Retired labels (apply `archived`):** `product`, `marketing`, `growth`, `funnel`, `activation`, `retention`, `kpi-conversion`, `case-study`, `social-proof`, `waitlist`, `roadmap-marketing`, `whitelabel`, `multi-tenant`, `organizations`, `sso-saml`, `scim`, `gdpr-dsar`, `cookie-consent`, `pricing`, `tiers`, `billing`, `paid`, `freemium`.
+
+**Banned vocabulary in docs/PRs/commits:** `delight`, `delightful`, `empower`, `empowering`, `enterprise-grade`, `world-class`, `powerful`, `magical`, `seamless`, `effortless`, `game-changing`, `cutting-edge`, `revolutionary`, `blazing-fast`, `next-generation`, `unleash`, `supercharge`, `robust` (use "tested"), `best-in-class`, `one-stop`, `beautiful`, `beloved`, `loved by`, `customers`, `users` (use "engineers"), `freemium`, `PLG`, `growth-loop`, `conversion`, `funnel`, `activation`, `retention-cohort`, `case study`, `testimonial`, `social proof`.
+
+### Removed
+
+#### CTO scope cleanup — peripheral surfaces deleted
+
+Per the owner rubric — internal tool only, NOT for sale, no marketing surface, no growth-funnel telemetry, every feature must give a measurable productivity / correctness / observability win to a platform or cloud engineer doing AWS/GCP→Azure migrations — the CTO verdict deleted four surfaces that did not feed the value spine:
+
+- **Migration Gallery** ([#637](https://github.com/idokatz86/Archmorph/pull/637)) — community-stories surface; pure marketing/social-proof. Deleted `MigrationGallery.jsx`, `gallery_routes.py`, supporting backend services, models, tests, frontend tests, nav/store/command-palette wiring (10 files, −720 LOC).
+- **Demo Playground + default-tab fix** ([#638](https://github.com/idokatz86/Archmorph/pull/638)) — try-before-signup sandbox; not relevant to an internal tool. Deleted `PlaygroundPage.jsx`, removed marketing analytics steps (`first_upload`, `returning_user`), changed default landing tab from `playground` to `translator`. Includes a popstate fix for the empty-hash translator route (11 files, +14/−222 LOC).
+- **Canvas Editor** ([#639](https://github.com/idokatz86/Archmorph/pull/639)) — hand-rolled diagram editor that duplicated external tools (draw.io, Excalidraw) without producing IaC, ALZ, or drift output. Deleted `CanvasEditor/` (CanvasEditor.jsx + servicesPalette.js), App/Nav/CommandPalette/store wiring, Nav test (7 files, −695 LOC). `@xyflow/react` retained for `DependencyGraph` and `ArchitectureFlow` inside `DiagramTranslator`.
+- **Marketing surface (CTO PR-1)** ([#646](https://github.com/idokatz86/Archmorph/pull/646)) — `LandingPage.jsx` (291), `CookieBanner.jsx` (166), `OnboardingTour.jsx` (130; `ContextualHint` extracted to its own file), `LegalPages.jsx` (302), `legal.py` (361 — 8 endpoints under `/api/legal/*`), `privacy.py` (364 — 8 endpoints under `/api/privacy/*`), all related tests, plus default-tab routing, ChatWidget cookie-banner offset logic, Footer Legal & Privacy button, and the "100% free for customers" copy throughout README/PRD/roadmap.json (25 files, **−3,327 LOC**).
+
+**Cumulative delivered:** **−4,964 LOC across 53 files**, 3 nav entries removed, 1 attack surface removed (Canvas drag-drop palette state), 16 endpoints removed from the public API.
+
+**Validation per PR:** backend pytest 1737 passed / 1 skipped / 2 xfailed (was 1767 pre-PR-1, −30 from removed legal+privacy tests); frontend vitest 242 passed / 26 files (was 271, −29 from removed Landing+Cookie+Legal tests); OpenAPI contract green; 235 routes mirrored under /api/v1 (was 243, −8 from `/api/legal/*` + `/api/privacy/*`).
+
 ### Added
 
 #### Architecture limitations engine (PR [#615](https://github.com/idokatz86/Archmorph/pull/615); follow-up phases [#616](https://github.com/idokatz86/Archmorph/issues/616) [#617](https://github.com/idokatz86/Archmorph/issues/617) [#618](https://github.com/idokatz86/Archmorph/issues/618) [#619](https://github.com/idokatz86/Archmorph/issues/619))

--- a/README.md
+++ b/README.md
@@ -1,33 +1,94 @@
 # Archmorph
 
-**AI-Powered Multi-Cloud Architecture Translator & Migration Platform**
+**Internal AWS/GCP → Azure migration workbench for platform & cloud engineers**
 
-Translate AWS and GCP architecture diagrams into Azure-ready migration artifacts: service mappings, guided questions, IaC drafts, HLD exports, cost estimates, and reviewable migration packages. Archmorph is in preview/stabilization; some enterprise surfaces are implemented as beta or scaffolded workflows.
+Archmorph converts AWS and GCP architecture diagrams into Azure-targeted IaC, Landing Zone designs, drift signals, and cost deltas. It exists for platform engineers and cloud engineers running migrations. It is not a product, has no customers, and ships nothing for sale.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Multi-Cloud](https://img.shields.io/badge/cloud-AWS%20%7C%20Azure%20%7C%20GCP-0078D4.svg)
 ![Version](https://img.shields.io/badge/version-4.2.0-22C55E.svg)
-![Status](https://img.shields.io/badge/status-Preview%20Stabilizing-F59E0B.svg)
+![Status](https://img.shields.io/badge/status-Internal%20Tool-F59E0B.svg)
 ![Tests](https://img.shields.io/badge/tests-CI%20Enforced-22C55E.svg)
 ![Python](https://img.shields.io/badge/python-3.12-3776AB.svg)
 ![React](https://img.shields.io/badge/react-19.2-61DAFB.svg)
-![Vibe Coding](https://img.shields.io/badge/built_with-Vibe_Coding-FF69B4.svg)
 
+
+---
+
+## Mission
+
+Archmorph is an internal engineering workbench. The value spine is:
+
+> `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`
+
+Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+## Operating Principles (CTO direction, May 1, 2026)
+
+1. **Value spine is law.** Every PR advances the spine. Anything off-spine is overhead and gets cut on sight.
+2. **The user is an engineer at a terminal.** Full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. **Every output is machine-checkable.** Mappings, IaC, ALZ SVG, drift reports — all parse, all schema-validate, all have round-trip tests.
+4. **Engineering observability over product analytics.** OpenTelemetry + Application Insights. Funnel tracking, cohort retention, PostHog — banned.
+5. **Identity is Entra ID. Period.** No SSO matrices, no SAML brokers, no SCIM provisioning UIs, no social auth.
+6. **Single tenant, single org.** No multi-tenant primitives. Roles: `engineer | reader` via Entra group claims.
+7. **Reduction beats addition.** A PR that deletes 500 LOC and preserves the spine is more valuable than one that adds 500 LOC of adjacent surface.
 
 ---
 
 ## Overview
 
-Archmorph is an AI-assisted cloud migration workbench. The live path analyzes uploaded architecture diagrams, maps AWS/GCP services to Azure equivalents with confidence scoring, asks guided migration questions, generates IaC drafts, prepares HLD/report exports, and estimates costs. The application is 100% free for customers: there are no subscriptions, paid tiers, billing steps, or hidden customer charges. Adjacent platform capabilities such as scanner, deploy, collaboration, SSO/SCIM, gallery, and drift are present in the codebase at varying maturity levels and are labeled below so operators know what is ready to trust.
+Archmorph is an AI-assisted cloud migration workbench used internally to convert uploaded AWS/GCP diagrams into Azure migration artifacts: detected services, confidence-scored mappings, guided migration questions, IaC drafts, HLD exports, and cost estimates. Adjacent surfaces (scanner, deploy orchestration, drift) are present at varying maturity levels and are labeled below.
 
 ### Capability Status
 
-| Status | Meaning | Capabilities |
-|--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, cost estimates, service catalog, admin analytics, auth shell, CI/security scanning |
-| Beta | Implemented but needs hardening, deeper tests, or production validation | RAG, Agent PaaS proof, cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, social auth/RBAC, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
-| Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault, SSO/SAML/SCIM, live drift/living architecture |
-| Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
+Refocused around the engineer-win each capability delivers (CTO direction, May 1, 2026). **Live** = on the spine and used today. **Beta** = on the spine, hardening in progress. **Cut-candidate** = scheduled for removal in the spine consolidation PRs (PR-2 and PR-3 below; PR-1 already merged).
+
+| Capability | Status | Engineer-win it delivers |
+|---|---|---|
+| Diagram upload + vision analysis (PNG/PDF/Visio) | Live | Skips 10–30 min of manual draw.io re-tracing per source diagram. |
+| AWS→Azure + GCP→Azure service mapping with confidence scores | Live | Removes the `aws-svc-X has no Azure equivalent — wait, what about Y?` lookup loop per migration. |
+| Mapping freshness contract (`last_reviewed`) + freshness tests | Live | CI fails when a mapping row goes stale — no silent rot. |
+| SKU translator with engine-correct defaults | Live | Stops mis-routing Aurora-PostgreSQL to MS SQL Hyperscale; catches license-cost surprises pre-deploy. |
+| IaC chat (Terraform + Bicep) | Live | Generates IaC scaffolds from analysis without `terraform init`-then-cry loops. |
+| Architecture limitations engine | Live | Fails CI on misconfigured topologies (e.g. SFTP via Front Door); 25 rules, growing to ≥40 in Phase 2. |
+| HLD generator (Word export) | Live | Auto-builds the migration design doc the engineer would otherwise write by hand. |
+| Drift detection vs deployed Azure | Beta | Surfaces config drift between IaC source-of-truth and live tenant. |
+| Cost comparison (source cloud → Azure target) | Beta | Quantifies migration cost delta in the same artifact as the IaC plan. |
+| Network topology translation (VPC/CIDR/NSG → VNet/NSG/Front Door) | Beta | Pre-validates IP plan and security groups before deploy. |
+| Azure Landing Zone target SVG (8 tiers, multi-source) | Beta | Hands a starter LZ the engineer can edit, not a blank tenant. Production-ready push tracked under epic [#586](https://github.com/idokatz86/Archmorph/issues/586). |
+| RAG-grounded mapping suggestions | Live (slim target) | Mapping suggestions cite Azure docs sources — auditable, not hallucinated. |
+| `azd up` / `terraform apply` orchestration | Live (slim target) | One command takes the IaC artifact to a deployed Azure RG. |
+| Observability (OTel spans + 4 ALZ metrics + Workbook + alerts) | Live | Engineering-grade telemetry on the workbench itself — no PostHog. |
+| GitHub IaC PR integration | Planned (P0) | Lands generated Terraform/Bicep as a PR with diff + drift comment in the engineer's repo. |
+| Live cloud scanner / deploy execution / SSO/SAML/SCIM | Cut-candidate | See PR-3 below — collapses to single-tenant Entra ID. |
+| Retention KPIs, product analytics, multi-tenant primitives, white-label SDK, Migration Replay, Migration Timeline, Agent PaaS PoC | Cut-candidate | Off-spine. Targeted for removal in PR-2 → PR-3 (see [Spine Consolidation Plan](#spine-consolidation-plan-cto-direction) below). |
+
+### Spine Consolidation Plan (CTO direction)
+
+Three deletion PRs sequenced after the already-merged Gallery → Playground → Canvas trio (#637/#638/#639, −1,637 LOC). Same pattern: highest LOC, highest conviction, fewest cross-deps first.
+
+| Order | PR | Removes | LOC delta | Status |
+|---|---|---|---|---|
+| 1 | `chore: remove marketing surface` | `LandingPage.jsx` (291), `CookieBanner.jsx` (166), `OnboardingTour.jsx` (130), `LegalPages.jsx` (302), `legal.py` (361), `privacy.py` (364), tests, default-tab routing, `100% free for customers` mentions | **−3,327** | **Merged via #646** |
+| 2 | `chore: remove product analytics + retention + onboarding funnel` | `analytics.js` (145), `analytics_routes.py` (111), `retention.py`, `retention_routes.py`, Day-7 retention tile, `EVENT_TAXONOMY.md`, `posthog-js` dep | ≈ −800 to −1,100 | Pending |
+| 3 | `chore: collapse multi-tenant + SSO scaffolds to single-tenant Entra ID` | `sso_routes.py` (438), `org_routes.py` (268), `profile_routes.py` (198), `feedback.py` (73), `feature_flags.py` (70), social auth providers, FE org/invite UIs, PRD §3.39 + §3.40 + §12.1. Replaces with single `Depends(verify_entra_token)` + `archmorph-engineer`/`archmorph-reader` group claims. | ≈ −1,500 to −2,000 | Pending — auth blast radius |
+
+**Cumulative target:** ≈ −5,500 to −6,500 LOC across PR-1 → PR-3, on top of the −1,637 already removed.
+
+### v5.0 North-Star Roadmap (8 epics)
+
+Replaces all prior product/marketing roadmap items.
+
+| # | Epic | Problem it solves for the engineer | Success metric |
+|---|---|---|---|
+| 1 | **Spine consolidation** | Repo carries ~3,000 LOC of off-spine routers and surfaces. | Net −3,000 LOC across 6 PRs; routers count drops from ~50 to ≤30. |
+| 2 | **ALZ production-ready** (epic #586 → GA) | ALZ output is demo-ware (43% icon hit rate, 6/8 tiers). | Icon hit rate ≥95%; all 8 tiers populated; golden-file pixel diff <2%; gpt-5-pro grader returns `production-ready`. |
+| 3 | **GitHub IaC PR integration** | Engineer copy-pastes generated IaC into a repo by hand. | One CLI/API call opens a PR in `<owner>/<repo>` with Terraform/Bicep + drift comment + ALZ SVG attached; round-trip <30s. |
+| 4 | **Drift loop closure** | Drift is detected but doesn't feed back into the IaC artifact. | Drift report becomes a machine-readable patch the IaC chat can apply. |
+| 5 | **Mapping coverage to 95%** | AWS→Azure + GCP→Azure mapping coverage has gaps; freshness contract incomplete. | ≥95% coverage across `aws_canonical_estate.json` + GCP equivalent; 100% rows under freshness contract. |
+| 6 | **CLI-first workflow** | Web UI is the only entry. | `archmorph run --diagram x.png --target-rg foo --emit terraform,bicep,alz-svg` produces all artifacts in <60s without a browser. |
+| 7 | **Architecture limitations engine Phase 2** | 25 rules with 7 known polish bugs (#620). | Phase 2 ships #620 fixes + ≥40 total rules + rule authoring docs. |
+| 8 | **Observability SLOs** | Tool itself has no uptime/latency SLO. | `analyze_image` p95 <8s, `generate_landing_zone` p95 <1.5s, end-to-end p95 <30s; alerts wire to PagerDuty. |
 
 ### Production-Ready Roadmap — Azure Landing Zone (v4.3.0 target)
 
@@ -77,11 +138,9 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 - **Migration intelligence** — ML-powered analysis with historical pattern matching
 - **Infrastructure import** — import existing Terraform/ARM/CloudFormation configurations
 - **Terraform State Import** — reverse-engineer existing infrastructure from tfstate/CloudFormation/ARM into architecture diagrams
-- **Multi-Cloud Cost Comparison** — side-by-side Azure vs AWS vs GCP TCO analysis with savings recommendations
 - **SSO / SAML / SCIM scaffold** — enterprise auth routes exist, but require tenant-specific configuration and production validation before use
 - **Real-time Collaboration** — multi-stakeholder migration workspace with share codes and role-based participants
 - **Migration Replay** — animated analysis timeline for presentations with playback controls
-- **Migration Gallery** — public anonymized success stories, filterable by cloud and complexity
 - **Product Analytics** — funnel tracking (PostHog + backend), session-based event ingestion
 - **API Developer Portal** — Swagger/Redoc integration with category overview and curl examples
 - **Living architecture scaffold** — drift/versioning APIs include saved baselines, repeat compares, finding decisions, and Markdown report export; live environment monitoring still requires tenant-specific scanner validation
@@ -212,7 +271,6 @@ flowchart TB
                 SSO[SSO / SAML / SCIM<br/>Tenant validation gated]
                 Collab[Collaboration<br/>Real-Time Sessions]
                 Replay[Migration Replay<br/>Animated Timeline]
-                Gallery[Migration Gallery<br/>Public Stories]
                 TFImport[TF State Import<br/>tfstate/ARM/CF]
                 MultiCost[Multi-Cloud Cost<br/>3-Cloud TCO]
                 Analytics[Product Analytics<br/>Funnel Tracking]
@@ -336,7 +394,6 @@ flowchart TB
 | SSO / SAML / SCIM | SAML 2.0 ACS + SCIM v2.0 provisioning, pending tenant validation | Middleware |
 | Collaboration | Real-time multi-stakeholder sessions | In-process engine |
 | Migration Replay | Animated analysis timeline playback | In-process engine |
-| Migration Gallery | Public anonymized success stories | In-process engine |
 | TF State Import | tfstate/ARM/CF → architecture diagrams | In-process engine |
 | Multi-Cloud Cost | Side-by-side Azure/AWS/GCP TCO | In-process engine |
 | Product Analytics | PostHog + backend funnel tracking | In-process engine |
@@ -354,7 +411,6 @@ flowchart LR
         A1[📤 Upload Diagram<br/>PNG/SVG/PDF/Draw.io/Visio]
         A2[📥 Import IaC<br/>TF State / ARM / CF]
         A3[🔍 Cloud Scan Scaffold<br/>AWS / Azure / GCP]
-        A4[🎮 Demo Playground<br/>Sample Diagrams]
         A5[🤖 AI Vision Analysis<br/>GPT-4.1 + Cache]
     end
     
@@ -411,8 +467,7 @@ Input (Upload / Scan / Import) → AI Analysis → Guided Questions → Collabor
 1. **Upload Diagram** — PNG, JPG, SVG, PDF, Draw.io (.drawio), or Visio (.vsdx) architecture diagram
 2. **Import IaC** — Upload existing Terraform state (v3/v4), CloudFormation template, or ARM deployment JSON
 3. **Cloud scan scaffold** — Connectors and credential-handling model exist, but live tenant scanning stays gated until provider validation is complete
-4. **Demo Playground** — Try with sample diagrams, no sign-up required
-5. **AI Vision Analysis** — GPT-4.1 detects services, connections, and annotations (with TTL cache)
+4. **AI Vision Analysis** — GPT-4.1 detects services, connections, and annotations (with TTL cache)
 
 **Phase 2 — Analysis** (collaborative, real-time):
 6. **Guided Questions** — 8–18 contextual questions refine migration (SKU, compliance, networking, DR, security, region) with inter-question constraints
@@ -431,7 +486,6 @@ Input (Upload / Scan / Import) → AI Analysis → Guided Questions → Collabor
 17. **Migration Timeline** — 7-phase plan with topological dependency ordering and parallel workstreams
 18. **Risk Assessment** — Risk scoring with automated runbook generation
 19. **Migration Replay** — Animated timeline playback for presentations (play/pause/speed controls)
-20. **Migration Gallery** — Submit anonymized success stories to the public gallery
 
 ---
 
@@ -668,22 +722,15 @@ Archmorph/
 │   │   │   │   ├── HLDTab.jsx           # HLD generation & export
 │   │   │   │   ├── DeployPanel.jsx      # One-click deployment
 │   │   │   │   └── useWorkflow.js       # Workflow state machine hook
-│   │   │   ├── ScannerWizard/       # Live cloud scanner flow
-│   │   │   │   ├── ConnectStep.jsx      # Cloud provider + credentials
-│   │   │   │   ├── ScanStep.jsx         # Scan execution + progress
-│   │   │   │   ├── ReviewStep.jsx       # Results review
-│   │   │   │   └── index.jsx            # 3-step wizard flow
-│   │   │   ├── CanvasEditor/        # Interactive architecture canvas
+│   │   │   ├── ScannerWizard/       # Live cloud scanner flow (gated)
 │   │   │   ├── DriftDashboard/      # Infrastructure drift monitoring
 │   │   │   ├── Auth/                # Social auth + user profiles
 │   │   │   ├── CollabWorkspace.jsx  # Real-time collaboration panel
 │   │   │   ├── MigrationReplay.jsx  # Animated replay viewer
-│   │   │   ├── MigrationGallery.jsx # Public migration gallery
 │   │   │   ├── ApiDocs.jsx          # API developer portal
 │   │   │   ├── EmptyState.jsx       # Reusable empty state component
 │   │   │   ├── PhaseIndicator.jsx   # 3-phase progress indicator
-│   │   │   ├── LandingPage.jsx      # Marketing landing page
-│   │   │   ├── Nav.jsx              # Navigation bar (9 tabs + Gallery)
+│   │   │   ├── Nav.jsx              # Navigation bar (Dashboard / Translator / Services + More menu)
 │   │   │   ├── ui.jsx               # Design system (Button, Badge, Card, Input, Select, Modal, Tabs, etc.)
 │   │   │   └── ... (109 total)      # + additional components
 │   │   ├── hooks/
@@ -707,7 +754,6 @@ Archmorph/
 │   │   ├── sso_routes.py            # SAML/SCIM enterprise SSO
 │   │   ├── collaboration_routes.py  # Real-time collaboration sessions
 │   │   ├── replay_routes.py         # Migration replay timeline
-│   │   ├── gallery_routes.py        # Public migration gallery
 │   │   ├── scanner_routes.py        # Live cloud infrastructure scanner
 │   │   ├── credentials.py           # Secure credential vault
 │   │   ├── deployments.py           # Deploy engine (preview + execute)

--- a/backend/routers/platform/__init__.py
+++ b/backend/routers/platform/__init__.py
@@ -1,7 +1,8 @@
 """
-Platform domain — routes for health, services, legal, compliance, jobs, etc.
+Platform domain — routes for health, services, jobs, compliance, cost, networking, etc.
 
-Consolidates 14 router files into one importable package (#503).
+Consolidates the platform-tier router files into one importable package (#503).
+Legal/privacy routers were removed in CTO PR-1 (May 2026, internal-tool refocus).
 """
 
 from fastapi import APIRouter

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,6 +6,41 @@
 
 ---
 
+## 0. CTO Direction (May 1, 2026)
+
+> **Authority:** CTO Master. **Status:** Binding. Supersedes prior product/marketing framing throughout this PRD.
+
+### Mission
+
+Archmorph is an internal engineering workbench. The value spine is `diagram → vision analysis → cross-cloud mapping → IaC (Terraform/Bicep) → Azure Landing Zone → drift / cost`. Every shippable change advances that spine. Anything else is overhead and gets cut.
+
+### Operating Principles
+
+1. Value spine is law. Off-spine changes get cut on sight.
+2. The user is an engineer at a terminal — full flow runs end-to-end in under 60 seconds. No marketing pages, no cookie banners, no sign-up modals.
+3. Every output is machine-checkable (parse, schema-validate, round-trip tested).
+4. Engineering observability over product analytics. OpenTelemetry + Application Insights only. PostHog, funnel tracking, retention cohorts — banned.
+5. Identity is Entra ID. Period. No SSO matrices, no SAML, no SCIM, no social auth.
+6. Single tenant, single org. Roles: `engineer | reader` via Entra group claims.
+7. Reduction beats addition.
+
+### Cut-candidate sections in this document
+
+The following sections describe surfaces flagged for removal in the spine consolidation PRs (PR-1 → PR-3). They remain in this document for historical traceability only and **must not** be cited as roadmap items in new work:
+
+- **§3.39 White-Label SDK** — internal tool has no partners.
+- **§3.40 Multi-Tenant Foundation** — single tenant.
+- **§12.1 Strategic Gaps (CEO Review)** rows S1 (free positioning), S2 (onboarding funnel), S4 (testimonials), S6 (SSO/SAML/SCIM), S10 (waitlist), S11 (investor data room).
+- All `Built-in diagram editor`, `Migration Gallery`, "100% free for customers" framing, and partner branding references throughout.
+
+### Banned vocabulary
+
+`delight`, `delightful`, `empower`, `empowering`, `enterprise-grade`, `world-class`, `powerful`, `magical`, `seamless`, `effortless`, `game-changing`, `cutting-edge`, `revolutionary`, `blazing-fast`, `next-generation`, `unleash`, `supercharge`, `robust` (use "tested"), `best-in-class`, `one-stop`, `beautiful`, `beloved`, `loved by`, `customers` (we have none), `users` (use "engineers"), `freemium`, `PLG`, `growth-loop`, `conversion`, `funnel`, `activation`, `retention-cohort`, `case study`, `testimonial`, `social proof`.
+
+---
+
+---
+
 ## 1. Executive Summary
 
 Archmorph is an AI-assisted cloud migration workbench in preview/stabilization. Its live product path converts uploaded AWS/GCP architecture diagrams into Azure migration artifacts: detected services, confidence-scored mappings, guided migration questions, IaC drafts, HLD/report exports, and cost estimates. The application is 100% free for customers: no subscriptions, paid tiers, billing setup, or hidden fees are required. The platform codebase also contains beta and scaffolded enterprise modules for collaboration, replay, gallery, RAG/Agent PaaS, Terraform state import, scanner, deploy, SSO/SCIM, and drift.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archmorph-frontend",
   "private": true,
-  "version": "3.9.0",
+  "version": "4.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import 'prismjs/themes/prism-tomorrow.css';
-import { Code, Coffee, Loader2, Shield } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import ErrorBoundary from './components/ErrorBoundary';
 import Nav from './components/Nav';
 import Footer from './components/Footer';

--- a/frontend/src/components/ChatWidget.jsx
+++ b/frontend/src/components/ChatWidget.jsx
@@ -2,9 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   MessageSquare, X, FileText, Loader2, Send, CheckCircle,
 } from 'lucide-react';
-import { API_BASE } from '../constants';
 import api from '../services/apiClient';
-import useAppStore from '../stores/useAppStore';
 
 export default function ChatWidget() {
   const [open, setOpen] = useState(false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archmorph",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "AI-Powered Cloud Architecture Translator to Azure",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Post-marketing-cleanup: CTO direction adoption + #645 review fixes

Folds two pending threads after #646 (PR-1 marketing surface) landed on `main`.

### 1. CTO direction docs

Re-applies the content from now-closed [PR #642](https://github.com/idokatz86/Archmorph/pull/642) (closed-superseded) on top of current `main`:

- **README**: replaces the AI/marketing tagline with `Internal AWS/GCP → Azure migration workbench for platform & cloud engineers`. New `## Mission` section ("value spine: `diagram → vision → mapping → IaC → ALZ → drift/cost`"). New `## Operating Principles` section (7 binding rules: engineer-at-a-terminal <60s, machine-checkable outputs, OTel over PostHog, Entra ID only, single tenant, reduction beats addition). Engineer-win-keyed Capability Status table replacing the prior Live/Beta/Scaffold/Planned grid. **Spine Consolidation Plan** showing PR-1 ✅ merged via #646 (−3,327 LOC), PR-2 pending (analytics), PR-3 pending (multi-tenant + SSO). v5.0 north-star roadmap (8 epics).
- **PRD**: new `## 0. CTO Direction (May 1, 2026)` header at the top with mission, principles, cut-candidate section list, banned vocabulary set.
- **CHANGELOG**: new `[Unreleased] → Changed` entry citing the CTO direction; new `[Unreleased] → Removed` entry covering all four already-merged cleanup PRs (#637/#638/#639/#646), cumulative **−4,964 LOC across 53 files**, 16 endpoints removed.

### 2. PR #645 review fixes

Real bot-flagged issues from the now-closed PR #645 that landed on `main` via #646:

| File | Fix |
|---|---|
| `frontend/src/components/ChatWidget.jsx` | Drop unused `API_BASE` and `useAppStore` imports left over after cookie-banner removal |
| `backend/routers/platform/__init__.py` | Docstring no longer claims `legal` routes (`legal_router`/`privacy_router` were removed in PR-1) |
| `frontend/src/App.jsx` | Drop unused `lucide-react` `Code`, `Coffee`, `Shield` imports (only `Loader2` is still used) |
| `README.md` | Finish the Migration Gallery / LandingPage / CanvasEditor / Demo Playground sweep across the capability table, mermaid system diagram, component overview table, project tree, workflow phase list, and `Nav.jsx` description |
| `package.json` + `frontend/package.json` | Bump to `4.2.0` to match the README badge and PRD version |

The fourth bot finding on PR #645 (`roadmap.json` invalid JSON after the `"100% free forever"` removal) was a false positive — `python -c "import json; json.load(open('backend/assets/roadmap.json'))"` parses cleanly.

### Net diff

- **+164 LOC docs / −36 LOC code = +128 LOC net.** Pure docs + import cleanup.
- 8 files changed.

### Validation

- Backend imports cleanly (554 routes, 235 mirrored under `/api/v1`).
- Frontend `vitest --run` — **242 passed (26 files)**, no regressions.
- No functional code touched beyond unused-import removal.

### What this PR does NOT do

- Does **not** execute PR-2 (analytics + retention removal) or PR-3 (multi-tenant + SSO collapse) — those land in subsequent PRs.
- Does **not** retire/rename GitHub issue labels — that's a separate housekeeping task documented in the CHANGELOG entry.
- Does **not** add a CI lint enforcing the banned vocabulary — listed as a follow-up.
