### PR TITLE
feat(export): add Architecture Package HTML/SVG exports

### DIFF
--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -1,0 +1,312 @@
+"""Customer-facing architecture package exports.
+
+The package renderer keeps Archmorph's architecture analysis as the source of
+truth and treats HTML/SVG as presentation targets. It composes the existing
+Azure Landing Zone SVG renderer with a small customer-intent profile and
+customer-safe talking points.
+"""
+
+from __future__ import annotations
+
+import copy
+import html
+import re
+from dataclasses import dataclass, asdict
+from typing import Any, Literal
+
+from azure_landing_zone import generate_landing_zone_svg
+from azure_landing_zone_schema import infer_dr_mode, infer_regions, infer_tiers_from_mappings
+
+
+PackageFormat = Literal["html", "svg"]
+DiagramVariant = Literal["primary", "dr"]
+
+
+@dataclass(frozen=True)
+class CustomerIntentProfile:
+    """Compact, presentation-safe view of guided-question answers."""
+
+    environment: str = "Production"
+    region: str = "West Europe"
+    availability: str = "Multi-AZ within region (99.95 %)"
+    rto: str = "<1 hour"
+    compliance: str = "None"
+    data_residency: str = "No restriction"
+    network_isolation: str = "VNet integration"
+    sku_strategy: str = "Balanced (good performance-to-cost ratio)"
+    iac_style: str = "Terraform (HCL)"
+
+
+def build_customer_intent_profile(answers: dict[str, Any] | None) -> dict[str, str]:
+    """Build a stable profile from guided-question answers.
+
+    Unknown fields are ignored and list answers are rendered as comma-separated
+    strings so the profile can safely travel through JSON, HTML, and reports.
+    """
+    answers = answers or {}
+
+    def value(key: str, default: str) -> str:
+        raw = answers.get(key, default)
+        if isinstance(raw, list):
+            return ", ".join(str(item) for item in raw if item) or default
+        if raw is None:
+            return default
+        text = str(raw).strip()
+        return text or default
+
+    profile = CustomerIntentProfile(
+        environment=value("env_target", "Production"),
+        region=value("arch_deploy_region", "West Europe"),
+        availability=value("arch_ha", "Multi-AZ within region (99.95 %)"),
+        rto=value("arch_dr_rto", "<1 hour"),
+        compliance=value("sec_compliance", "None"),
+        data_residency=value("sec_data_residency", "No restriction"),
+        network_isolation=value("sec_network_isolation", "VNet integration"),
+        sku_strategy=value("arch_sku_strategy", "Balanced (good performance-to-cost ratio)"),
+        iac_style=value("arch_iac_style", "Terraform (HCL)"),
+    )
+    return asdict(profile)
+
+
+def generate_architecture_package(
+    analysis: dict[str, Any],
+    *,
+    format: PackageFormat = "html",
+    diagram: DiagramVariant = "primary",
+) -> dict[str, str]:
+    """Generate the architecture package in HTML or SVG form."""
+    if format not in ("html", "svg"):
+        raise ValueError("format must be 'html' or 'svg'")
+    if diagram not in ("primary", "dr"):
+        raise ValueError("diagram must be 'primary' or 'dr'")
+    if not isinstance(analysis, dict):
+        raise ValueError("analysis must be a dict")
+
+    if format == "svg":
+        result = generate_landing_zone_svg(analysis, dr_variant=diagram)
+        return {
+            "format": "architecture-package-svg",
+            "filename": result["filename"].replace("landing-zone", "architecture-package"),
+            "content": result["content"],
+        }
+
+    primary_svg = _namespace_svg_ids(
+        _strip_xml_declaration(generate_landing_zone_svg(analysis, dr_variant="primary")["content"]),
+        "primary",
+    )
+    dr_svg = _namespace_svg_ids(
+        _strip_xml_declaration(generate_landing_zone_svg(analysis, dr_variant="dr")["content"]),
+        "dr",
+    )
+    content = _render_html_package(analysis, primary_svg, dr_svg)
+    return {
+        "format": "architecture-package-html",
+        "filename": f"archmorph-{_safe_filename(analysis)}-architecture-package.html",
+        "content": content,
+    }
+
+
+def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str) -> str:
+    title = html.escape(str(analysis.get("title") or "Azure Architecture Package"))
+    source = html.escape(str(analysis.get("source_provider") or "AWS").upper())
+    profile = _profile_from_analysis(analysis)
+    intent_rows = "\n".join(
+        f"<div><span>{html.escape(label)}</span><strong>{html.escape(value)}</strong></div>"
+        for label, value in _profile_rows(profile)
+    )
+    talking_points = "\n".join(
+        f"<li>{html.escape(point)}</li>" for point in _talking_points(analysis, profile)
+    )
+    limitations = "\n".join(
+        f"<li>{html.escape(item)}</li>" for item in _limitations(analysis, profile)
+    )
+    tier_summary = "\n".join(
+        f"<li><strong>{html.escape(tier.title())}</strong><span>{html.escape(', '.join(names) or 'No service inferred')}</span></li>"
+        for tier, names in _tier_summary(analysis)
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title}</title>
+  <style>
+    :root {{ color-scheme: light; --ink:#172033; --muted:#526178; --line:#d9e0ea; --azure:#0078d4; --bg:#f6f8fb; --card:#ffffff; }}
+    * {{ box-sizing: border-box; }}
+    body {{ margin: 0; background: var(--bg); color: var(--ink); font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif; }}
+    header {{ padding: 22px 28px 16px; background: #fff; border-bottom: 1px solid var(--line); }}
+    h1 {{ margin: 0; font-size: 24px; line-height: 1.2; letter-spacing: 0; }}
+    header p {{ margin: 6px 0 0; color: var(--muted); font-size: 13px; }}
+    nav {{ display: flex; gap: 8px; padding: 12px 28px; background: #fff; border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 2; }}
+    button.tab {{ border: 1px solid var(--line); background: #fff; color: var(--ink); border-radius: 8px; padding: 8px 12px; font: inherit; font-size: 13px; cursor: pointer; }}
+    button.tab[aria-selected="true"] {{ background: var(--azure); border-color: var(--azure); color: #fff; }}
+    main {{ padding: 20px 28px 32px; }}
+    section.panel {{ display: none; }}
+    section.panel.active {{ display: block; }}
+    .diagram {{ overflow: auto; background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 12px; }}
+    .diagram svg {{ width: 100%; min-width: 1100px; height: auto; display: block; }}
+    .grid {{ display: grid; grid-template-columns: minmax(280px, 0.8fr) minmax(420px, 1.2fr); gap: 16px; align-items: start; }}
+    .block {{ background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 16px; }}
+    h2 {{ margin: 0 0 12px; font-size: 16px; }}
+    ul {{ margin: 0; padding-left: 20px; }}
+    li {{ margin: 8px 0; color: #27344a; line-height: 1.45; }}
+    .intent {{ display: grid; gap: 8px; }}
+    .intent div {{ display: grid; grid-template-columns: 150px 1fr; gap: 12px; border-bottom: 1px solid #edf1f6; padding-bottom: 8px; }}
+    .intent div:last-child {{ border-bottom: 0; padding-bottom: 0; }}
+    .intent span {{ color: var(--muted); font-size: 12px; }}
+    .intent strong {{ font-size: 13px; font-weight: 600; overflow-wrap: anywhere; }}
+    .tiers {{ list-style: none; padding: 0; }}
+    .tiers li {{ display: grid; grid-template-columns: 130px 1fr; gap: 12px; margin: 0; padding: 9px 0; border-bottom: 1px solid #edf1f6; }}
+    .tiers li:last-child {{ border-bottom: 0; }}
+    .tiers span {{ color: var(--muted); overflow-wrap: anywhere; }}
+    @media (max-width: 900px) {{ .grid {{ grid-template-columns: 1fr; }} nav {{ overflow-x: auto; }} main, header, nav {{ padding-left: 16px; padding-right: 16px; }} }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{title}</h1>
+    <p>{source} to Azure architecture package with target topology, customer intent, talking points, and known constraints.</p>
+  </header>
+  <nav aria-label="Architecture package sections">
+    <button class="tab" type="button" data-tab="as-is" aria-selected="true">Target Topology</button>
+    <button class="tab" type="button" data-tab="dr" aria-selected="false">DR Topology</button>
+    <button class="tab" type="button" data-tab="talking" aria-selected="false">Talking Points</button>
+    <button class="tab" type="button" data-tab="limits" aria-selected="false">Limitations</button>
+  </nav>
+  <main>
+    <section id="as-is" class="panel active"><div class="diagram">{primary_svg}</div></section>
+    <section id="dr" class="panel"><div class="diagram">{dr_svg}</div></section>
+    <section id="talking" class="panel"><div class="grid"><div class="block"><h2>Customer Intent</h2><div class="intent">{intent_rows}</div></div><div class="block"><h2>Recommended Narrative</h2><ul>{talking_points}</ul></div></div></section>
+    <section id="limits" class="panel"><div class="grid"><div class="block"><h2>Service Tiers</h2><ul class="tiers">{tier_summary}</ul></div><div class="block"><h2>Assumptions And Constraints</h2><ul>{limitations}</ul></div></div></section>
+  </main>
+  <script>
+    document.querySelectorAll('button.tab').forEach((button) => {{
+      button.addEventListener('click', () => {{
+        document.querySelectorAll('button.tab').forEach((tab) => tab.setAttribute('aria-selected', 'false'));
+        document.querySelectorAll('section.panel').forEach((panel) => panel.classList.remove('active'));
+        button.setAttribute('aria-selected', 'true');
+        document.getElementById(button.dataset.tab).classList.add('active');
+      }});
+    }});
+  </script>
+</body>
+</html>"""
+
+
+def _profile_from_analysis(analysis: dict[str, Any]) -> dict[str, str]:
+    profile = analysis.get("customer_intent")
+    if isinstance(profile, dict) and profile:
+        return {str(k): str(v) for k, v in profile.items()}
+
+    answers = analysis.get("guided_answers")
+    if isinstance(answers, dict):
+        return build_customer_intent_profile(answers)
+
+    iac_params = analysis.get("iac_parameters") if isinstance(analysis.get("iac_parameters"), dict) else {}
+    inferred = {
+        "arch_deploy_region": iac_params.get("location") or iac_params.get("region"),
+        "env_target": iac_params.get("environment"),
+        "arch_ha": analysis.get("dr_mode") or infer_dr_mode(analysis),
+    }
+    return build_customer_intent_profile({k: v for k, v in inferred.items() if v})
+
+
+def _profile_rows(profile: dict[str, str]) -> list[tuple[str, str]]:
+    labels = [
+        ("environment", "Environment"),
+        ("region", "Azure Region"),
+        ("availability", "Availability"),
+        ("rto", "RTO"),
+        ("compliance", "Compliance"),
+        ("data_residency", "Residency"),
+        ("network_isolation", "Network"),
+        ("sku_strategy", "SKU Strategy"),
+        ("iac_style", "IaC"),
+    ]
+    return [(label, profile.get(key, "Not specified")) for key, label in labels]
+
+
+def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[str]:
+    regions = infer_regions(analysis, dr_variant="primary")
+    dr_mode = infer_dr_mode({**analysis, "regions": regions})
+    mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
+    high_conf = sum(1 for m in mappings if float(m.get("confidence") or 0) >= 0.9)
+    source = str(analysis.get("source_provider") or "AWS").upper()
+    target_region = profile.get("region") or regions[0].get("name", "the selected Azure region")
+
+    points = [
+        f"Translate the detected {source} estate into Azure landing-zone tiers so platform teams can review ingress, compute, data, identity, storage, and observability separately.",
+        f"Use {target_region} as the primary deployment anchor and align the topology to {profile.get('availability', 'the stated availability target')}.",
+        f"Apply {profile.get('network_isolation', 'VNet integration')} and {profile.get('data_residency', 'the stated data residency posture')} as design guardrails.",
+        f"Keep {profile.get('sku_strategy', 'balanced')} as the commercial posture for sizing and cost discussions.",
+    ]
+    if high_conf:
+        points.append(f"{high_conf} service mappings are high-confidence and can move into implementation planning after owner review.")
+    if dr_mode != "single-region":
+        points.append(f"The DR view should be reviewed as a {dr_mode} pattern before committing RTO/RPO or runbook ownership.")
+    return points[:6]
+
+
+def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[str]:
+    warnings = [str(w) for w in analysis.get("warnings", []) if w]
+    mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
+    low_conf = [m for m in mappings if float(m.get("confidence") or 0) < 0.8]
+    limits = warnings[:5]
+    if low_conf:
+        names = ", ".join(str(m.get("azure_service") or m.get("target") or "Unknown") for m in low_conf[:4])
+        limits.append(f"Low-confidence mappings need owner validation before deployment: {names}.")
+    if profile.get("compliance") and profile.get("compliance") != "None":
+        limits.append(f"Compliance scope is advisory until validated against the customer's control set: {profile['compliance']}.")
+    if profile.get("rto") and profile.get("rto") != "Not required":
+        limits.append(f"RTO target {profile['rto']} requires backup, replication, failover, and operations runbook validation.")
+    if not limits:
+        limits.append("No blocking limitations were inferred, but service owners should validate networking, identity, and data dependencies before deployment.")
+    return limits[:8]
+
+
+def _tier_summary(analysis: dict[str, Any]) -> list[tuple[str, list[str]]]:
+    tiers = infer_tiers_from_mappings(analysis)
+    out: list[tuple[str, list[str]]] = []
+    for tier, services in tiers.items():
+        names = []
+        for service in services[:6]:
+            if isinstance(service, dict) and service.get("name"):
+                names.append(str(service["name"]))
+        out.append((tier, names))
+    return out
+
+
+def _strip_xml_declaration(svg: str) -> str:
+    return re.sub(r"^\s*<\?xml[^>]*>\s*", "", svg, count=1)
+
+
+def _namespace_svg_ids(svg: str, suffix: str) -> str:
+    ids = re.findall(r'\bid="([^"]+)"', svg)
+    if not ids:
+        return svg
+    out = svg
+    for raw_id in sorted(set(ids), key=len, reverse=True):
+        new_id = f"{raw_id}-{suffix}"
+        out = re.sub(rf'\bid="{re.escape(raw_id)}"', f'id="{new_id}"', out)
+        out = re.sub(rf'url\(#{re.escape(raw_id)}\)', f'url(#{new_id})', out)
+        out = re.sub(rf'href="#{re.escape(raw_id)}"', f'href="#{new_id}"', out)
+        out = re.sub(rf'xlink:href="#{re.escape(raw_id)}"', f'xlink:href="#{new_id}"', out)
+    return out
+
+
+def _safe_filename(analysis: dict[str, Any]) -> str:
+    zones = analysis.get("zones") or []
+    name = analysis.get("title") or "diagram"
+    if zones and isinstance(zones[0], dict) and zones[0].get("name"):
+        name = zones[0]["name"]
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(name)).strip("-")
+    return cleaned or "diagram"
+
+
+def clone_with_customer_intent(analysis: dict[str, Any], answers: dict[str, Any]) -> dict[str, Any]:
+    """Return an analysis copy annotated with answer and intent metadata."""
+    result = copy.deepcopy(analysis)
+    result["guided_answers"] = copy.deepcopy(answers)
+    result["customer_intent"] = build_customer_intent_profile(answers)
+    return result

--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -11,62 +11,15 @@ from __future__ import annotations
 import copy
 import html
 import re
-from dataclasses import dataclass, asdict
 from typing import Any, Literal
 
 from azure_landing_zone import generate_landing_zone_svg
 from azure_landing_zone_schema import infer_dr_mode, infer_regions, infer_tiers_from_mappings
+from customer_intent import build_customer_intent_profile
 
 
 PackageFormat = Literal["html", "svg"]
 DiagramVariant = Literal["primary", "dr"]
-
-
-@dataclass(frozen=True)
-class CustomerIntentProfile:
-    """Compact, presentation-safe view of guided-question answers."""
-
-    environment: str = "Production"
-    region: str = "West Europe"
-    availability: str = "Multi-AZ within region (99.95 %)"
-    rto: str = "<1 hour"
-    compliance: str = "None"
-    data_residency: str = "No restriction"
-    network_isolation: str = "VNet integration"
-    sku_strategy: str = "Balanced (good performance-to-cost ratio)"
-    iac_style: str = "Terraform (HCL)"
-
-
-def build_customer_intent_profile(answers: dict[str, Any] | None) -> dict[str, str]:
-    """Build a stable profile from guided-question answers.
-
-    Unknown fields are ignored and list answers are rendered as comma-separated
-    strings so the profile can safely travel through JSON, HTML, and reports.
-    """
-    answers = answers or {}
-
-    def value(key: str, default: str) -> str:
-        raw = answers.get(key, default)
-        if isinstance(raw, list):
-            return ", ".join(str(item) for item in raw if item) or default
-        if raw is None:
-            return default
-        text = str(raw).strip()
-        return text or default
-
-    profile = CustomerIntentProfile(
-        environment=value("env_target", "Production"),
-        region=value("arch_deploy_region", "West Europe"),
-        availability=value("arch_ha", "Multi-AZ within region (99.95 %)"),
-        rto=value("arch_dr_rto", "<1 hour"),
-        compliance=value("sec_compliance", "None"),
-        data_residency=value("sec_data_residency", "No restriction"),
-        network_isolation=value("sec_network_isolation", "VNet integration"),
-        sku_strategy=value("arch_sku_strategy", "Balanced (good performance-to-cost ratio)"),
-        iac_style=value("arch_iac_style", "Terraform (HCL)"),
-    )
-    return asdict(profile)
-
 
 def generate_architecture_package(
     analysis: dict[str, Any],

--- a/backend/customer_intent.py
+++ b/backend/customer_intent.py
@@ -1,0 +1,56 @@
+"""Compact customer-intent profile helpers.
+
+This module is intentionally lightweight so guided-question routes can persist
+presentation intent without importing the architecture package/SVG pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CustomerIntentProfile:
+    """Compact, presentation-safe view of guided-question answers."""
+
+    environment: str = "Production"
+    region: str = "West Europe"
+    availability: str = "Multi-AZ within region (99.95 %)"
+    rto: str = "<1 hour"
+    compliance: str = "None"
+    data_residency: str = "No restriction"
+    network_isolation: str = "VNet integration"
+    sku_strategy: str = "Balanced (good performance-to-cost ratio)"
+    iac_style: str = "Terraform (HCL)"
+
+
+def build_customer_intent_profile(answers: dict[str, Any] | None) -> dict[str, str]:
+    """Build a stable profile from guided-question answers.
+
+    Unknown fields are ignored and list answers are rendered as comma-separated
+    strings so the profile can safely travel through JSON, HTML, and reports.
+    """
+    answers = answers or {}
+
+    def value(key: str, default: str) -> str:
+        raw = answers.get(key, default)
+        if isinstance(raw, list):
+            return ", ".join(str(item) for item in raw if item) or default
+        if raw is None:
+            return default
+        text = str(raw).strip()
+        return text or default
+
+    profile = CustomerIntentProfile(
+        environment=value("env_target", "Production"),
+        region=value("arch_deploy_region", "West Europe"),
+        availability=value("arch_ha", "Multi-AZ within region (99.95 %)"),
+        rto=value("arch_dr_rto", "<1 hour"),
+        compliance=value("sec_compliance", "None"),
+        data_residency=value("sec_data_residency", "No restriction"),
+        network_isolation=value("sec_network_isolation", "VNet integration"),
+        sku_strategy=value("arch_sku_strategy", "Balanced (good performance-to-cost ratio)"),
+        iac_style=value("arch_iac_style", "Terraform (HCL)"),
+    )
+    return asdict(profile)

--- a/backend/guided_questions.py
+++ b/backend/guided_questions.py
@@ -44,7 +44,7 @@ Answers = dict[str, Any]
 
 import json
 import os
-from architecture_package import build_customer_intent_profile
+from customer_intent import build_customer_intent_profile
 
 _data_file_QUESTION_BANK = os.path.join(os.path.dirname(__file__), 'assets', 'guided_questions_bank.json')
 try:
@@ -393,7 +393,7 @@ def apply_answers(analysis_result: dict, answers: dict) -> dict:
     result["mappings"] = mappings
     result["warnings"] = warnings
     result["iac_parameters"] = iac_params
-    result["guided_answers"] = copy.deepcopy(effective)
+    result["guided_answers"] = copy.deepcopy(answers or {})
     result["customer_intent"] = build_customer_intent_profile(effective)
 
     # ── Recalculate confidence_summary after all rule adjustments ──

--- a/backend/guided_questions.py
+++ b/backend/guided_questions.py
@@ -44,6 +44,7 @@ Answers = dict[str, Any]
 
 import json
 import os
+from architecture_package import build_customer_intent_profile
 
 _data_file_QUESTION_BANK = os.path.join(os.path.dirname(__file__), 'assets', 'guided_questions_bank.json')
 try:
@@ -392,6 +393,8 @@ def apply_answers(analysis_result: dict, answers: dict) -> dict:
     result["mappings"] = mappings
     result["warnings"] = warnings
     result["iac_parameters"] = iac_params
+    result["guided_answers"] = copy.deepcopy(effective)
+    result["customer_intent"] = build_customer_intent_profile(effective)
 
     # ── Recalculate confidence_summary after all rule adjustments ──
     high = len([m for m in mappings if m.get("confidence", 0) >= 0.90])

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -9235,6 +9235,64 @@
         "summary": "Diff Versions"
       }
     },
+    "/api/diagrams/{diagram_id}/export-architecture-package": {
+      "post": {
+        "description": "Generate the customer-facing Architecture Package.\n\nformat=html returns the full tabbed package. format=svg returns a single\nselected topology SVG where diagram=primary|dr.",
+        "operationId": "export_architecture_package_api_diagrams__diagram_id__export_architecture_package_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "diagram_id",
+            "required": true,
+            "schema": {
+              "title": "Diagram Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "html",
+              "title": "Format",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "diagram",
+            "required": false,
+            "schema": {
+              "default": "primary",
+              "title": "Diagram",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Architecture Package"
+      }
+    },
     "/api/diagrams/{diagram_id}/export-diagram": {
       "post": {
         "description": "Generate an architecture diagram in Excalidraw, Draw.io, Visio, or\nLanding-Zone-SVG format.\n\nSet multi_page=true for presentation-ready 4-page exports (Draw.io only, #479).\nSet format=landing-zone-svg + dr_variant=primary|dr for the region-aware\nlanding-zone diagram (#571).\n\nNote (#576): the source provider for the landing-zone diagram is read\nimplicitly from ``analysis[\"source_provider\"]`` (allowed: \"aws\"|\"gcp\",\ndefault \"aws\"). It is intentionally NOT exposed as a query param so the\nfrontend stays untouched and the analyzer pipeline remains the single\nsource of truth. Unknown values raise ``ValueError`` → HTTP 400.",
@@ -19889,6 +19947,67 @@
         "summary": "Api Dependency Graph V1",
         "tags": [
           "ai-suggestion",
+          "v1"
+        ]
+      }
+    },
+    "/api/v1/diagrams/{diagram_id}/export-architecture-package": {
+      "post": {
+        "description": "Generate the customer-facing Architecture Package.\n\nformat=html returns the full tabbed package. format=svg returns a single\nselected topology SVG where diagram=primary|dr.",
+        "operationId": "export_architecture_package_v1_api_v1_diagrams__diagram_id__export_architecture_package_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "diagram_id",
+            "required": true,
+            "schema": {
+              "title": "Diagram Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "html",
+              "title": "Format",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "diagram",
+            "required": false,
+            "schema": {
+              "default": "primary",
+              "title": "Diagram",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Architecture Package V1",
+        "tags": [
           "v1"
         ]
       }

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -17,6 +17,7 @@ from usage_metrics import record_event, record_funnel_step
 from guided_questions import generate_questions, apply_answers, get_question_constraints
 from mcp_diagram_generator import mcp_client
 from service_builder import deduplicate_questions, get_smart_defaults_from_analysis, add_services_from_text
+from architecture_package import generate_architecture_package
 
 logger = logging.getLogger(__name__)
 
@@ -231,5 +232,48 @@ async def export_architecture_diagram(
         raise ArchmorphException(400, str(exc))
 
     record_event(f"exports_{format}", {"diagram_id": diagram_id})
+    record_funnel_step(diagram_id, "export")
+    return result
+
+
+# ─────────────────────────────────────────────────────────────
+# Architecture Package Export (HTML / SVG)
+# ─────────────────────────────────────────────────────────────
+@router.post("/api/diagrams/{diagram_id}/export-architecture-package")
+@limiter.limit("10/minute")
+async def export_architecture_package(
+    request: Request,
+    diagram_id: str,
+    format: str = "html",
+    diagram: str = "primary",
+):
+    """Generate the customer-facing Architecture Package.
+
+    format=html returns the full tabbed package. format=svg returns a single
+    selected topology SVG where diagram=primary|dr.
+    """
+    if format not in ("html", "svg"):
+        raise ArchmorphException(400, "Format must be 'html' or 'svg'")
+    if diagram not in ("primary", "dr"):
+        raise ArchmorphException(400, "diagram must be 'primary' or 'dr'")
+
+    analysis = get_or_recreate_session(diagram_id)
+    if not analysis:
+        raise ArchmorphException(404, f"No analysis found for diagram {diagram_id}. Run /analyze first.")
+
+    try:
+        result = generate_architecture_package(
+            analysis,
+            format=format,  # type: ignore[arg-type]
+            diagram=diagram,  # type: ignore[arg-type]
+        )
+    except ValueError as exc:
+        raise ArchmorphException(400, str(exc))
+
+    record_event("exports_architecture_package", {
+        "diagram_id": diagram_id,
+        "format": format,
+        "diagram": diagram,
+    })
     record_funnel_step(diagram_id, "export")
     return result

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
-from architecture_package import (
-    build_customer_intent_profile,
-    generate_architecture_package,
-)
+from architecture_package import generate_architecture_package
+from customer_intent import build_customer_intent_profile
 from routers.shared import SESSION_STORE
 
 

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -1,0 +1,91 @@
+"""Tests for customer-facing architecture package exports."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from architecture_package import (
+    build_customer_intent_profile,
+    generate_architecture_package,
+)
+from routers.shared import SESSION_STORE
+
+
+SAMPLE_ANALYSIS: dict = {
+    "title": "Package Test",
+    "source_provider": "AWS",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "web-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96},
+        {"source_service": "EKS", "azure_service": "AKS", "category": "Containers", "confidence": 0.94},
+        {"source_service": "RDS", "azure_service": "Azure SQL", "category": "Database", "confidence": 0.88},
+        {"source_service": "CloudWatch", "azure_service": "Azure Monitor", "category": "Monitoring", "confidence": 0.92},
+    ],
+    "guided_answers": {
+        "env_target": "Production",
+        "arch_deploy_region": "East US",
+        "arch_ha": "Multi-region active-passive (99.99 %)",
+        "arch_dr_rto": "<15 min",
+        "sec_compliance": ["SOC 2", "GDPR"],
+        "sec_network_isolation": "Full private endpoints",
+    },
+}
+
+
+def test_customer_intent_profile_normalises_lists():
+    profile = build_customer_intent_profile({"sec_compliance": ["SOC 2", "GDPR"]})
+    assert profile["compliance"] == "SOC 2, GDPR"
+    assert profile["environment"] == "Production"
+
+
+def test_svg_package_is_parseable_xml():
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="svg", diagram="primary")
+    assert result["format"] == "architecture-package-svg"
+    assert result["filename"].endswith(".svg")
+    root = ET.fromstring(result["content"])
+    assert root.tag.endswith("svg")
+
+
+def test_html_package_contains_tabs_and_namespaced_svg_ids():
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    content = result["content"]
+    assert result["format"] == "architecture-package-html"
+    assert result["filename"].endswith(".html")
+    assert "Target Topology" in content
+    assert "DR Topology" in content
+    assert "Customer Intent" in content
+    assert "East US" in content
+    assert 'id="a-primary"' in content
+    assert 'id="a-dr"' in content
+    assert 'marker-end="url(#a)"' not in content
+
+
+def test_export_architecture_package_endpoint_returns_html(test_client):
+    diagram_id = "package-endpoint-test"
+    SESSION_STORE[diagram_id] = SAMPLE_ANALYSIS
+
+    response = test_client.post(
+        f"/api/diagrams/{diagram_id}/export-architecture-package?format=html"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["format"] == "architecture-package-html"
+    assert data["filename"].endswith(".html")
+    assert "Target Topology" in data["content"]
+
+
+def test_export_architecture_package_endpoint_returns_dr_svg(test_client):
+    diagram_id = "package-endpoint-dr-test"
+    SESSION_STORE[diagram_id] = SAMPLE_ANALYSIS
+
+    response = test_client.post(
+        f"/api/diagrams/{diagram_id}/export-architecture-package?format=svg&diagram=dr"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["format"] == "architecture-package-svg"
+    assert data["filename"].endswith("-dr.svg")
+    ET.fromstring(data["content"])

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   X, Download, Check, Loader2, Package, FileCode, Image,
   FileText, DollarSign, CalendarClock, ShieldCheck, FileDown,
-  ChevronDown,
+  ChevronDown, PanelTop,
 } from 'lucide-react';
 import { Button, Card } from '../ui';
 import api from '../../services/apiClient';
@@ -22,7 +22,7 @@ const DELIVERABLES = [
   },
   {
     id: 'diagram',
-    label: 'Architecture Diagram',
+    label: 'Classic Diagram Export',
     icon: Image,
     formats: [
       { id: 'excalidraw', label: 'Excalidraw' },
@@ -30,6 +30,17 @@ const DELIVERABLES = [
       { id: 'vsdx', label: 'Visio' },
     ],
     defaultFormat: 'excalidraw',
+  },
+  {
+    id: 'architecture-package',
+    label: 'Architecture Package',
+    icon: PanelTop,
+    formats: [
+      { id: 'html', label: 'HTML' },
+      { id: 'svg-primary', label: 'Target SVG' },
+      { id: 'svg-dr', label: 'DR SVG' },
+    ],
+    defaultFormat: 'html',
   },
   {
     id: 'hld',
@@ -107,6 +118,16 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
       ? 'application/xml'
       : 'application/vnd.visio'; // VDX legacy XML
     return { blob: new Blob([content], { type: mime }), filename: data.filename || `archmorph-diagram.${ext}` };
+  }
+
+  if (id === 'architecture-package') {
+    const packageFormat = format.startsWith('svg') ? 'svg' : format;
+    const packageDiagram = format === 'svg-dr' ? '&diagram=dr' : '';
+    const data = await api.post(`/diagrams/${diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`);
+    const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
+    const mime = packageFormat === 'html' ? 'text/html' : 'image/svg+xml';
+    const filename = data.filename || `archmorph-architecture-package${format === 'svg-dr' ? '-dr' : ''}.${packageFormat}`;
+    return { blob: new Blob([content], { type: mime }), filename };
   }
 
   if (id === 'hld') {

--- a/frontend/src/components/DiagramTranslator/ExportPanel.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportPanel.jsx
@@ -3,6 +3,9 @@ import { Download } from 'lucide-react';
 import { Button, Card } from '../ui';
 
 const EXPORT_FORMATS = [
+  { id: 'architecture-package-html', label: 'HTML Package' },
+  { id: 'architecture-package-svg', label: 'Target SVG' },
+  { id: 'architecture-package-svg-dr', label: 'DR SVG' },
   { id: 'excalidraw', label: 'Excalidraw' },
   { id: 'drawio', label: 'Draw.io' },
   { id: 'vsdx', label: 'Visio' },
@@ -13,8 +16,8 @@ export default function ExportPanel({ exportLoading, onExportDiagram }) {
     <Card className="p-6">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
-          <h3 className="text-sm font-semibold text-text-primary mb-1">Export Architecture Diagram</h3>
-          <p className="text-xs text-text-muted">Download in your preferred format with Azure stencils</p>
+          <h3 className="text-sm font-semibold text-text-primary mb-1">Export Architecture Package</h3>
+          <p className="text-xs text-text-muted">Download polished HTML/SVG output or classic diagram formats</p>
         </div>
         <div className="flex items-center gap-2">
           {EXPORT_FORMATS.map(f => (

--- a/frontend/src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx
@@ -11,12 +11,27 @@ describe('ExportPanel', () => {
 
   it('renders the export title', () => {
     render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText('Export Architecture Diagram')).toBeInTheDocument()
+    expect(screen.getByText('Export Architecture Package')).toBeInTheDocument()
   })
 
   it('shows subtitle', () => {
     render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText(/Download in your preferred format/)).toBeInTheDocument()
+    expect(screen.getByText(/Download polished HTML\/SVG output/)).toBeInTheDocument()
+  })
+
+  it('renders HTML Package button', () => {
+    render(<ExportPanel {...defaultProps} />)
+    expect(screen.getByText('HTML Package')).toBeInTheDocument()
+  })
+
+  it('renders Target SVG button', () => {
+    render(<ExportPanel {...defaultProps} />)
+    expect(screen.getByText('Target SVG')).toBeInTheDocument()
+  })
+
+  it('renders DR SVG button', () => {
+    render(<ExportPanel {...defaultProps} />)
+    expect(screen.getByText('DR SVG')).toBeInTheDocument()
   })
 
   it('renders Excalidraw button', () => {
@@ -37,8 +52,22 @@ describe('ExportPanel', () => {
   it('calls onExportDiagram with correct format', async () => {
     const user = userEvent.setup()
     render(<ExportPanel {...defaultProps} />)
-    await user.click(screen.getByText('Excalidraw'))
-    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('excalidraw')
+    await user.click(screen.getByText('HTML Package'))
+    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('architecture-package-html')
+  })
+
+  it('calls onExportDiagram with SVG package format', async () => {
+    const user = userEvent.setup()
+    render(<ExportPanel {...defaultProps} />)
+    await user.click(screen.getByText('Target SVG'))
+    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('architecture-package-svg')
+  })
+
+  it('calls onExportDiagram with DR SVG package format', async () => {
+    const user = userEvent.setup()
+    render(<ExportPanel {...defaultProps} />)
+    await user.click(screen.getByText('DR SVG'))
+    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('architecture-package-svg-dr')
   })
 
   it('calls onExportDiagram with drawio format', async () => {

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -598,8 +598,14 @@ export default function DiagramTranslator() {
       );
       if (data) {
         const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
-        const mime = packageFormat === 'html' ? 'text/html' : packageFormat === 'svg' ? 'image/svg+xml' : 'application/octet-stream';
-        const blob = new Blob([content], { type: mime });
+        const exportMime = isArchitecturePackage
+          ? (packageFormat === 'html' ? 'text/html' : 'image/svg+xml')
+          : format === 'excalidraw'
+          ? 'application/json'
+          : format === 'drawio'
+          ? 'application/xml'
+          : 'application/vnd.visio';
+        const blob = new Blob([content], { type: exportMime });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -586,17 +586,26 @@ export default function DiagramTranslator() {
   const handleExportDiagram = async (format) => {
     setExportLoading(format, true);
     try {
+      const isArchitecturePackage = format.startsWith('architecture-package-');
+      const packageSelection = format.replace('architecture-package-', '');
+      const packageFormat = packageSelection.startsWith('svg') ? 'svg' : packageSelection;
+      const packageDiagram = packageSelection === 'svg-dr' ? '&diagram=dr' : '';
       const data = await withRestore(
-        () => api.post(`/diagrams/${state.diagramId}/export-diagram?format=${format}`),
+        () => isArchitecturePackage
+          ? api.post(`/diagrams/${state.diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`)
+          : api.post(`/diagrams/${state.diagramId}/export-diagram?format=${format}`),
         { cleanup: () => setExportLoading(format, false) },
       );
       if (data) {
         const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
-        const blob = new Blob([content], { type: 'application/octet-stream' });
+        const mime = packageFormat === 'html' ? 'text/html' : packageFormat === 'svg' ? 'image/svg+xml' : 'application/octet-stream';
+        const blob = new Blob([content], { type: mime });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = data.filename || `archmorph-diagram.${format === 'excalidraw' ? 'excalidraw' : format === 'drawio' ? 'drawio' : 'vdx'}`;
+        a.download = data.filename || (isArchitecturePackage
+          ? `archmorph-architecture-package${packageSelection === 'svg-dr' ? '-dr' : ''}.${packageFormat}`
+          : `archmorph-diagram.${format === 'excalidraw' ? 'excalidraw' : format === 'drawio' ? 'drawio' : 'vdx'}`);
         a.click();
         URL.revokeObjectURL(url);
       }


### PR DESCRIPTION
## Summary
- Add a backend Architecture Package renderer for customer-facing HTML and direct SVG exports
- Add `POST /api/diagrams/{diagram_id}/export-architecture-package?format=html|svg&diagram=primary|dr`
- Persist guided-question answers as `guided_answers` plus a compact `customer_intent` profile
- Update the direct export panel to lead with HTML Package, Target SVG, and DR SVG
- Add Architecture Package as a distinct Export Hub deliverable while keeping Classic Diagram Export available

Closes #665
Related to #575
Related to #601

## Validation
- `cd backend && python3 -m pytest tests/test_architecture_package.py tests/test_azure_landing_zone.py tests/test_guided_questions_rules.py -q`
- `cd backend && python3 -m ruff check architecture_package.py tests/test_architecture_package.py routers/analysis.py guided_questions.py`
- `cd frontend && npx vitest run src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx`
- `cd frontend && npx eslint src/components/DiagramTranslator/ExportHub.jsx src/components/DiagramTranslator/ExportPanel.jsx src/components/DiagramTranslator/index.jsx src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx`
- `cd frontend && npm run build`