### PR TITLE
fix: guard source_provider contract

### DIFF
--- a/backend/ai_suggestion.py
+++ b/backend/ai_suggestion.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from services.mappings import CROSS_CLOUD_MAPPINGS
+from source_provider import normalize_source_provider
 from openai_client import (
     get_openai_client,
     AZURE_OPENAI_DEPLOYMENT,
@@ -65,11 +66,12 @@ def lookup_mapping(
     Returns the mapping dict if found, None otherwise.
     """
     key = source_service.strip().lower()
-    if source_provider.lower() in ("aws", "amazon"):
+    provider = normalize_source_provider(source_provider)
+    if provider == "aws":
         return _KNOWN_AWS.get(key)
-    if source_provider.lower() in ("gcp", "google"):
+    if provider == "gcp":
         return _KNOWN_GCP.get(key)
-    return None
+    raise AssertionError(f"Unhandled source_provider: {provider}")
 
 
 # ─────────────────────────────────────────────────────────
@@ -101,6 +103,7 @@ Rules:
 
 def _build_few_shot_examples(source_provider: str, max_examples: int = 5) -> str:
     """Build few-shot examples from approved feedback for the GPT prompt."""
+    provider = normalize_source_provider(source_provider)
     # Ensure feedback is loaded from DB
     _load_feedback_from_db()
 
@@ -109,7 +112,7 @@ def _build_few_shot_examples(source_provider: str, max_examples: int = 5) -> str
         approved = [
             fb for fb in _feedback_cache
             if fb.get("decision") == "approved"
-            and fb.get("source_provider", "").lower() == source_provider.lower()
+            and fb.get("source_provider", "").lower() == provider
         ]
     # Take most recent approved entries
     for fb in approved[-max_examples:]:
@@ -120,7 +123,7 @@ def _build_few_shot_examples(source_provider: str, max_examples: int = 5) -> str
             f'"category": "{fb.get("category", "")}"}}'
         )
     # Also pull a few from the known catalogue
-    known = _KNOWN_AWS if source_provider.lower() in ("aws", "amazon") else _KNOWN_GCP
+    known = _KNOWN_AWS if provider == "aws" else _KNOWN_GCP
     for key, m in list(known.items())[:max(0, max_examples - len(examples))]:
         examples.append(
             f'  {{"source": "{key}", '
@@ -609,6 +612,7 @@ def _call_gpt_suggest(
 ) -> Dict[str, Any]:
     """Call GPT-4o for a mapping suggestion."""
     client = get_openai_client()
+    source_provider = normalize_source_provider(source_provider)
 
     user_content = f"Source provider: {source_provider}\nSource service: {source_service}"
     if context_services:
@@ -662,6 +666,8 @@ def suggest_mapping(
     dict
         Suggestion with azure_service, confidence, category, notes, etc.
     """
+    source_provider = normalize_source_provider(source_provider)
+
     # Fast path — catalogue hit
     existing = lookup_mapping(source_service, source_provider)
     if existing:
@@ -741,6 +747,7 @@ def suggest_batch(
     list
         List of suggestion dicts.
     """
+    source_provider = normalize_source_provider(source_provider)
     all_names = [s.get("name") or s.get("source_service", "") for s in services]
     results = []
     for svc in services:

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -31,6 +31,10 @@ from azure_landing_zone_schema import (
     infer_replication,
     infer_tiers_from_mappings,
 )
+from source_provider import (
+    SUPPORTED_SOURCE_PROVIDERS as _SUPPORTED_SOURCE_PROVIDERS,
+    normalize_source_provider,
+)
 
 # #595 — Observability for the landing-zone-svg pipeline. The observability
 # module is a thin wrapper around the OpenTelemetry SDK + an in-memory store
@@ -81,8 +85,6 @@ MAX_SVG_BYTES = 300 * 1024
 # one of the values in ``_SUPPORTED_SOURCE_PROVIDERS``. Missing → "aws"
 # (backwards-compatible with #571). Unknown → ValueError.
 
-_SUPPORTED_SOURCE_PROVIDERS: frozenset[str] = frozenset({"aws", "gcp"})
-
 _SOURCE_PROVIDER_LEGEND_LINE: dict[str, str] = {
     "aws": (
         "AWS → Azure · ALB → App Gateway · EKS → AKS · "
@@ -110,20 +112,7 @@ def _validate_source_provider(value: object) -> str:
       * Empty / whitespace-only string → ``ValueError`` (do NOT silently default).
       * Unknown known-string → ``ValueError``.
     """
-    if value is None:
-        return "aws"
-    if not isinstance(value, str):
-        raise ValueError(
-            f"Unsupported source_provider: {value!r}. "
-            f"Expected a string in {sorted(_SUPPORTED_SOURCE_PROVIDERS)}."
-        )
-    provider = value.strip().lower()
-    if not provider or provider not in _SUPPORTED_SOURCE_PROVIDERS:
-        raise ValueError(
-            f"Unsupported source_provider: {value!r}. "
-            f"Expected one of {sorted(_SUPPORTED_SOURCE_PROVIDERS)}."
-        )
-    return provider
+    return normalize_source_provider(value)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/network_translator.py
+++ b/backend/network_translator.py
@@ -21,6 +21,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from source_provider import normalize_source_provider
+
 logger = logging.getLogger(__name__)
 
 # ─────────────────────────────────────────────────────────────
@@ -578,7 +580,7 @@ def translate_network_topology(
         NetworkTopology with all translated components.
     """
     validate_cidr(vnet_cidr)
-    provider = analysis.get("source_provider", "aws").lower()
+    provider = normalize_source_provider(analysis.get("source_provider"))
 
     with _lock:
         return _translate_impl(analysis, vnet_cidr, subnet_prefix, vnet_name, provider)

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -34,6 +34,7 @@ from analysis_history import maybe_save_from_session
 from sku_translator import get_sku_translator
 from confidence_provenance import build_provenance
 from architecture_rules import evaluate as evaluate_architecture_rules
+from source_provider import normalize_source_provider
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def _enrich_with_sku(result: dict) -> dict:
     SKU translation details with parity scores.
     """
     engine = get_sku_translator()
-    provider = result.get("source_provider", "aws").lower()
+    provider = normalize_source_provider(result.get("source_provider"))
 
     for m in result.get("mappings", []):
         source_name = m.get("source_service", "")

--- a/backend/routers/network_routes.py
+++ b/backend/routers/network_routes.py
@@ -9,6 +9,7 @@ import logging
 
 from routers.shared import SESSION_STORE, limiter, verify_api_key
 from error_envelope import ArchmorphException
+from source_provider import normalize_source_provider
 from network_translator import (
     translate_network_topology,
     translate_gcp_network,
@@ -79,7 +80,10 @@ async def generate_network_topology(
     if params.network_overrides:
         effective_analysis["network"] = params.network_overrides
 
-    provider = effective_analysis.get("source_provider", "aws").lower()
+    try:
+        provider = normalize_source_provider(effective_analysis.get("source_provider"))
+    except ValueError as exc:
+        raise ArchmorphException(400, str(exc))
 
     try:
         if provider == "gcp":

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -6,13 +6,14 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional
 import asyncio
 import logging
 
 from routers.shared import limiter, verify_api_key
 from routers.samples import get_or_recreate_session
+from source_provider import normalize_source_provider
 from usage_metrics import record_event
 from ai_suggestion import (
     suggest_mapping,
@@ -29,17 +30,24 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class SuggestMappingRequest(BaseModel):
+class SourceProviderRequest(BaseModel):
+    source_provider: str = Field("aws", pattern="^(aws|gcp)$")
+
+    @field_validator("source_provider", mode="before")
+    @classmethod
+    def normalize_provider(cls, value):
+        return normalize_source_provider(value)
+
+
+class SuggestMappingRequest(SourceProviderRequest):
     """Request body for single AI mapping suggestion."""
     source_service: str = Field(..., min_length=1, max_length=200)
-    source_provider: str = Field("aws", pattern="^(aws|gcp)$")
     context_services: Optional[list] = None
 
 
-class SuggestBatchRequest(BaseModel):
+class SuggestBatchRequest(SourceProviderRequest):
     """Request body for batch AI mapping suggestions."""
     services: list = Field(..., min_length=1, max_length=50)
-    source_provider: str = Field("aws", pattern="^(aws|gcp)$")
 
 
 class ReviewRequest(BaseModel):
@@ -51,17 +59,15 @@ class ReviewRequest(BaseModel):
     notes: Optional[str] = None
 
 
-class GenerateRequest(BaseModel):
+class GenerateRequest(SourceProviderRequest):
     """Request body for triggering AI suggestion generation."""
     source_service: str = Field(..., min_length=1, max_length=200)
-    source_provider: str = Field("aws", pattern="^(aws|gcp)$")
     context_services: Optional[list] = None
 
 
-class GenerateBatchRequest(BaseModel):
+class GenerateBatchRequest(SourceProviderRequest):
     """Request body for batch AI suggestion generation."""
     services: list = Field(..., min_length=1, max_length=50)
-    source_provider: str = Field("aws", pattern="^(aws|gcp)$")
 
 
 @router.post("/api/suggest/mapping", tags=["ai-suggestion"])

--- a/backend/source_provider.py
+++ b/backend/source_provider.py
@@ -1,0 +1,35 @@
+"""Source-cloud provider contract helpers."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+SUPPORTED_SOURCE_PROVIDERS: Final[frozenset[str]] = frozenset({"aws", "gcp"})
+
+
+def normalize_source_provider(value: object, *, default: str = "aws") -> str:
+    """Return a canonical source provider or raise ``ValueError``.
+
+    Contract:
+      * ``None`` means the caller omitted the field and falls back to ``default``.
+      * Strings are stripped and lowercased.
+      * Empty strings, non-strings, and unsupported values are rejected.
+    """
+    if value is None:
+        value = default
+
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Unsupported source_provider: {value!r}. "
+            f"Expected a string in {sorted(SUPPORTED_SOURCE_PROVIDERS)}."
+        )
+
+    provider = value.strip().lower()
+    if not provider or provider not in SUPPORTED_SOURCE_PROVIDERS:
+        raise ValueError(
+            f"Unsupported source_provider: {value!r}. "
+            f"Expected one of {sorted(SUPPORTED_SOURCE_PROVIDERS)}."
+        )
+
+    return provider

--- a/backend/tests/test_ai_suggestion.py
+++ b/backend/tests/test_ai_suggestion.py
@@ -7,6 +7,8 @@ Tests for ai_suggestion.py (Issue #153)
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from ai_suggestion import (
@@ -45,6 +47,17 @@ class TestLookupMapping:
     def test_lambda_lookup(self):
         result = lookup_mapping("Lambda", "aws")
         assert result is not None
+
+    def test_uppercase_provider_is_normalized(self):
+        assert lookup_mapping("EC2", "AWS") == lookup_mapping("EC2", "aws")
+
+    @pytest.mark.parametrize("provider", ["azure", "amazon", "google", "", 123])
+    def test_invalid_provider_is_rejected(self, provider):
+        with pytest.raises(ValueError, match="Unsupported source_provider"):
+            lookup_mapping("EC2", provider)
+
+    def test_none_provider_uses_legacy_aws_default(self):
+        assert lookup_mapping("EC2", None) == lookup_mapping("EC2", "aws")
 
 
 # ====================================================================
@@ -230,3 +243,13 @@ def test_suggest_mapping_gpt_failure(mock_get_client):
     res = suggest_mapping("UnknownService", "aws")
     # if suggest_mapping catches error, it returns "Unknown Resource/No Match"
     assert res["azure_service"] == "Unknown"
+
+
+def test_suggest_mapping_normalizes_provider_in_result():
+    res = suggest_mapping("EC2", "AWS")
+    assert res["source_provider"] == "aws"
+
+
+def test_suggest_mapping_rejects_azure_source_provider():
+    with pytest.raises(ValueError, match="Unsupported source_provider"):
+        suggest_mapping("Virtual Machines", "azure")

--- a/backend/tests/test_source_provider.py
+++ b/backend/tests/test_source_provider.py
@@ -1,0 +1,35 @@
+import pytest
+
+from network_translator import translate_network_topology
+from source_provider import SUPPORTED_SOURCE_PROVIDERS, normalize_source_provider
+
+
+class TestNormalizeSourceProvider:
+    def test_supported_values_are_exactly_aws_and_gcp(self):
+        assert SUPPORTED_SOURCE_PROVIDERS == frozenset({"aws", "gcp"})
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, "aws"),
+            ("aws", "aws"),
+            ("AWS", "aws"),
+            (" gCp ", "gcp"),
+        ],
+    )
+    def test_normalizes_supported_values(self, raw, expected):
+        assert normalize_source_provider(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", "   ", "azure", "amazon", "google", "alibaba"])
+    def test_rejects_empty_aliases_and_unsupported_values(self, raw):
+        with pytest.raises(ValueError, match="Unsupported source_provider"):
+            normalize_source_provider(raw)
+
+    @pytest.mark.parametrize("raw", [123, True, ["aws"], {"provider": "aws"}])
+    def test_rejects_non_strings(self, raw):
+        with pytest.raises(ValueError, match="Expected a string"):
+            normalize_source_provider(raw)
+
+    def test_network_translator_rejects_azure_as_source_provider(self):
+        with pytest.raises(ValueError, match="Unsupported source_provider"):
+            translate_network_topology({"source_provider": "azure"})

--- a/backend/tests/test_suggestion_provider_contract.py
+++ b/backend/tests/test_suggestion_provider_contract.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import ValidationError
+
+from routers.suggestions import GenerateBatchRequest, GenerateRequest, SuggestBatchRequest, SuggestMappingRequest
+
+
+class TestSuggestionProviderContract:
+    @pytest.mark.parametrize(
+        "model_cls,payload",
+        [
+            (SuggestMappingRequest, {"source_service": "EC2", "source_provider": "AWS"}),
+            (GenerateRequest, {"source_service": "Compute Engine", "source_provider": " gCp "}),
+            (SuggestBatchRequest, {"services": [{"name": "EC2"}], "source_provider": None}),
+            (GenerateBatchRequest, {"services": [{"name": "Cloud SQL"}]}),
+        ],
+    )
+    def test_request_models_normalize_supported_values_and_defaults(self, model_cls, payload):
+        model = model_cls(**payload)
+        assert model.source_provider in {"aws", "gcp"}
+
+    @pytest.mark.parametrize(
+        "model_cls,payload",
+        [
+            (SuggestMappingRequest, {"source_service": "VM", "source_provider": "azure"}),
+            (GenerateRequest, {"source_service": "EC2", "source_provider": ""}),
+            (SuggestBatchRequest, {"services": [{"name": "EC2"}], "source_provider": "amazon"}),
+            (GenerateBatchRequest, {"services": [{"name": "Cloud SQL"}], "source_provider": 123}),
+        ],
+    )
+    def test_request_models_reject_unsupported_values(self, model_cls, payload):
+        with pytest.raises(ValidationError):
+            model_cls(**payload)

--- a/docs/azure-landing-zone-source-provider.md
+++ b/docs/azure-landing-zone-source-provider.md
@@ -56,12 +56,12 @@ Mapping: GCP → Azure · GLB → App Gateway · GKE → AKS · Filestore → Az
 
 ## Source of truth
 
-- Constants live in [`backend/azure_landing_zone.py`](../backend/azure_landing_zone.py):
-  - `_SUPPORTED_SOURCE_PROVIDERS: frozenset[str]` — allowed values.
+- The shared contract helper lives in [`backend/source_provider.py`](../backend/source_provider.py):
+  - `SUPPORTED_SOURCE_PROVIDERS: frozenset[str]` — allowed values.
+  - `normalize_source_provider(value) -> str` — lowercases, defaults, raises.
+- Landing-zone legend constants live in [`backend/azure_landing_zone.py`](../backend/azure_landing_zone.py):
   - `_SOURCE_PROVIDER_LEGEND_LINE: dict[str, str]` — verbatim mapping line per
     provider.
-  - `_validate_source_provider(value: str | None) -> str` — single validation
-    entry point. Lowercases, defaults, raises.
 - A module-load `assert` keeps `_SUPPORTED_SOURCE_PROVIDERS` and
   `_SOURCE_PROVIDER_LEGEND_LINE` in lockstep.
 


### PR DESCRIPTION
## Summary
- centralize the source-provider contract in `backend/source_provider.py` with exact `aws|gcp` support and legacy `None`/missing -> `aws` default
- wire the shared normalizer into ALZ, AI suggestions, suggestion request models, SKU enrichment, and network topology translation
- reject aliases/unsupported values such as `azure`, `amazon`, and `google` instead of silently routing them through AWS/GCP paths
- update the ALZ source-provider contract doc and add regression tests

Closes #685.

## Validation
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_source_provider.py tests/test_ai_suggestion.py tests/test_suggestion_provider_contract.py tests/test_azure_landing_zone.py -q`
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_source_provider.py tests/test_ai_suggestion.py tests/test_suggestion_provider_contract.py tests/test_azure_landing_zone.py tests/test_api.py tests/test_middleware_and_routers.py tests/test_contract.py -q`