### PR TITLE
test: validate cross-cloud architecture package scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **AWS/GCP source-cloud parity** — upgraded relevant custom agents so CTO, Cloud, Backend, API, DevOps, CISO, QA, Performance, Bug, PM, FE, UX, and Scrum guidance treats AWS and GCP source environments with the same architectural rigor as Azure while preserving Azure as the target artifact platform.
 - **Diagramming skill parity** — Draw.io and Excalidraw skills now call out AWS-to-Azure, GCP-to-Azure, and mixed-cloud migration views, including GCP topology expectations and explicit source-provider context in Architecture Package handoffs.
+- **Architecture Package cross-cloud validation** — Architecture Package HTML/SVG tests now cover AWS, GCP, and mixed AWS/GCP source scenarios, including source traceability, Azure target primacy, DR outputs, talking points, limitations, and customer source filenames.
 
 #### Main-branch convergence and Architecture Package export (PRs #651 #652 #649 #667 #666)
 

--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 from azure_landing_zone import generate_landing_zone_svg
 from azure_landing_zone_schema import infer_dr_mode, infer_regions, infer_tiers_from_mappings
 from customer_intent import build_customer_intent_profile
+from source_provider import normalize_source_provider
 
 
 PackageFormat = Literal["html", "svg"]
@@ -63,7 +64,7 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
     package_name = _package_name(analysis)
     title = html.escape(f"Archmorph — {package_name} Architecture Package")
     display_name = html.escape(package_name)
-    source = html.escape(str(analysis.get("source_provider") or "AWS").upper())
+    source = html.escape(_source_label(analysis))
     profile = _profile_from_analysis(analysis)
     regions = infer_regions(analysis, dr_variant="primary")
     target_region = html.escape(profile.get("region") or regions[0].get("name", "Selected Azure region"))
@@ -208,7 +209,7 @@ def _package_name(analysis: dict[str, Any]) -> str:
 
 
 def _diagram_analysis(analysis: dict[str, Any], diagram: DiagramVariant) -> dict[str, Any]:
