### PR TITLE
fix(package): restore architecture package output quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Customer-grade package shell** — Architecture Package HTML exports now use the richer Archmorph review structure with branded header metadata, source-to-target story strip, A/B/C/D tab semantics, and grouped talking-point/limitation rows.
 - **Legacy export cleanup** — Draw.io, Excalidraw, and Visio are removed from visible website export controls so the customer UI leads only with Architecture Package HTML, Target SVG, and DR SVG.
+- **Azure icon recovery** — Azure topology SVG rendering now falls back to Archmorph's bundled Azure service icons when the runtime icon registry is incomplete, avoiding letter-badge-only customer diagrams.
 - **Diagram placeholder cleanup** — Azure topology SVG rendering suppresses visible `(empty)` workload cells in availability-zone columns.
 
 #### Main-branch convergence and Architecture Package export (PRs #651 #652 #649 #667 #666)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Architecture Package quality recovery
+
+- **Customer-grade package shell** — Architecture Package HTML exports now use the richer Archmorph review structure with branded header metadata, source-to-target story strip, A/B/C/D tab semantics, and grouped talking-point/limitation rows.
+- **Legacy export cleanup** — Draw.io, Excalidraw, and Visio are removed from visible website export controls so the customer UI leads only with Architecture Package HTML, Target SVG, and DR SVG.
+- **Diagram placeholder cleanup** — Azure topology SVG rendering suppresses visible `(empty)` workload cells in availability-zone columns.
+
 #### Main-branch convergence and Architecture Package export (PRs #651 #652 #649 #667 #666)
 
-- **Architecture Package HTML/SVG export** — new customer-facing export path that produces a polished tabbed HTML package plus standalone target and DR SVG renderings. It preserves classic Excalidraw, Draw.io, and Visio exports while making the Azure topology package the lead deliverable.
+- **Architecture Package HTML/SVG export** — new customer-facing export path that produces a polished tabbed HTML package plus standalone target and DR SVG renderings. It preserves classic Excalidraw, Draw.io, and Visio compatibility endpoints while making the Azure topology package the lead deliverable.
 - **Customer intent profile** — guided-question answers now feed a compact `customer_intent` object for export narration while raw `guided_answers` remain limited to user-provided answers.
 - **Scheduled job freshness health** — service catalog refresh now registers durable freshness in `/api/health.scheduled_jobs`, restores last-success state after restart, and avoids marking success when provider refreshes fail.
 - **Branch convergence** — all active convergence PRs were merged or superseded and the repository was reduced back to `main` as the only active branch.

