### PR TITLE
fix(package): improve networking icon fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Customer-grade package shell** — Architecture Package HTML exports now use the richer Archmorph review structure with branded header metadata, source-to-target story strip, A/B/C/D tab semantics, and grouped talking-point/limitation rows.
 - **Legacy export cleanup** — Draw.io, Excalidraw, and Visio are removed from visible website export controls so the customer UI leads only with Architecture Package HTML, Target SVG, and DR SVG.
 - **Azure icon recovery** — Azure topology SVG rendering now falls back to Archmorph's bundled Azure service icons when the runtime icon registry is incomplete, avoiding letter-badge-only customer diagrams.
+- **Networking package icon fidelity** — Networking-heavy Architecture Packages now render a dedicated Network Services rail with real Azure icons for Virtual WAN, VPN Gateway, ExpressRoute, Azure Firewall, Front Door, Application Gateway, Azure DNS, Private Link, and related edge services.
 - **Diagram placeholder cleanup** — Azure topology SVG rendering suppresses visible `(empty)` workload cells in availability-zone columns.
 
 #### Main-branch convergence and Architecture Package export (PRs #651 #652 #649 #667 #666)

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -148,6 +148,18 @@ _ICON_SERVICE_IDS: dict[str, list[str]] = {
     "avd":          ["avd", "azure-virtual-desktop", "virtual-desktop"],
     "entra":        ["entra-id", "azure-active-directory", "aad"],
     "keyvault":     ["key-vault", "keyvault"],
+    "firewall":     ["azure-firewall", "firewall"],
+    "bastion":      ["azure-bastion", "bastion"],
+    "vpn":          ["vpn-gateway", "azure-vpn-gateway", "vpn"],
+    "expressroute": ["expressroute", "express-route", "azure-expressroute"],
+    "loadbalancer": ["load-balancer", "azure-load-balancer", "loadbalancer"],
+    "privatelink":  ["private-link", "private-endpoint", "privatelink"],
+    "trafficmgr":   ["traffic-manager", "trafficmanager"],
+    "ddos":         ["ddos-protection", "azure-ddos-protection", "ddos"],
+    "virtualwan":   ["virtual-wan", "virtualwan", "azure-virtual-wan"],
+    "waf":          ["web-application-firewall", "waf"],
+    "cdn":          ["cdn", "azure-cdn"],
+    "networkwatcher": ["network-watcher", "networkwatcher"],
     "region":       ["region", "azure-region"],
     "subnet":       ["subnet", "virtual-network-subnet"],
     "vm":           ["virtual-machine", "vm"],
@@ -172,6 +184,18 @@ _ICON_TILE_COLOR: dict[str, str] = {
     "avd":          COLOR_PRIMARY,
     "entra":        COLOR_PRIMARY,
     "keyvault":     COLOR_PRIMARY,
+    "firewall":     COLOR_RED,
+    "bastion":      COLOR_PRIMARY,
+    "vpn":          COLOR_GREEN,
+    "expressroute": COLOR_GREEN,
+    "loadbalancer": COLOR_PRIMARY,
+    "privatelink":  COLOR_PURPLE,
+    "trafficmgr":   COLOR_CYAN,
+    "ddos":         COLOR_RED,
+    "virtualwan":   COLOR_GREEN,
+    "waf":          COLOR_RED,
+    "cdn":          COLOR_CYAN,
+    "networkwatcher": COLOR_PRIMARY,
     "region":       COLOR_GREEN,
     "subnet":       COLOR_PURPLE,
     "vm":           COLOR_PRIMARY,
@@ -195,6 +219,18 @@ _BUNDLED_ICON_FILES: dict[str, str] = {
     "avd": "virtual_desktop.svg",
     "entra": "entra_id.svg",
     "keyvault": "key_vault.svg",
+    "firewall": "azure_firewall.svg",
+    "bastion": "azure_bastion.svg",
+    "vpn": "vpn_gateway.svg",
+    "expressroute": "expressroute.svg",
+    "loadbalancer": "load_balancer.svg",
+    "privatelink": "private_link.svg",
+    "trafficmgr": "traffic_manager.svg",
+    "ddos": "ddos_protection.svg",
+    "virtualwan": "virtual_wan.svg",
+    "waf": "web_application_firewall.svg",
+    "cdn": "cdn.svg",
+    "networkwatcher": "network_watcher.svg",
     "region": "management_groups.svg",
     "subnet": "virtual_network.svg",
     "vnet": "virtual_network.svg",
@@ -305,8 +341,11 @@ def _placeholder_glyph(icon_key: str) -> str:
         "frontdoor": "FD", "appgw": "AG", "storage": "ST", "aks": "AK",
         "files": "AF", "sql": "DB", "eventhub": "EH", "monitor": "AM",
         "appinsights": "AI", "loganalytics": "LA", "dns": "DN", "avd": "VD",
-        "entra": "ID", "keyvault": "KV", "region": "RG", "subnet": "SN",
-        "vm": "VM", "vnet": "VN", "rg": "RG", "user": "U",
+        "entra": "ID", "keyvault": "KV", "firewall": "FW", "bastion": "BA",
+        "vpn": "VP", "expressroute": "ER", "loadbalancer": "LB",
+        "privatelink": "PL", "trafficmgr": "TM", "ddos": "DD",
+        "virtualwan": "VW", "waf": "WF", "cdn": "CD", "networkwatcher": "NW",
+        "region": "RG", "subnet": "SN", "vm": "VM", "vnet": "VN", "rg": "RG", "user": "U",
     }
     return table.get(icon_key, icon_key[:2].upper())
 
@@ -586,8 +625,122 @@ def _region_stamp(x: int, y: int, region: dict[str, Any], tiers: dict[str, list[
     # Files banner + Data subnet.
     out.append(_data_band(tiers))
 
+    # Networking services rail — make source-networking packages visibly accurate.
+    out.append(_network_services_rail(tiers))
+
     out.append('</g>')
     return "\n".join(out)
+
+
+def _network_services_rail(tiers: dict[str, list[dict[str, Any]]]) -> str:
+    """Right-side rail for inferred Azure networking services with real icons."""
+    services = _networking_services(tiers)
+    if not services:
+        return ""
+
+    x, y, w = 1540, 200, 160
+    row_h = 54
+    visible = services[:8]
+    h = 42 + len(visible) * row_h
+    out = [f'<g id="network-services" transform="translate({x}, {y})">']
+    out.append(_card(0, 0, w, h, stroke=COLOR_GREEN, fill="#FFFFFF"))
+    out.append(
+        f'<rect x="0" y="0" width="{w}" height="24" rx="2" fill="{COLOR_GREEN}"/>'
+    )
+    out.append(_tx(10, 17, "Network Services", "t-banner"))
+
+    for i, item in enumerate(visible):
+        row_y = 34 + i * row_h
+        out.append(
+            f'<rect x="8" y="{row_y}" width="{w - 16}" height="44" rx="5" '
+            f'fill="#F7FBFF" stroke="#cdd5e3" stroke-width="1"/>'
+        )
+        out.append(_img(item["icon"], 14, row_y + 8, 28, 28))
+        out.append(_tx(48, row_y + 20, _truncate(item["label"], 18), "t-tiny"))
+        if item.get("source"):
+            out.append(_tx(48, row_y + 34, _truncate(item["source"], 18), "t-tinier"))
+    out.append("</g>")
+    return "\n".join(out)
+
+
+def _networking_services(tiers: dict[str, list[dict[str, Any]]]) -> list[dict[str, str]]:
+    """Extract known Azure networking services from all inferred tier buckets."""
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entries in tiers.values():
+        for entry in entries:
+            name = str(entry.get("name", "")).strip()
+            if not name:
+                continue
+            icon = _network_icon_key(name)
+            if not icon:
+                continue
+            key = f"{icon}:{name.lower()}"
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({
+                "icon": icon,
+                "label": _network_label(name),
+                "source": str(entry.get("source", "")).strip(),
+            })
+    return out
+
+
+def _network_icon_key(name: str) -> Optional[str]:
+    text = name.lower()
+    checks: list[tuple[tuple[str, ...], str]] = [
+        (("virtual wan", "vwan"), "virtualwan"),
+        (("vpn gateway", "vpn"), "vpn"),
+        (("expressroute", "express route"), "expressroute"),
+        (("azure firewall", "firewall"), "firewall"),
+        (("bastion",), "bastion"),
+        (("application gateway", "app gateway"), "appgw"),
+        (("front door",), "frontdoor"),
+        (("web application firewall", " waf", "waf"), "waf"),
+        (("load balancer",), "loadbalancer"),
+        (("private link", "private endpoint"), "privatelink"),
+        (("traffic manager",), "trafficmgr"),
+        (("ddos",), "ddos"),
+        (("cdn",), "cdn"),
+        (("azure dns", "private dns", "dns"), "dns"),
+        (("network security group", "nsg", "route table", "udr", "nat gateway"), "networkwatcher"),
+        (("virtual network", "vnet"), "vnet"),
+    ]
+    for needles, icon in checks:
+        if any(needle in text for needle in needles):
+            return icon
+    return None
+
+
+def _network_label(name: str) -> str:
+    text = name.lower()
+    labels = {
+        "virtual wan": "Virtual WAN",
+        "vpn gateway": "VPN Gateway",
+        "expressroute": "ExpressRoute",
+        "azure firewall": "Azure Firewall",
+        "bastion": "Bastion",
+        "application gateway": "App Gateway",
+        "front door": "Front Door",
+        "web application firewall": "WAF",
+        "load balancer": "Load Balancer",
+        "private link": "Private Link",
+        "private endpoint": "Private Link",
+        "traffic manager": "Traffic Manager",
+        "ddos": "DDoS Protection",
+        "cdn": "CDN",
+        "azure dns": "Azure DNS",
+        "private dns": "Private DNS",
+        "network security group": "NSG",
+        "nat gateway": "NAT Gateway",
+        "route table": "Route Table",
+        "virtual network": "VNet",
+    }
+    for needle, label in labels.items():
+        if needle in text:
+            return label
+    return name
 
 
 def _tier1_row(tiers: dict[str, list[dict[str, Any]]]) -> str:

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -642,7 +642,7 @@ def _network_services_rail(tiers: dict[str, list[dict[str, Any]]]) -> str:
     row_h = 54
     visible = services[:8]
     h = 42 + len(visible) * row_h
-    out = [f'<g id="network-services" transform="translate({x}, {y})">']
+    out = [f'<g transform="translate({x}, {y})">']
     out.append(_card(0, 0, w, h, stroke=COLOR_GREEN, fill="#FFFFFF"))
     out.append(
         f'<rect x="0" y="0" width="{w}" height="24" rx="2" fill="{COLOR_GREEN}"/>'
@@ -684,7 +684,28 @@ def _networking_services(tiers: dict[str, list[dict[str, Any]]]) -> list[dict[st
                 "label": _network_label(name),
                 "source": str(entry.get("source", "")).strip(),
             })
+    if not _should_render_network_services(out):
+        return []
     return out
+
+
+def _should_render_network_services(services: list[dict[str, str]]) -> bool:
+    """Only show the rail when it adds real networking-specific signal."""
+    if len(services) < 3:
+        return False
+    signal_icons = {
+        "virtualwan",
+        "vpn",
+        "expressroute",
+        "firewall",
+        "bastion",
+        "loadbalancer",
+        "privatelink",
+        "trafficmgr",
+        "ddos",
+        "waf",
+    }
+    return any(service.get("icon") in signal_icons for service in services)
 
 
 def _network_icon_key(name: str) -> Optional[str]:

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -16,8 +16,11 @@ from azure_landing_zone import (
     CANVAS_H_DR,
     CANVAS_H_PRIMARY,
     CANVAS_W,
+    _icon_data_uri,
+    _networking_services,
     generate_landing_zone_svg,
 )
+from azure_landing_zone_schema import infer_tiers_from_mappings
 
 # #588 — canonical AWS estate fixture used by the tier-population +
 # real-icon-ratio guardrails. Single source of truth so a future change
@@ -52,6 +55,24 @@ DR_ANALYSIS: dict = {
     "regions": [
         {"name": "East US",     "role": "primary", "traffic_pct": 100},
         {"name": "West US 3",   "role": "standby", "traffic_pct": 0},
+    ],
+}
+
+
+NETWORKING_ANALYSIS: dict = {
+    "title": "Networking Architecture Package",
+    "source_provider": "AWS",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "networking", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "Transit Gateway", "azure_service": "Virtual WAN", "category": "Networking"},
+        {"source_service": "VPN Gateway", "azure_service": "Azure VPN Gateway", "category": "Networking"},
+        {"source_service": "Direct Connect", "azure_service": "ExpressRoute", "category": "Networking"},
+        {"source_service": "Network Firewall", "azure_service": "Azure Firewall", "category": "Security"},
+        {"source_service": "CloudFront", "azure_service": "Azure Front Door", "category": "Edge"},
+        {"source_service": "ALB", "azure_service": "Application Gateway", "category": "LoadBalancer"},
+        {"source_service": "Route 53", "azure_service": "Azure DNS", "category": "Networking"},
+        {"source_service": "PrivateLink", "azure_service": "Private Link", "category": "Networking"},
     ],
 }
 
@@ -149,6 +170,39 @@ class TestGenerator:
         # Default region name must show up.
         texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
         assert any("East US" in t for t in texts), "Default primary region missing"
+
+    def test_networking_package_renders_real_networking_icons(self):
+        result = generate_landing_zone_svg(NETWORKING_ANALYSIS, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        joined = " | ".join(texts)
+
+        for expected in [
+            "Network Services",
+            "Virtual WAN",
+            "VPN Gateway",
+            "ExpressRoute",
+            "Azure Firewall",
+            "Front Door",
+            "App Gateway",
+            "Azure DNS",
+            "Private Link",
+        ]:
+            assert expected in joined
+
+        services = _networking_services(infer_tiers_from_mappings(NETWORKING_ANALYSIS))
+        icons = {service["icon"] for service in services}
+        assert {
+            "virtualwan",
+            "vpn",
+            "expressroute",
+            "firewall",
+            "frontdoor",
+            "appgw",
+            "dns",
+            "privatelink",
+        }.issubset(icons)
+        assert all(_icon_data_uri(icon) for icon in icons)
 
     def test_landing_zone_svg_invalid_dr_variant_raises(self):
         with pytest.raises(ValueError):

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -204,6 +204,24 @@ class TestGenerator:
         }.issubset(icons)
         assert all(_icon_data_uri(icon) for icon in icons)
 
+    def test_network_services_rail_is_gated_to_networking_heavy_packages(self):
+        result = generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        assert "Network Services" not in texts
+
+    def test_networking_dr_variant_does_not_duplicate_network_services_id(self):
+        analysis = {
+            **NETWORKING_ANALYSIS,
+            "dr_mode": "active-standby",
+            "regions": DR_ANALYSIS["regions"],
+        }
+        result = generate_landing_zone_svg(analysis, dr_variant="dr")
+        root = ET.fromstring(result["content"])
+        texts = [t.text or "" for t in root.iter(f"{SVG_NS}text")]
+        assert texts.count("Network Services") == 2
+        assert 'id="network-services"' not in result["content"]
+
     def test_landing_zone_svg_invalid_dr_variant_raises(self):
         with pytest.raises(ValueError):
             generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="bogus")  # type: ignore[arg-type]

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -98,6 +98,7 @@ The PRD distinguishes three maturity levels. **Live** features are usable in the
 
 ### 3.7 Diagram Export (v2.0)
 - **Architecture Package (v4.3.0-main):** Polished customer-facing HTML export with target/as-is topology, hardened/DR topology, talking points, and limitations; SVG-only target and DR exports are available for downstream documentation tools.
+- **Networking Architecture Package fidelity:** Networking-heavy diagrams render a dedicated Azure Network Services rail with bundled Azure icons for services such as Virtual WAN, VPN Gateway, ExpressRoute, Azure Firewall, Front Door, Application Gateway, Azure DNS, and Private Link.
 - **Customer intent profile:** Guided answers are condensed into a lightweight `customer_intent` profile while raw `guided_answers` stay compact and distinguish user choices from defaults.
 - **Excalidraw (.excalidraw):** Interactive JSON format with Azure service stencils
 - **Draw.io (.drawio):** mxGraphModel XML with Azure stencils, compatible with diagrams.net


### PR DESCRIPTION
## Summary
- adds explicit bundled Azure icon mappings for networking and edge services used in Architecture Package SVG output
- renders a dedicated Network Services rail for networking-heavy packages so VPN Gateway, ExpressRoute, Azure Firewall, Virtual WAN, Front Door, Application Gateway, Azure DNS, and Private Link are visible as real Azure icons
- updates PRD/changelog and adds a regression test for networking icon coverage

## CTO review follow-up
The guided questions after upload should become adaptive and optional rather than broad and mandatory. Tracked separately in #681 so this PR stays focused on the P0 icon quality issue.

## Tests
- `cd backend && .venv/bin/python -m pytest tests/test_azure_landing_zone.py tests/test_architecture_package.py -q`

Closes part of the Networking Architecture Package icon quality follow-up.