-    source = str(analysis.get("source_provider") or "AWS").upper()
+    source = _source_label(analysis)
     package_name = _package_name(analysis)
     title = (
         f"{package_name} — DR Azure Topology ({source} → Azure)"
@@ -238,7 +239,7 @@ def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[t
     dr_mode = infer_dr_mode({**analysis, "regions": regions})
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
     high_conf = sum(1 for m in mappings if float(m.get("confidence") or 0) >= 0.9)
-    source = str(analysis.get("source_provider") or "AWS").upper()
+    source = _source_label(analysis)
     target_region = profile.get("region") or regions[0].get("name", "the selected Azure region")
 
     points = [
@@ -252,6 +253,32 @@ def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[t
     if dr_mode != "single-region":
         points.append(("Review DR before commitment", f"The DR view should be reviewed as a {dr_mode} pattern before committing RTO/RPO or runbook ownership."))
     return points[:6]
+
+
+def _source_label(analysis: dict[str, Any]) -> str:
+    providers: list[str] = []
+
+    def add_provider(value: Any) -> None:
+        provider = normalize_source_provider(value)
+        if provider not in providers:
+            providers.append(provider)
+
+    declared = analysis.get("source_providers")
+    if isinstance(declared, (list, tuple, set)):
+        for value in declared:
+            add_provider(value)
+
+    source_provider = analysis.get("source_provider")
+    if source_provider is not None or not providers:
+        add_provider(source_provider)
+
+    mappings = analysis.get("mappings", [])
+    if isinstance(mappings, list):
+        for mapping in mappings:
+            if isinstance(mapping, dict) and mapping.get("source_provider") is not None:
+                add_provider(mapping["source_provider"])
+
+    return "/".join(provider.upper() for provider in providers)
 
 
 def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[tuple[str, str]]:

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
+import pytest
+
 from architecture_package import generate_architecture_package
 from customer_intent import build_customer_intent_profile
 from routers.shared import SESSION_STORE
@@ -27,6 +29,52 @@ SAMPLE_ANALYSIS: dict = {
         "arch_dr_rto": "<15 min",
         "sec_compliance": ["SOC 2", "GDPR"],
         "sec_network_isolation": "Full private endpoints",
+    },
+}
+
+
+GCP_ANALYSIS: dict = {
+    "title": "GCP Package Test",
+    "source_provider": "gcp",
+    "target_provider": "azure",
+    "source_filename": "gcp-topology.drawio",
+    "zones": [{"id": 1, "name": "gcp-web-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "Cloud Load Balancing", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.93},
+        {"source_service": "GKE", "azure_service": "AKS", "category": "Containers", "confidence": 0.95},
+        {"source_service": "Cloud SQL", "azure_service": "Azure SQL", "category": "Database", "confidence": 0.91},
+        {"source_service": "Pub/Sub", "azure_service": "Event Hubs", "category": "Messaging", "confidence": 0.86},
+    ],
+    "guided_answers": {
+        "env_target": "Production",
+        "arch_deploy_region": "West US 3",
+        "arch_ha": "Multi-region active-passive (99.99 %)",
+        "arch_dr_rto": "<30 min",
+        "sec_compliance": ["HIPAA"],
+    },
+}
+
+
+MIXED_ANALYSIS: dict = {
+    "title": "Mixed Source Package Test",
+    "source_provider": "aws",
+    "source_providers": ["aws", "gcp"],
+    "target_provider": "azure",
+    "source_filename": "mixed-estate.pdf",
+    "zones": [{"id": 1, "name": "mixed-platform", "number": 1, "services": []}],
+    "mappings": [
+        {"source_provider": "aws", "source_service": "EKS", "azure_service": "AKS", "category": "Containers", "confidence": 0.94},
+        {"source_provider": "aws", "source_service": "RDS", "azure_service": "Azure SQL", "category": "Database", "confidence": 0.89},
+        {"source_provider": "gcp", "source_service": "Pub/Sub", "azure_service": "Event Hubs", "category": "Messaging", "confidence": 0.87},
+        {"source_provider": "gcp", "source_service": "Cloud Storage", "azure_service": "Blob Storage", "category": "Storage", "confidence": 0.9},
+    ],
+    "warnings": ["Mixed source estate requires source-owner validation before deployment."],
+    "guided_answers": {
+        "env_target": "Production",
+        "arch_deploy_region": "East US",
+        "arch_ha": "Multi-region active-passive (99.99 %)",
+        "arch_dr_rto": "<1 hour",
+        "sec_network_isolation": "Hub-spoke VNets with private endpoints",
     },
 }
 
@@ -66,6 +114,55 @@ def test_html_package_contains_tabs_and_namespaced_svg_ids():
     assert 'id="a-primary"' in content
     assert 'id="a-dr"' in content
     assert 'marker-end="url(#a)"' not in content
+
+
+@pytest.mark.parametrize(
+    ("analysis", "source_label", "expected_services"),
+    [
+        (SAMPLE_ANALYSIS, "AWS", ["Application Gateway", "AKS", "Azure SQL"]),
+        (GCP_ANALYSIS, "GCP", ["Application Gateway", "AKS", "Event Hubs"]),
+        (MIXED_ANALYSIS, "AWS/GCP", ["AKS", "Azure SQL", "Event Hubs", "Blob Storage"]),
+    ],
+)
+def test_architecture_package_preserves_source_context_and_azure_target(
+    analysis, source_label, expected_services
+):
+    result = generate_architecture_package(analysis, format="html")
+    content = result["content"]
+
+    assert f"Source: {source_label}" in content
+    assert "Target: Azure" in content
+    assert f"{source_label} → Azure" in content
+    assert "A — Target Azure Topology" in content
+    assert "B — DR Topology" in content
+    assert "C — Talking Points" in content
+    assert "D — Services Limitations" in content
+    assert "Assumptions And Constraints" in content
+    if analysis.get("source_filename"):
+        assert str(analysis["source_filename"]) in content
+    for service in expected_services:
+        assert service in content
+
+
+def test_mixed_architecture_package_surfaces_mixed_source_traceability():
+    result = generate_architecture_package(MIXED_ANALYSIS, format="html")
+    content = result["content"]
+
+    assert "Source: AWS/GCP" in content
+    assert "Mixed source estate requires source-owner validation before deployment." in content
+    assert "mixed-estate.pdf" in content
+    assert "Mixed Source Package Test — Target Azure Topology (AWS/GCP → Azure)" in content
+    assert "Mixed Source Package Test — DR Azure Topology (AWS/GCP → Azure)" in content
+
+
+@pytest.mark.parametrize("diagram", ["primary", "dr"])
+def test_mixed_architecture_package_svg_outputs_are_parseable(diagram):
+    result = generate_architecture_package(MIXED_ANALYSIS, format="svg", diagram=diagram)
+    assert result["format"] == "architecture-package-svg"
+    assert result["filename"].endswith(f"-{diagram}.svg")
+    root = ET.fromstring(result["content"])
+    assert root.tag.endswith("svg")
+    assert f"Mixed Source Package Test — {'DR' if diagram == 'dr' else 'Target'} Azure Topology (AWS/GCP → Azure)" in result["content"]
 
 
 def test_export_architecture_package_endpoint_returns_html(test_client):


### PR DESCRIPTION
## Summary
- add Architecture Package source labeling that can surface mixed AWS/GCP source context without expanding the strict `source_provider=aws|gcp` contract
- add AWS, GCP, and mixed AWS/GCP Architecture Package scenario coverage for source traceability, Azure target primacy, tabs, talking points, limitations, filenames, and DR/primary SVG outputs
- document the validation coverage in the changelog

Closes #684.

## Validation
- `.venv/bin/python -m pytest tests/test_architecture_package.py tests/test_azure_landing_zone.py tests/test_source_provider.py`