--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -36,7 +36,7 @@ def generate_architecture_package(
         raise ValueError("analysis must be a dict")
 
     if format == "svg":
-        result = generate_landing_zone_svg(analysis, dr_variant=diagram)
+        result = generate_landing_zone_svg(_diagram_analysis(analysis, diagram), dr_variant=diagram)
         return {
             "format": "architecture-package-svg",
             "filename": result["filename"].replace("landing-zone", "architecture-package"),
@@ -44,11 +44,11 @@ def generate_architecture_package(
         }
 
     primary_svg = _namespace_svg_ids(
-        _strip_xml_declaration(generate_landing_zone_svg(analysis, dr_variant="primary")["content"]),
+        _strip_xml_declaration(generate_landing_zone_svg(_diagram_analysis(analysis, "primary"), dr_variant="primary")["content"]),
         "primary",
     )
     dr_svg = _namespace_svg_ids(
-        _strip_xml_declaration(generate_landing_zone_svg(analysis, dr_variant="dr")["content"]),
+        _strip_xml_declaration(generate_landing_zone_svg(_diagram_analysis(analysis, "dr"), dr_variant="dr")["content"]),
         "dr",
     )
     content = _render_html_package(analysis, primary_svg, dr_svg)
@@ -60,21 +60,28 @@ def generate_architecture_package(
 
 
 def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str) -> str:
-    title = html.escape(str(analysis.get("title") or "Azure Architecture Package"))
+    package_name = _package_name(analysis)
+    title = html.escape(f"Archmorph — {package_name} Architecture Package")
+    display_name = html.escape(package_name)
     source = html.escape(str(analysis.get("source_provider") or "AWS").upper())
     profile = _profile_from_analysis(analysis)
+    regions = infer_regions(analysis, dr_variant="primary")
+    target_region = html.escape(profile.get("region") or regions[0].get("name", "Selected Azure region"))
+    source_file = html.escape(str(analysis.get("source_filename") or analysis.get("filename") or "Customer architecture diagram"))
     intent_rows = "\n".join(
         f"<div><span>{html.escape(label)}</span><strong>{html.escape(value)}</strong></div>"
         for label, value in _profile_rows(profile)
     )
     talking_points = "\n".join(
-        f"<li>{html.escape(point)}</li>" for point in _talking_points(analysis, profile)
+        f"<div class=\"insight-row\"><div class=\"insight-h\">{html.escape(point[0])}</div><div class=\"insight-b\">{html.escape(point[1])}</div></div>"
+        for point in _talking_points(analysis, profile)
     )
     limitations = "\n".join(
-        f"<li>{html.escape(item)}</li>" for item in _limitations(analysis, profile)
+        f"<div class=\"insight-row\"><div class=\"insight-h\">{html.escape(item[0])}</div><div class=\"insight-b\">{html.escape(item[1])}</div></div>"
+        for item in _limitations(analysis, profile)
     )
     tier_summary = "\n".join(
-        f"<li><strong>{html.escape(tier.title())}</strong><span>{html.escape(', '.join(names) or 'No service inferred')}</span></li>"
+        f"<li><strong>{html.escape(tier.title())}</strong><span>{html.escape(', '.join(names) or 'Review required')}</span></li>"
         for tier, names in _tier_summary(analysis)
     )
 
@@ -85,22 +92,30 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{title}</title>
   <style>
-    :root {{ color-scheme: light; --ink:#172033; --muted:#526178; --line:#d9e0ea; --azure:#0078d4; --bg:#f6f8fb; --card:#ffffff; }}
+    :root {{ color-scheme: light; --ink:#111827; --muted:#526178; --line:#d9e0ea; --azure:#0078d4; --brand:#0078d4; --brand-2:#5c2d91; --bg:#f6f8fb; --card:#ffffff; --soft:#edf4ff; }}
     * {{ box-sizing: border-box; }}
     body {{ margin: 0; background: var(--bg); color: var(--ink); font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif; }}
-    header {{ padding: 22px 28px 16px; background: #fff; border-bottom: 1px solid var(--line); }}
+    .shell {{ max-width: 1440px; margin: 0 auto; padding: 18px 24px 32px; }}
+    header {{ display: flex; justify-content: space-between; gap: 18px; align-items: flex-start; padding: 18px 20px; background: #fff; border: 1px solid var(--line); border-radius: 8px; box-shadow: 0 10px 30px rgba(17, 24, 39, 0.06); }}
+    .brand {{ display: flex; align-items: center; gap: 12px; }}
+    .mark {{ width: 42px; height: 42px; border-radius: 8px; background: linear-gradient(135deg, var(--brand), var(--brand-2)); color: #fff; display: grid; place-items: center; font-weight: 800; }}
     h1 {{ margin: 0; font-size: 24px; line-height: 1.2; letter-spacing: 0; }}
-    header p {{ margin: 6px 0 0; color: var(--muted); font-size: 13px; }}
-    nav {{ display: flex; gap: 8px; padding: 12px 28px; background: #fff; border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 2; }}
-    button.tab {{ border: 1px solid var(--line); background: #fff; color: var(--ink); border-radius: 8px; padding: 8px 12px; font: inherit; font-size: 13px; cursor: pointer; }}
-    button.tab[aria-selected="true"] {{ background: var(--azure); border-color: var(--azure); color: #fff; }}
-    main {{ padding: 20px 28px 32px; }}
+    header p {{ margin: 5px 0 0; color: var(--muted); font-size: 13px; }}
+    .meta-pills {{ display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; max-width: 540px; }}
+    .brand-pill {{ display: inline-flex; align-items: center; min-height: 28px; border-radius: 8px; padding: 5px 9px; background: var(--soft); color: #155f9f; font-size: 12px; font-weight: 700; }}
+    .story {{ display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 14px 0; padding: 12px 14px; background: #fff; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); font-size: 13px; }}
+    .story strong {{ color: var(--ink); }}
+    nav {{ display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr)); gap: 10px; margin-bottom: 14px; position: sticky; top: 0; z-index: 2; background: rgba(246, 248, 251, 0.94); padding: 8px 0; backdrop-filter: blur(8px); }}
+    button.tab {{ border: 1px solid var(--line); background: #fff; color: var(--ink); border-radius: 8px; padding: 11px 12px; font: inherit; font-size: 13px; font-weight: 750; cursor: pointer; text-align: left; box-shadow: 0 4px 14px rgba(17, 24, 39, 0.04); }}
+    button.tab span {{ display: block; margin-top: 4px; color: var(--muted); font-size: 11px; font-weight: 650; }}
+    button.tab[aria-selected="true"] {{ border-color: #b8d8f5; background: #edf4ff; color: #074f87; }}
+    main {{ padding: 0; }}
     section.panel {{ display: none; }}
     section.panel.active {{ display: block; }}
-    .diagram {{ overflow: auto; background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 12px; }}
+    .diagram {{ overflow: auto; background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 12px; box-shadow: 0 12px 34px rgba(17, 24, 39, 0.07); }}
     .diagram svg {{ width: 100%; min-width: 1100px; height: auto; display: block; }}
     .grid {{ display: grid; grid-template-columns: minmax(280px, 0.8fr) minmax(420px, 1.2fr); gap: 16px; align-items: start; }}
-    .block {{ background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 16px; }}
+    .block {{ background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 16px; box-shadow: 0 8px 24px rgba(17, 24, 39, 0.05); }}
     h2 {{ margin: 0 0 12px; font-size: 16px; }}
     ul {{ margin: 0; padding-left: 20px; }}
     li {{ margin: 8px 0; color: #27344a; line-height: 1.45; }}
@@ -113,26 +128,35 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
     .tiers li {{ display: grid; grid-template-columns: 130px 1fr; gap: 12px; margin: 0; padding: 9px 0; border-bottom: 1px solid #edf1f6; }}
     .tiers li:last-child {{ border-bottom: 0; }}
     .tiers span {{ color: var(--muted); overflow-wrap: anywhere; }}
-    @media (max-width: 900px) {{ .grid {{ grid-template-columns: 1fr; }} nav {{ overflow-x: auto; }} main, header, nav {{ padding-left: 16px; padding-right: 16px; }} }}
+        .insight-list {{ display: grid; gap: 10px; }}
+        .insight-row {{ border: 1px solid #e7edf5; border-radius: 8px; padding: 12px; background: #fbfdff; }}
+        .insight-h {{ font-size: 13px; font-weight: 800; color: var(--ink); margin-bottom: 5px; }}
+        .insight-b {{ font-size: 13px; line-height: 1.5; color: #314158; }}
+        footer {{ margin-top: 16px; color: var(--muted); font-size: 12px; }}
+        @media (max-width: 900px) {{ .shell {{ padding: 12px; }} header {{ flex-direction: column; }} .meta-pills {{ justify-content: flex-start; }} .grid {{ grid-template-columns: 1fr; }} nav {{ grid-template-columns: 1fr; position: static; }} }}
   </style>
 </head>
 <body>
-  <header>
-    <h1>{title}</h1>
-    <p>{source} to Azure architecture package with target topology, customer intent, talking points, and known constraints.</p>
-  </header>
-  <nav aria-label="Architecture package sections">
-    <button class="tab" type="button" data-tab="as-is" aria-selected="true">Target Topology</button>
-    <button class="tab" type="button" data-tab="dr" aria-selected="false">DR Topology</button>
-    <button class="tab" type="button" data-tab="talking" aria-selected="false">Talking Points</button>
-    <button class="tab" type="button" data-tab="limits" aria-selected="false">Limitations</button>
-  </nav>
-  <main>
+    <div class="shell">
+    <header>
+        <div class="brand"><div class="mark">A↻</div><div><h1>{title}</h1><p>Cross-cloud architecture translation and Azure hardening package</p></div></div>
+        <div class="meta-pills"><span class="brand-pill">Customer / workload: {display_name}</span><span class="brand-pill">Source: {source}</span><span class="brand-pill">Target: Azure</span><span class="brand-pill">Region: {target_region}</span></div>
+    </header>
+    <div class="story"><strong>{source_file}</strong><span>→</span><span>Archmorph produced four review outputs:</span><span class="brand-pill">A · Target</span><span class="brand-pill">B · DR</span><span class="brand-pill">C · Talking Points</span><span class="brand-pill">D · Limitations</span></div>
+    <nav aria-label="Architecture package sections">
+        <button class="tab" type="button" data-tab="as-is" aria-selected="true">A — Target Azure Topology<span>customer-ready package</span></button>
+        <button class="tab" type="button" data-tab="dr" aria-selected="false">B — DR Topology<span>resilience review</span></button>
+        <button class="tab" type="button" data-tab="talking" aria-selected="false">C — Talking Points<span>customer-facing narrative</span></button>
+        <button class="tab" type="button" data-tab="limits" aria-selected="false">D — Services Limitations<span>technical gotchas</span></button>
+    </nav>
+    <main>
     <section id="as-is" class="panel active"><div class="diagram">{primary_svg}</div></section>
     <section id="dr" class="panel"><div class="diagram">{dr_svg}</div></section>
-    <section id="talking" class="panel"><div class="grid"><div class="block"><h2>Customer Intent</h2><div class="intent">{intent_rows}</div></div><div class="block"><h2>Recommended Narrative</h2><ul>{talking_points}</ul></div></div></section>
-    <section id="limits" class="panel"><div class="grid"><div class="block"><h2>Service Tiers</h2><ul class="tiers">{tier_summary}</ul></div><div class="block"><h2>Assumptions And Constraints</h2><ul>{limitations}</ul></div></div></section>
+        <section id="talking" class="panel"><div class="grid"><div class="block"><h2>Customer Intent</h2><div class="intent">{intent_rows}</div></div><div class="block"><h2>Recommended Narrative</h2><div class="insight-list">{talking_points}</div></div></div></section>
+        <section id="limits" class="panel"><div class="grid"><div class="block"><h2>Service Tiers</h2><ul class="tiers">{tier_summary}</ul></div><div class="block"><h2>Assumptions And Constraints</h2><div class="insight-list">{limitations}</div></div></div></section>
   </main>
+    <footer>Archmorph · {display_name} · {source} → Azure · generated from the customer-uploaded architecture diagram.</footer>
+    </div>
   <script>
     document.querySelectorAll('button.tab').forEach((button) => {{
       button.addEventListener('click', () => {{
@@ -165,6 +189,35 @@ def _profile_from_analysis(analysis: dict[str, Any]) -> dict[str, str]:
     return build_customer_intent_profile({k: v for k, v in inferred.items() if v})
 
 
+def _package_name(analysis: dict[str, Any]) -> str:
+    title = str(analysis.get("title") or "").strip()
+    if title and title.lower() not in {"azure architecture package", "azure landing zone", "architecture package"}:
+        return title
+
+    workload = analysis.get("workload") or analysis.get("workload_name") or analysis.get("application")
+    if workload:
+        return str(workload).strip()
+
+    zones = analysis.get("zones")
+    if isinstance(zones, list):
+        for zone in zones:
+            if isinstance(zone, dict) and zone.get("name"):
+                return str(zone["name"]).strip()
+
+    return "Azure"
+
+
+def _diagram_analysis(analysis: dict[str, Any], diagram: DiagramVariant) -> dict[str, Any]:
+    source = str(analysis.get("source_provider") or "AWS").upper()
+    package_name = _package_name(analysis)
+    title = (
+        f"{package_name} — DR Azure Topology ({source} → Azure)"
+        if diagram == "dr"
+        else f"{package_name} — Target Azure Topology ({source} → Azure)"
+    )
+    return {**analysis, "title": title}
+
+
 def _profile_rows(profile: dict[str, str]) -> list[tuple[str, str]]:
     labels = [
         ("environment", "Environment"),
@@ -180,7 +233,7 @@ def _profile_rows(profile: dict[str, str]) -> list[tuple[str, str]]:
     return [(label, profile.get(key, "Not specified")) for key, label in labels]
 
 
-def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[str]:
+def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[tuple[str, str]]:
     regions = infer_regions(analysis, dr_variant="primary")
     dr_mode = infer_dr_mode({**analysis, "regions": regions})
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
@@ -189,32 +242,32 @@ def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[s
     target_region = profile.get("region") or regions[0].get("name", "the selected Azure region")
 
     points = [
-        f"Translate the detected {source} estate into Azure landing-zone tiers so platform teams can review ingress, compute, data, identity, storage, and observability separately.",
-        f"Use {target_region} as the primary deployment anchor and align the topology to {profile.get('availability', 'the stated availability target')}.",
-        f"Apply {profile.get('network_isolation', 'VNet integration')} and {profile.get('data_residency', 'the stated data residency posture')} as design guardrails.",
-        f"Keep {profile.get('sku_strategy', 'balanced')} as the commercial posture for sizing and cost discussions.",
+        ("Lead with the source-to-target story", f"Translate the detected {source} estate into Azure landing-zone tiers so platform teams can review ingress, compute, data, identity, storage, and observability separately."),
+        ("Anchor the deployment region", f"Use {target_region} as the primary deployment anchor and align the topology to {profile.get('availability', 'the stated availability target')}."),
+        ("Make security boundaries explicit", f"Apply {profile.get('network_isolation', 'VNet integration')} and {profile.get('data_residency', 'the stated data residency posture')} as design guardrails."),
+        ("Keep cost posture visible", f"Keep {profile.get('sku_strategy', 'balanced')} as the commercial posture for sizing and cost discussions."),
     ]
     if high_conf:
-        points.append(f"{high_conf} service mappings are high-confidence and can move into implementation planning after owner review.")
+        points.append(("Move high-confidence services forward", f"{high_conf} service mappings are high-confidence and can move into implementation planning after owner review."))
     if dr_mode != "single-region":
-        points.append(f"The DR view should be reviewed as a {dr_mode} pattern before committing RTO/RPO or runbook ownership.")
+        points.append(("Review DR before commitment", f"The DR view should be reviewed as a {dr_mode} pattern before committing RTO/RPO or runbook ownership."))
     return points[:6]
 
 
-def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[str]:
+def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[tuple[str, str]]:
     warnings = [str(w) for w in analysis.get("warnings", []) if w]
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
     low_conf = [m for m in mappings if float(m.get("confidence") or 0) < 0.8]
-    limits = warnings[:5]
+    limits = [("Review warning", warning) for warning in warnings[:5]]
     if low_conf:
         names = ", ".join(str(m.get("azure_service") or m.get("target") or "Unknown") for m in low_conf[:4])
-        limits.append(f"Low-confidence mappings need owner validation before deployment: {names}.")
+        limits.append(("Validate low-confidence mappings", f"Low-confidence mappings need owner validation before deployment: {names}."))
     if profile.get("compliance") and profile.get("compliance") != "None":
-        limits.append(f"Compliance scope is advisory until validated against the customer's control set: {profile['compliance']}.")
+        limits.append(("Validate compliance scope", f"Compliance scope is advisory until validated against the customer's control set: {profile['compliance']}."))
     if profile.get("rto") and profile.get("rto") != "Not required":
-        limits.append(f"RTO target {profile['rto']} requires backup, replication, failover, and operations runbook validation.")
+        limits.append(("Prove RTO/RPO operations", f"RTO target {profile['rto']} requires backup, replication, failover, and operations runbook validation."))
     if not limits:
-        limits.append("No blocking limitations were inferred, but service owners should validate networking, identity, and data dependencies before deployment.")
+        limits.append(("Owner validation required", "No blocking limitations were inferred, but service owners should validate networking, identity, and data dependencies before deployment."))
     return limits[:8]
 
 

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -693,17 +693,18 @@ def _az_column(x: int, y: int, label: str, pods: list[Optional[str]]) -> str:
     )
     out.append(_tx(8, 16, label, "t-banner"))
 
+    visible_pods = [pod for pod in pods[:6] if pod]
+    if not visible_pods:
+        visible_pods = ["Workload not inferred"]
+
     cell_h = 36
-    for i, pod in enumerate(pods[:6]):
+    for i, pod in enumerate(visible_pods[:6]):
         cy = 30 + i * cell_h
         out.append(
             f'<rect x="8" y="{cy}" width="{col_w - 16}" height="{cell_h - 4}" rx="4" '
             f'fill="#FFFFFF" stroke="#cdd5e3" stroke-width="1"/>'
         )
-        if pod:
-            out.append(_tx(col_w / 2, cy + 20, pod, "t-tiny", anchor="middle"))
-        else:
-            out.append(_tx(col_w / 2, cy + 20, "(empty)", "t-tinier", anchor="middle"))
+        out.append(_tx(col_w / 2, cy + 20, pod, "t-tiny", anchor="middle"))
     out.append('</g>')
     return "\n".join(out)
 

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -724,7 +724,7 @@ def _vnet_block(tiers: dict[str, list[dict[str, Any]]]) -> str:
 
 
 def _az_column(x: int, y: int, label: str, pods: list[Optional[str]]) -> str:
-    """Single AZ column with header + 6 pod cells."""
+    """Single AZ column with header and inferred workload pod cells."""
     out = [f'<g transform="translate({x}, {y})">']
     col_w, col_h = 320, 260
     out.append(_card(0, 0, col_w, col_h, stroke=COLOR_INK_2))

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -21,6 +21,7 @@ import base64
 import re
 import time
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from typing import Any, Literal, Optional
 
 from azure_landing_zone_schema import (
@@ -179,27 +180,66 @@ _ICON_TILE_COLOR: dict[str, str] = {
     "user":         COLOR_INK_2,
 }
 
+_BUNDLED_ICON_FILES: dict[str, str] = {
+    "frontdoor": "front_door.svg",
+    "appgw": "application_gateway.svg",
+    "storage": "blob_storage.svg",
+    "aks": "aks.svg",
+    "files": "azure_files.svg",
+    "sql": "sql_database.svg",
+    "eventhub": "event_hubs.svg",
+    "monitor": "azure_monitor.svg",
+    "appinsights": "application_insights.svg",
+    "loganalytics": "log_analytics.svg",
+    "dns": "azure_dns.svg",
+    "avd": "virtual_desktop.svg",
+    "entra": "entra_id.svg",
+    "keyvault": "key_vault.svg",
+    "region": "management_groups.svg",
+    "subnet": "virtual_network.svg",
+    "vnet": "virtual_network.svg",
+    "vm": "virtual_machine.svg",
+    "rg": "resource_manager.svg",
+}
+
+_BUNDLED_AZURE_ICON_DIR = Path(__file__).resolve().parent / "samples" / "azure"
+
 
 def _resolve_data_uri(icon_key: str) -> Optional[str]:
     """Look the icon up in Archmorph's icon registry and return a data URI."""
     try:
         from icons.registry import resolve_icon  # type: ignore
     except Exception:  # nosec B110 - registry optional
-        return None
+        resolve_icon = None  # type: ignore[assignment]
 
-    candidates = _ICON_SERVICE_IDS.get(icon_key, [icon_key])
-    for sid in candidates:
-        try:
-            entry = resolve_icon(sid, provider="azure")
-        except Exception:  # nosec B110 - any registry error → placeholder
-            entry = None
-        if entry and entry.svg:
+    if resolve_icon is not None:
+        candidates = _ICON_SERVICE_IDS.get(icon_key, [icon_key])
+        for sid in candidates:
             try:
-                b64 = base64.b64encode(entry.svg.encode("utf-8")).decode("ascii")
-            except Exception:  # nosec B110 - encoding errors → placeholder
-                continue
-            return f"data:image/svg+xml;base64,{b64}"
-    return None
+                entry = resolve_icon(sid, provider="azure")
+            except Exception:  # nosec B110 - any registry error → bundled fallback
+                entry = None
+            if entry and entry.svg:
+                try:
+                    b64 = base64.b64encode(entry.svg.encode("utf-8")).decode("ascii")
+                except Exception:  # nosec B110 - encoding errors → bundled fallback
+                    continue
+                return f"data:image/svg+xml;base64,{b64}"
+    return _resolve_bundled_data_uri(icon_key)
+
+
+def _resolve_bundled_data_uri(icon_key: str) -> Optional[str]:
+    """Resolve a bundled Azure SVG icon when the runtime registry is incomplete."""
+    filename = _BUNDLED_ICON_FILES.get(icon_key)
+    if not filename:
+        return None
+    path = _BUNDLED_AZURE_ICON_DIR / filename
+    try:
+        svg = path.read_bytes()
+    except OSError:
+        return None
+    b64 = base64.b64encode(svg).decode("ascii")
+    return f"data:image/svg+xml;base64,{b64}"
 
 
 _ICON_CACHE: dict[str, Optional[str]] = {}

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -56,6 +56,13 @@ def test_html_package_contains_tabs_and_namespaced_svg_ids():
     assert "Customer Intent" in content
     assert "East US" in content
     assert "(empty)" not in content
+    assert "data:image/svg+xml;base64" in content
+    assert ">FD<" not in content
+    assert ">AG<" not in content
+    assert ">ST<" not in content
+    assert ">AK<" not in content
+    assert ">AF<" not in content
+    assert ">DB<" not in content
     assert 'id="a-primary"' in content
     assert 'id="a-dr"' in content
     assert 'marker-end="url(#a)"' not in content

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -50,10 +50,12 @@ def test_html_package_contains_tabs_and_namespaced_svg_ids():
     content = result["content"]
     assert result["format"] == "architecture-package-html"
     assert result["filename"].endswith(".html")
-    assert "Target Topology" in content
-    assert "DR Topology" in content
+    assert "Archmorph — Package Test Architecture Package" in content
+    assert "A — Target Azure Topology" in content
+    assert "B — DR Topology" in content
     assert "Customer Intent" in content
     assert "East US" in content
+    assert "(empty)" not in content
     assert 'id="a-primary"' in content
     assert 'id="a-dr"' in content
     assert 'marker-end="url(#a)"' not in content
@@ -71,7 +73,7 @@ def test_export_architecture_package_endpoint_returns_html(test_client):
     data = response.json()
     assert data["format"] == "architecture-package-html"
     assert data["filename"].endswith(".html")
-    assert "Target Topology" in data["content"]
+    assert "A — Target Azure Topology" in data["content"]
 
 
 def test_export_architecture_package_endpoint_returns_dr_svg(test_client):

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -246,22 +246,8 @@ class TestProductionReadyGuardrails:
             f"_ICON_SERVICE_IDS. See epic #586."
         )
 
-    @pytest.mark.xfail(
-        reason="#592 — `_ICON_SERVICE_IDS` map currently covers 20 of 35 "
-               "canonical service slots; raising to ≥ 90% requires expanding "
-               "the map to cover Service Bus, Event Grid, Cosmos DB, Defender, "
-               "Activity Log, Conditional Access, Container Apps, etc. This "
-               "test is the TDD anchor for that work and will start passing "
-               "once #592 lands.",
-        strict=True,
-    )
     def test_real_icon_ratio_meets_90pct_target(self, canonical_aws_estate):
-        """#592 target — real_icon_count ≥ 0.9 * total_image_count.
-
-        The original issue-#588 acceptance bullet, kept here as an explicit
-        TDD anchor. Strict xfail: if the ratio ever crosses 90%, this test
-        fails-the-build and the human must convert it to a real assertion.
-        """
+        """#592 target — real_icon_count ≥ 0.9 * total_image_count."""
         result = generate_landing_zone_svg(canonical_aws_estate, dr_variant="primary")
         real, placeholder = _count_real_vs_placeholder(result["content"])
         total = real + placeholder

--- a/docs/DIAGRAM_EXPORT_SPEC.md
+++ b/docs/DIAGRAM_EXPORT_SPEC.md
@@ -4,7 +4,7 @@
 > Target audience: developers implementing the export pipeline.
 > Date: 2026-03-17 | Version: 2.0
 
-> May 2026 update: the classic diagram formats remain supported, and the customer-facing Architecture Package adds HTML plus standalone target/DR SVG render targets on top of the same analysis result.
+> May 2026 update: the customer-facing Architecture Package is the primary website export. It exposes HTML plus standalone target/DR SVG render targets. Classic editable diagram formats remain legacy/internal API capabilities only and are no longer visible in the customer export UI.
 
 ---
 
@@ -41,8 +41,8 @@ Architecture Package exports additionally consume `customer_intent` and optional
 
 | Family | Formats | Primary Consumer | Notes |
 |--------|---------|------------------|-------|
-| Architecture Package | `format=html` or `format=svg` with `diagram=primary` or `diagram=dr` | Customer, CTO, architecture review | Polished review package with Azure topology views, talking points, limitations, and namespaced inline SVG assets. |
-| Classic Diagram Export | `excalidraw`, `drawio`, `vsdx` | Engineers editing diagrams in external tools | Multi-page/multi-frame editable diagrams using the legacy renderer contract below. |
+| Architecture Package | `format=html` or `format=svg` with `diagram=primary` or `diagram=dr` | Customer, CTO, architecture review | Polished review package with Azure topology views, talking points, limitations, and namespaced inline SVG assets. This is the only visible website diagram export family. |
+| Classic Diagram Export | `excalidraw`, `drawio`, `vsdx` | Internal/legacy engineers editing diagrams in external tools | Legacy renderer contract retained for compatibility only; do not surface these options in the customer website export UI. |
 
 ---
 

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
-  X, Download, Check, Loader2, Package, FileCode, Image,
+  X, Download, Check, Loader2, Package, FileCode,
   FileText, DollarSign, CalendarClock, ShieldCheck, FileDown,
   ChevronDown, PanelTop,
 } from 'lucide-react';
@@ -19,17 +19,6 @@ const DELIVERABLES = [
       { id: 'cloudformation', label: 'CloudFormation' },
     ],
     defaultFormat: 'terraform',
-  },
-  {
-    id: 'diagram',
-    label: 'Classic Diagram Export',
-    icon: Image,
-    formats: [
-      { id: 'excalidraw', label: 'Excalidraw' },
-      { id: 'drawio', label: 'Draw.io' },
-      { id: 'vsdx', label: 'Visio' },
-    ],
-    defaultFormat: 'excalidraw',
   },
   {
     id: 'architecture-package',
@@ -102,22 +91,6 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
     const content = data.code || JSON.stringify(data, null, 2);
     const ext = format === 'terraform' ? 'tf' : format === 'bicep' ? 'bicep' : format;
     return { blob: new Blob([content], { type: 'text/plain' }), filename: `archmorph-iac.${ext}` };
-  }
-
-  if (id === 'diagram') {
-    const data = await api.post(`/diagrams/${diagramId}/export-diagram?format=${format}`);
-    const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
-    // Visio export is legacy VDX 2003 XML — extension must be .vdx, not .vsdx.
-    // .vsdx is OOXML zip; if we labelled raw XML as .vsdx, Visio refuses to open.
-    const ext = format === 'excalidraw' ? 'excalidraw' : format === 'drawio' ? 'drawio' : 'vdx';
-    // Use format-specific MIME types so the browser/OS can route the file
-    // correctly when saved (instead of a generic octet-stream).
-    const mime = format === 'excalidraw'
-      ? 'application/json'
-      : format === 'drawio'
-      ? 'application/xml'
-      : 'application/vnd.visio'; // VDX legacy XML
-    return { blob: new Blob([content], { type: mime }), filename: data.filename || `archmorph-diagram.${ext}` };
   }
 
   if (id === 'architecture-package') {

--- a/frontend/src/components/DiagramTranslator/ExportPanel.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportPanel.jsx
@@ -6,9 +6,6 @@ const EXPORT_FORMATS = [
   { id: 'architecture-package-html', label: 'HTML Package' },
   { id: 'architecture-package-svg', label: 'Target SVG' },
   { id: 'architecture-package-svg-dr', label: 'DR SVG' },
-  { id: 'excalidraw', label: 'Excalidraw' },
-  { id: 'drawio', label: 'Draw.io' },
-  { id: 'vsdx', label: 'Visio' },
 ];
 
 export default function ExportPanel({ exportLoading, onExportDiagram }) {
@@ -17,7 +14,7 @@ export default function ExportPanel({ exportLoading, onExportDiagram }) {
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
           <h3 className="text-sm font-semibold text-text-primary mb-1">Export Architecture Package</h3>
-          <p className="text-xs text-text-muted">Download polished HTML/SVG output or classic diagram formats</p>
+          <p className="text-xs text-text-muted">Download the customer-ready HTML package or focused SVG topology outputs</p>
         </div>
         <div className="flex items-center gap-2">
           {EXPORT_FORMATS.map(f => (

--- a/frontend/src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx
@@ -16,7 +16,7 @@ describe('ExportPanel', () => {
 
   it('shows subtitle', () => {
     render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText(/Download polished HTML\/SVG output/)).toBeInTheDocument()
+    expect(screen.getByText(/Download the customer-ready HTML package/)).toBeInTheDocument()
   })
 
   it('renders HTML Package button', () => {
@@ -34,19 +34,11 @@ describe('ExportPanel', () => {
     expect(screen.getByText('DR SVG')).toBeInTheDocument()
   })
 
-  it('renders Excalidraw button', () => {
+  it('does not render legacy diagram export buttons', () => {
     render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText('Excalidraw')).toBeInTheDocument()
-  })
-
-  it('renders Draw.io button', () => {
-    render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText('Draw.io')).toBeInTheDocument()
-  })
-
-  it('renders Visio button', () => {
-    render(<ExportPanel {...defaultProps} />)
-    expect(screen.getByText('Visio')).toBeInTheDocument()
+    expect(screen.queryByText('Excalidraw')).not.toBeInTheDocument()
+    expect(screen.queryByText('Draw.io')).not.toBeInTheDocument()
+    expect(screen.queryByText('Visio')).not.toBeInTheDocument()
   })
 
   it('calls onExportDiagram with correct format', async () => {
@@ -70,17 +62,4 @@ describe('ExportPanel', () => {
     expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('architecture-package-svg-dr')
   })
 
-  it('calls onExportDiagram with drawio format', async () => {
-    const user = userEvent.setup()
-    render(<ExportPanel {...defaultProps} />)
-    await user.click(screen.getByText('Draw.io'))
-    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('drawio')
-  })
-
-  it('calls onExportDiagram with vsdx format', async () => {
-    const user = userEvent.setup()
-    render(<ExportPanel {...defaultProps} />)
-    await user.click(screen.getByText('Visio'))
-    expect(defaultProps.onExportDiagram).toHaveBeenCalledWith('vsdx')
-  })
 })


### PR DESCRIPTION
## Summary
- Restore the customer-grade Architecture Package shell with branded metadata, source/target story strip, and A/B/C/D review tabs.
- Generate package-specific target/DR SVG titles and suppress visible `(empty)` workload placeholders in Azure topology columns.
- Restore visible Azure service icons by falling back to Archmorph's bundled Azure SVG icon pack when the runtime registry is incomplete.
- Remove Draw.io, Excalidraw, and Visio from visible website export controls while documenting them as legacy/internal compatibility paths.

## Validation
- `cd backend && .venv/bin/python -m pytest tests/test_architecture_package.py -q`
- `cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/ExportPanel.test.jsx`
- `cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/index.test.jsx`
- Generated `/tmp/archmorph-package-fixed-icons.html` and verified 87 embedded SVG icon images, service badges removed for FD/AG/ST/AK/AF/DB, A/B/C/D tabs, source/target metadata, and no `(empty)` placeholders.

Closes #679