### PR TITLE
fix(services): hot-reload live catalog after refresh — closes #647 Part 1 [PRIORITY: HIGH — merge first]

### DIFF
--- a/backend/service_updater.py
+++ b/backend/service_updater.py
@@ -179,6 +179,19 @@ DISCOVERED_BLOB_CONTAINER = os.getenv("DISCOVERED_BLOB_CONTAINER", "service-cata
 DISCOVERED_BLOB_NAME = os.getenv(
     "DISCOVERED_BLOB_NAME", "discovered_services.json"
 )
+DISCOVERED_BLOB_TIMEOUT_SECONDS = 5
+
+
+def _blob_timeout_seconds() -> int:
+    """Return the bounded timeout used for blob catalog operations."""
+    raw = os.getenv("DISCOVERED_BLOB_TIMEOUT_SECONDS", "")
+    if not raw:
+        return DISCOVERED_BLOB_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DISCOVERED_BLOB_TIMEOUT_SECONDS
+    return max(1, min(value, 30))
 
 
 def _get_discovered_blob_client():
@@ -187,6 +200,7 @@ def _get_discovered_blob_client():
     conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "")
     if not account_url and not conn_str:
         return None
+    timeout = _blob_timeout_seconds()
     try:
         from azure.storage.blob import BlobServiceClient
 
@@ -196,15 +210,24 @@ def _get_discovered_blob_client():
             credential = DefaultAzureCredential(
                 managed_identity_client_id=os.getenv("AZURE_CLIENT_ID") or None
             )
-            bsc = BlobServiceClient(account_url, credential=credential)
+            bsc = BlobServiceClient(
+                account_url,
+                credential=credential,
+                connection_timeout=timeout,
+                read_timeout=timeout,
+            )
         else:
-            bsc = BlobServiceClient.from_connection_string(conn_str)
+            bsc = BlobServiceClient.from_connection_string(
+                conn_str,
+                connection_timeout=timeout,
+                read_timeout=timeout,
+            )
 
         container = bsc.get_container_client(DISCOVERED_BLOB_CONTAINER)
         try:
-            container.get_container_properties()
+            container.get_container_properties(timeout=timeout)
         except Exception:
-            container.create_container()
+            container.create_container(timeout=timeout)
             logger.info(
                 "Created blob container '%s' for discovered services",
                 DISCOVERED_BLOB_CONTAINER,
@@ -224,7 +247,7 @@ def _load_discovered_from_blob() -> Optional[dict[str, list[dict[str, str]]]]:
     if blob is None:
         return None
     try:
-        raw = blob.download_blob().readall()
+        raw = blob.download_blob(timeout=_blob_timeout_seconds()).readall()
         data = json.loads(raw)
         if isinstance(data, dict):
             # Hydrate the local cache so import-time consumers see it too.
@@ -237,7 +260,13 @@ def _load_discovered_from_blob() -> Optional[dict[str, list[dict[str, str]]]]:
             return data
     except Exception as exc:  # noqa: BLE001
         # ResourceNotFoundError on a fresh deployment is expected.
-        logger.debug("No discovered-services blob yet (%s)", type(exc).__name__)
+        if type(exc).__name__ == "ResourceNotFoundError":
+            logger.debug("No discovered-services blob yet (%s)", type(exc).__name__)
+        else:
+            logger.warning(
+                "Failed to load discovered services from blob; falling back to disk",
+                exc_info=True,
+            )
     return None
 
 
@@ -753,7 +782,11 @@ def run_update_now(*, auto_add: bool = True) -> dict[str, Any]:
                 counts["aws"], counts["azure"], counts["gcp"],
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Live catalog reload failed (non-fatal): %s", exc)
+            logger.warning(
+                "Live catalog reload failed (non-fatal): %s",
+                exc,
+                exc_info=True,
+            )
 
     logger.info("Service catalog update complete.")
     return check_record

--- a/backend/service_updater.py
+++ b/backend/service_updater.py
@@ -740,6 +740,21 @@ def run_update_now(*, auto_add: bool = True) -> dict[str, Any]:
         state["auto_added"][provider] = sorted(existing_added)
 
     _write_state(state)
+
+    # Issue #647 — re-merge static + discovered catalogs in place so live API
+    # responses reflect new discoveries without requiring a container restart.
+    # Best-effort: if reload fails (test isolation, partial init), log and continue.
+    if any(auto_added[p] for p in ("aws", "azure", "gcp")):
+        try:
+            import services as _services_mod
+            counts = _services_mod.reload()
+            logger.info(
+                "Live catalog reloaded after refresh: aws=%d azure=%d gcp=%d",
+                counts["aws"], counts["azure"], counts["gcp"],
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Live catalog reload failed (non-fatal): %s", exc)
+
     logger.info("Service catalog update complete.")
     return check_record
 

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -17,7 +17,28 @@ _DISCOVERED_FILE = Path(__file__).resolve().parent.parent / "data" / "discovered
 
 
 def _load_discovered() -> dict[str, list[dict]]:
-    """Load discovered services from the JSON data file."""
+    """Load discovered services from the JSON data file.
+
+    Issue #647 — also consults the durable Azure Blob mirror (when configured)
+    via service_updater._load_discovered_from_blob, so a fresh container that
+    boots before its first refresh still picks up the cumulative discoveries
+    rather than serving the static-only catalog.
+    """
+    # Try blob first when available — this is the source of truth on stateless
+    # container deployments (Azure Container Apps wipe the disk on restart).
+    try:
+        # Local import to avoid module-load circular: service_updater imports
+        # this module's _load_discovered when called from run_update_now after
+        # write, but it does not need the blob loader at import time.
+        from service_updater import _load_discovered_from_blob
+
+        blob_data = _load_discovered_from_blob()
+        if blob_data is not None:
+            return blob_data
+    except Exception:  # noqa: BLE001
+        # service_updater unavailable (test isolation, etc.) — fall through to disk.
+        pass
+
     try:
         with open(_DISCOVERED_FILE, "r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -39,18 +60,73 @@ def _merge(static: list[dict], discovered: list[dict]) -> list[dict]:
     return merged
 
 
-_discovered = _load_discovered()
-AWS_SERVICES = _merge(_AWS_STATIC, _discovered.get("aws", []))
-AZURE_SERVICES = _merge(_AZURE_STATIC, _discovered.get("azure", []))
-GCP_SERVICES = _merge(_GCP_STATIC, _discovered.get("gcp", []))
+# ---------------------------------------------------------------------------
+# Module-level catalog lists (issue #647 — kept as the same list objects across
+# reload() calls so existing `from services import AWS_SERVICES` references
+# stay valid; reload mutates in place via clear()+extend()).
+# ---------------------------------------------------------------------------
+AWS_SERVICES: list[dict] = []
+AZURE_SERVICES: list[dict] = []
+GCP_SERVICES: list[dict] = []
 
-if any(_discovered.get(p) for p in ("aws", "azure", "gcp")):
-    _total = (
-        len(AWS_SERVICES) - len(_AWS_STATIC)
-        + len(AZURE_SERVICES) - len(_AZURE_STATIC)
-        + len(GCP_SERVICES) - len(_GCP_STATIC)
-    )
-    if _total > 0:
-        logger.info("Merged %d discovered services from %s", _total, _DISCOVERED_FILE.name)
 
-__all__ = ["AWS_SERVICES", "AZURE_SERVICES", "GCP_SERVICES", "CROSS_CLOUD_MAPPINGS"]
+def reload() -> dict[str, int]:
+    """Re-merge static + discovered catalogs in place.
+
+    Issue #647 — the merged lists were previously bound once at module-import
+    time, so refreshes that wrote to ``discovered_services.json`` after boot
+    were invisible to ``/api/services/providers`` until container restart.
+    ``service_updater.run_update_now`` calls this on success so live API
+    responses reflect the latest discoveries.
+
+    Returns a dict of ``{provider: total_count}`` after reload.
+    """
+    discovered = _load_discovered()
+
+    new_aws = _merge(_AWS_STATIC, discovered.get("aws", []))
+    new_azure = _merge(_AZURE_STATIC, discovered.get("azure", []))
+    new_gcp = _merge(_GCP_STATIC, discovered.get("gcp", []))
+
+    # Mutate in place so existing `from services import AWS_SERVICES` references
+    # see the new entries without needing a re-import.
+    AWS_SERVICES.clear()
+    AWS_SERVICES.extend(new_aws)
+    AZURE_SERVICES.clear()
+    AZURE_SERVICES.extend(new_azure)
+    GCP_SERVICES.clear()
+    GCP_SERVICES.extend(new_gcp)
+
+    counts = {
+        "aws": len(AWS_SERVICES),
+        "azure": len(AZURE_SERVICES),
+        "gcp": len(GCP_SERVICES),
+    }
+
+    if any(discovered.get(p) for p in ("aws", "azure", "gcp")):
+        added = (
+            (len(AWS_SERVICES) - len(_AWS_STATIC))
+            + (len(AZURE_SERVICES) - len(_AZURE_STATIC))
+            + (len(GCP_SERVICES) - len(_GCP_STATIC))
+        )
+        if added > 0:
+            logger.info(
+                "Catalog reloaded: %d discovered services merged (aws=%d azure=%d gcp=%d)",
+                added,
+                counts["aws"],
+                counts["azure"],
+                counts["gcp"],
+            )
+
+    return counts
+
+
+# Initial load at module import.
+reload()
+
+__all__ = [
+    "AWS_SERVICES",
+    "AZURE_SERVICES",
+    "GCP_SERVICES",
+    "CROSS_CLOUD_MAPPINGS",
+    "reload",
+]

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -35,9 +35,16 @@ def _load_discovered() -> dict[str, list[dict]]:
         blob_data = _load_discovered_from_blob()
         if blob_data is not None:
             return blob_data
-    except Exception:  # noqa: BLE001
-        # service_updater unavailable (test isolation, etc.) — fall through to disk.
-        pass
+    except ImportError as exc:
+        logger.debug(
+            "Blob catalog bootstrap unavailable; falling back to disk: %s",
+            exc,
+        )
+    except Exception:
+        logger.warning(
+            "Blob catalog bootstrap failed; falling back to disk",
+            exc_info=True,
+        )
 
     try:
         with open(_DISCOVERED_FILE, "r", encoding="utf-8") as fh:
@@ -120,7 +127,8 @@ def reload() -> dict[str, int]:
     return counts
 
 
-# Initial load at module import.
+# Initial load at module import. Blob bootstrap uses bounded Azure SDK timeouts
+# so startup falls back quickly to local disk when storage is slow/unavailable.
 reload()
 
 __all__ = [

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -620,7 +620,7 @@ class TestServicesReload:
         """
         import services
         import service_updater
-        from unittest.mock import patch as _patch, MagicMock
+        from unittest.mock import patch as _patch
 
         # Sentinel function to detect the reload call
         reload_called = {"count": 0}

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -536,3 +536,159 @@ class TestBlobPersistence:
             result = _load_discovered_services()
             assert result["aws"][0]["id"] == "aws-from-blob"
 
+
+# ====================================================================
+# Issue #647 — services.reload() and refresh-time hot reload
+# ====================================================================
+
+class TestServicesReload:
+    def test_reload_function_exists(self):
+        import services
+        assert hasattr(services, "reload"), (
+            "services.reload() missing — required by issue #647 so live API "
+            "reflects discoveries without container restart."
+        )
+        assert callable(services.reload)
+
+    def test_reload_returns_counts(self):
+        import services
+        counts = services.reload()
+        assert isinstance(counts, dict)
+        assert set(counts.keys()) >= {"aws", "azure", "gcp"}
+        assert all(isinstance(v, int) and v > 0 for v in counts.values())
+
+    def test_lists_are_same_object_across_reloads(self):
+        """Critical contract: reload() must mutate in place, not rebind.
+
+        Otherwise `from services import AWS_SERVICES` references in routers
+        would still point at the old list after a refresh.
+        """
+        import services
+        before = services.AWS_SERVICES
+        services.reload()
+        after = services.AWS_SERVICES
+        assert before is after, (
+            "AWS_SERVICES list identity changed across reload(); routers that "
+            "imported by name will still see the old list."
+        )
+
+    def test_reload_picks_up_new_discovered_entries(self, tmp_path, monkeypatch):
+        """After writing a new entry to discovered_services.json, reload() picks it up."""
+        import json as _json
+        import services
+
+        # Static-only baseline: reload from a fresh empty discovery file first
+        empty_disc = tmp_path / "empty.json"
+        empty_disc.write_text('{"aws": [], "azure": [], "gcp": []}', encoding="utf-8")
+        monkeypatch.setattr(services, "_DISCOVERED_FILE", empty_disc)
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_URL", "")
+        monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+        services.reload()
+        baseline_aws = len(services.AWS_SERVICES)
+
+        # Now point at a discovery file with one synthetic entry
+        disc = tmp_path / "discovered.json"
+        disc.write_text(_json.dumps({
+            "aws": [
+                {"id": "aws-647-test-svc", "name": "Reload Test Svc",
+                 "fullName": "AWS Reload Test", "category": "Other",
+                 "description": "test", "icon": "cloud"},
+            ],
+            "azure": [],
+            "gcp": [],
+        }), encoding="utf-8")
+        monkeypatch.setattr(services, "_DISCOVERED_FILE", disc)
+
+        services.reload()
+
+        try:
+            assert len(services.AWS_SERVICES) == baseline_aws + 1
+            assert any(
+                s.get("id") == "aws-647-test-svc" for s in services.AWS_SERVICES
+            ), "newly-discovered entry not visible after reload()"
+        finally:
+            # Restore: reload from the real discovery file so other tests see
+            # the canonical state.
+            monkeypatch.undo()
+            services.reload()
+
+    def test_run_update_now_triggers_reload(self, tmp_path, monkeypatch):
+        """run_update_now must call services.reload() when discoveries are saved.
+
+        Issue #647 — without this hook, refresh writes data nobody can read
+        until container restart.
+        """
+        import services
+        import service_updater
+        from unittest.mock import patch as _patch, MagicMock
+
+        # Sentinel function to detect the reload call
+        reload_called = {"count": 0}
+        original_reload = services.reload
+
+        def tracking_reload():
+            reload_called["count"] += 1
+            return original_reload()
+
+        # Stub fetchers to return a synthetic new service so auto_added is non-empty
+        def fake_fetch(_client):
+            return {"NewSyntheticService647"}
+
+        def empty_fetch(_client):
+            return set()
+
+        # Use tmp paths for state + discovered file to avoid polluting real data
+        with _patch.object(services, "reload", tracking_reload), \
+             _patch("service_updater._fetch_aws_services", fake_fetch), \
+             _patch("service_updater._fetch_azure_services", empty_fetch), \
+             _patch("service_updater._fetch_gcp_services", empty_fetch), \
+             _patch("service_updater._UPDATES_FILE", tmp_path / "state.json"), \
+             _patch("service_updater._DISCOVERED_FILE", tmp_path / "discovered.json"), \
+             _patch("service_updater._DATA_DIR", tmp_path), \
+             _patch("service_updater._get_discovered_blob_client", return_value=None):
+            service_updater.run_update_now(auto_add=True)
+
+        assert reload_called["count"] == 1, (
+            "services.reload() was not called by run_update_now; live catalog "
+            "will not reflect new discoveries until container restart."
+        )
+
+    def test_run_update_now_skips_reload_when_no_changes(self, tmp_path):
+        """No discoveries → no reload (avoid wasted work)."""
+        import services
+        import service_updater
+        from unittest.mock import patch as _patch
+
+        reload_called = {"count": 0}
+        original_reload = services.reload
+
+        def tracking_reload():
+            reload_called["count"] += 1
+            return original_reload()
+
+        # Make every fetcher return the empty set against an empty local
+        # catalog — guaranteed zero new services for every provider.
+        def empty_fetch(_client):
+            return set()
+
+        def empty_local_catalog(_provider):
+            # (service_list, normalised name set)
+            return [], set()
+
+        with _patch.object(services, "reload", tracking_reload), \
+             _patch("service_updater._fetch_aws_services", empty_fetch), \
+             _patch("service_updater._fetch_azure_services", empty_fetch), \
+             _patch("service_updater._fetch_gcp_services", empty_fetch), \
+             _patch("service_updater._load_local_catalog", empty_local_catalog), \
+             _patch("service_updater._UPDATES_FILE", tmp_path / "state.json"), \
+             _patch("service_updater._DISCOVERED_FILE", tmp_path / "discovered.json"), \
+             _patch("service_updater._DATA_DIR", tmp_path), \
+             _patch("service_updater._get_discovered_blob_client", return_value=None):
+            service_updater.run_update_now(auto_add=True)
+
+        assert reload_called["count"] == 0, (
+            "reload() was called even though no new services were discovered; "
+            "this is wasted work."
+        )
+
+


### PR DESCRIPTION
## Priority & merge order

**🔴 HIGH PRIORITY — MERGE FIRST.**

This PR converts the work shipped in #641 (durable refresh pipeline) into actual customer-visible value. Without it, the daily refresh detects ~473 new services / day but `/api/services/providers` keeps serving the static 485 until container restart.

**Merge order in this branch:**
1. ✅ #641 (merged) — durable refresh pipeline
2. ✅ #646 (merged) — workflow URL prefix hotfix
3. **➡️ THIS PR (#647 Part 1) — merge next**
4. PR for #640 (medium priority) — generalized freshness guardrail, structural follow-up

## Summary

After #641, production refresh runs successfully and writes to `discovered_services.json` + Azure Blob. But `AWS_SERVICES` / `AZURE_SERVICES` / `GCP_SERVICES` were bound once at module-import time in `backend/services/__init__.py` and never re-merged, so the live API kept serving the static catalog.

**Verified live right now**: `/api/service-updates/last` reports aws=174, azure=69, gcp=230 detected per refresh, but `/api/services/providers.serviceCount` returns the static `aws=174, azure=168, gcp=143` (= 485 total, not the 949 the refresh actually computed).

## Fix

| File | Change |
|---|---|
| `backend/services/__init__.py` | Extract merge logic into `services.reload()` that re-runs static + discovered merge **in place** via `list.clear() + list.extend()`. Preserves list identity so existing `from services import AWS_SERVICES` references in routers stay valid without re-import. |
| `backend/services/__init__.py` | `_load_discovered()` now consults the durable Azure Blob mirror first when available (via `service_updater._load_discovered_from_blob`), so a fresh container that boots before its first refresh still picks up cumulative discoveries. |
| `backend/service_updater.py` | `run_update_now()` calls `services.reload()` after a successful save with non-zero `auto_added`. Best-effort: reload failures are logged warning and do not abort the refresh. |
| `backend/tests/test_service_updater.py` | +6 net-new tests in `TestServicesReload`: function exists, list-identity preserved, picks up new discoveries, hot-reload triggered on auto_added, skipped when no changes, returns counts dict. |

## Tests

- 70/70 `service_updater` tests pass (+6 net new)
- Full backend suite: **1743 passed / 1 skipped / 2 xfailed** — zero regressions
- Critical contract test: `assert before is after` — guarantees `from services import AWS_SERVICES` references in `routers/services.py`, `routers/health.py`, etc. remain valid after reload (no need to re-import)

## What still needs to happen after merge (Part 2 of #647)

The blob-persistence helpers in `service_updater.py` are best-effort and silent if no env vars are set. Production verification needs Azure CLI access:

- [ ] Inspect Container App env vars; confirm `AZURE_STORAGE_ACCOUNT_URL` is set (already used by `services/azure_pricing.py` for pricing cache, so this is likely already configured).
- [ ] Confirm system-assigned identity has `Storage Blob Data Contributor` on the storage account.
- [ ] Trigger a refresh post-deploy; confirm via Azure CLI that blob `service-catalog/discovered_services.json` exists.
- [ ] Restart the container; confirm next `/api/services/providers` call shows merged counts (i.e. blob → boot → merge → live response).

## Validation criterion (post-merge + post-deploy)

```bash
curl https://api.archmorphai.com/api/services/providers \
  | jq '.providers | map(.serviceCount) | add'
# Expected: ≥ 717 within 24h of a successful refresh
# Expected: stays ≥ 717 across at least one container restart
```

## Risk

**Low.** Additive change. List identity preservation tested explicitly (the only way this could break callers). Reload errors are caught and logged — refresh never aborts on reload failure.

Refs #571 #641.