### PR TITLE
test: validate mixed-cloud classic diagram handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AWS/GCP source-cloud parity** — upgraded relevant custom agents so CTO, Cloud, Backend, API, DevOps, CISO, QA, Performance, Bug, PM, FE, UX, and Scrum guidance treats AWS and GCP source environments with the same architectural rigor as Azure while preserving Azure as the target artifact platform.
 - **Diagramming skill parity** — Draw.io and Excalidraw skills now call out AWS-to-Azure, GCP-to-Azure, and mixed-cloud migration views, including GCP topology expectations and explicit source-provider context in Architecture Package handoffs.
 - **Architecture Package cross-cloud validation** — Architecture Package HTML/SVG tests now cover AWS, GCP, and mixed AWS/GCP source scenarios, including source traceability, Azure target primacy, DR outputs, talking points, limitations, and customer source filenames.
+- **Classic diagram mixed-cloud handoff validation** — Draw.io and Excalidraw parser tests now cover mixed AWS/GCP-to-Azure handoffs with provider-prefixed source labels and deterministic Draw.io fallback icons for unmapped GCP-origin services.
 
 #### Main-branch convergence and Architecture Package export (PRs #651 #652 #649 #667 #666)
 

--- a/backend/diagram_export.py
+++ b/backend/diagram_export.py
@@ -21,6 +21,8 @@ from typing import Any
 import os
 import re
 
+from source_provider import normalize_source_provider
+
 _data_file_AZURE_STENCILS = os.path.join(os.path.dirname(__file__), 'assets', 'diagram_stencils.json')
 try:
     with open(_data_file_AZURE_STENCILS, 'r') as _f:
@@ -69,6 +71,27 @@ _CONFIDENCE_COLORS = {
 
 _AZURE_PRIMARY = "#0078D4"
 _AZURE_SECONDARY = "#50E6FF"
+
+
+def _source_provider_label(value: Any) -> str:
+    return normalize_source_provider(value).upper()
+
+
+def _source_service_label(source_service: str, source_provider: Any) -> str:
+    return f"[{_source_provider_label(source_provider)}] {source_service}"
+
+
+def _migration_label(source_service: str, azure_service: str, source_provider: Any) -> str:
+    source = _source_service_label(source_service, source_provider)
+    return f"{source} → {azure_service}" if source_service != azure_service else source
+
+
+def _service_source_name(service: Any) -> str:
+    if isinstance(service, str):
+        return service
+    if isinstance(service, dict):
+        return str(service.get("source", service.get("aws", service.get("gcp", service.get("source_service", service.get("name", ""))))))
+    return str(service)
 
 
 # ---------------------------------------------------------------------------
@@ -272,9 +295,10 @@ def _drawio_page_migration_overview(root, title, mappings, zones):
     src_ids = {}
     for i, m in enumerate(mappings[:15]):
         src = m.get("source_service", "?")
+        label = _source_service_label(src, m.get("source_provider"))
         sid = nid()
         src_ids[src] = sid
-        cell = ET.SubElement(rt, "mxCell", id=sid, value=src,
+        cell = ET.SubElement(rt, "mxCell", id=sid, value=label,
                              style="rounded=1;whiteSpace=wrap;html=1;opacity=40;fillColor=#F1F5F9;strokeColor=#CBD5E1;fontColor=#94A3B8;fontFamily=Segoe UI;fontSize=12;",
                              vertex="1", parent="1")
         y = 160 + i * 70
@@ -404,12 +428,13 @@ def _drawio_page_mapping_detail(root, title, mappings):
     # Table rows
     for row_idx, m in enumerate(mappings[:20]):
         src = m.get("source_service", "?")
+        source_label = _source_service_label(src, m.get("source_provider"))
         tgt = m.get("azure_service", "?")
         cat = m.get("category", "—")
         conf = m.get("confidence", 0)
         conf_str = f"{int(conf * 100)}%" if isinstance(conf, (int, float)) and conf <= 1 else str(conf)
         notes = m.get("notes", "")[:60]
-        values = [src, tgt, cat, conf_str, notes]
+        values = [source_label, tgt, cat, conf_str, notes]
 
         rx = 40
         y = 160 + row_idx * 36
@@ -703,7 +728,11 @@ def _generate_excalidraw(analysis: dict) -> dict:
         aws = m.get("source_service") or m.get("aws_service") or m.get("source", "")
         azure = m.get("azure_service") or m.get("target", "")
         confidence = m.get("confidence", "medium")
-        svc_map[aws] = {"azure": azure, "confidence": confidence}
+        svc_map[aws] = {
+            "azure": azure,
+            "confidence": confidence,
+            "source_provider": m.get("source_provider", analysis.get("source_provider")),
+        }
 
     # Excalidraw file attachments for embedded icons
     exc_files: dict[str, dict] = {}
@@ -777,10 +806,13 @@ def _generate_excalidraw(analysis: dict) -> dict:
                 info = svc_map.get(aws_name, {})
                 azure_name = info.get("azure", aws_name)
                 raw_conf = info.get("confidence", "medium")
+                provider = info.get("source_provider", analysis.get("source_provider"))
             else:
-                aws_name = svc.get("source", svc.get("aws", svc.get("gcp", svc.get("source_service", svc.get("name", "")))))
+                aws_name = _service_source_name(svc)
+                info = svc_map.get(aws_name, {})
                 azure_name = svc.get("azure", svc.get("azure_service", aws_name))
                 raw_conf = svc.get("confidence", "medium")
+                provider = svc.get("source_provider", info.get("source_provider", analysis.get("source_provider")))
 
             if isinstance(raw_conf, (int, float)):
                 confidence = "high" if raw_conf >= 0.85 else "medium" if raw_conf >= 0.7 else "low"
@@ -837,7 +869,7 @@ def _generate_excalidraw(analysis: dict) -> dict:
                 }
                 elements.append(img_el)
                 # Label beside icon (fontSize ≥ 14 per skill rules)
-                label = f"{aws_name} → {azure_name}" if aws_name != azure_name else azure_name
+                label = _migration_label(aws_name, azure_name, provider)
                 elements.append(
                     _exc_text(sx + 44, sy + 6, label, size=14, color="#1a1a1a", group=gid)
                 )
@@ -845,7 +877,7 @@ def _generate_excalidraw(analysis: dict) -> dict:
                     _exc_text(sx + 44, sy + 28, f"[{confidence}]", size=14, color=conf_color, group=gid)
                 )
             else:
-                label = f"{aws_name} → {azure_name}" if aws_name != azure_name else azure_name
+                label = _migration_label(aws_name, azure_name, provider)
                 elements.append(
                     _exc_text(sx + 8, sy + 6, label, size=14, color="#1a1a1a", group=gid)
                 )
@@ -926,7 +958,11 @@ def _generate_drawio(analysis: dict) -> dict:
         aws = m.get("source_service") or m.get("aws_service") or m.get("source", "")
         azure = m.get("azure_service") or m.get("target", "")
         confidence = m.get("confidence", "medium")
-        svc_map[aws] = {"azure": azure, "confidence": confidence}
+        svc_map[aws] = {
+            "azure": azure,
+            "confidence": confidence,
+            "source_provider": m.get("source_provider", analysis.get("source_provider")),
+        }
 
     # Root XML
     root = ET.Element("mxfile", host="archmorph", type="device")
@@ -1019,10 +1055,13 @@ def _generate_drawio(analysis: dict) -> dict:
                 info = svc_map.get(aws_name, {})
                 azure_name = info.get("azure", aws_name)
                 raw_conf = info.get("confidence", "medium")
+                provider = info.get("source_provider", analysis.get("source_provider"))
             else:
-                aws_name = svc.get("source", svc.get("aws", svc.get("gcp", svc.get("source_service", svc.get("name", "")))))
+                aws_name = _service_source_name(svc)
+                info = svc_map.get(aws_name, {})
                 azure_name = svc.get("azure", svc.get("azure_service", aws_name))
                 raw_conf = svc.get("confidence", "medium")
+                provider = svc.get("source_provider", info.get("source_provider", analysis.get("source_provider")))
 
             # Normalise confidence to string key
             if isinstance(raw_conf, (int, float)):
@@ -1032,7 +1071,7 @@ def _generate_drawio(analysis: dict) -> dict:
             conf_color = _CONFIDENCE_COLORS.get(confidence, _CONFIDENCE_COLORS["medium"])
 
             azure2_icon = get_azure_stencil_id(azure_name, "drawio")
-            label = f"{aws_name} → {azure_name}" if aws_name != azure_name else azure_name
+            label = _migration_label(aws_name, azure_name, provider)
 
             sx = 16
             sy = 40 + si * svc_spacing

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -42,6 +42,32 @@ SAMPLE_ANALYSIS = {
 }
 
 
+MIXED_CLOUD_ANALYSIS = {
+    "source_provider": "aws",
+    "source_providers": ["aws", "gcp"],
+    "target_provider": "azure",
+    "services_detected": 4,
+    "title": "Mixed Classic Handoff",
+    "zones": [
+        {
+            "id": 1,
+            "number": 1,
+            "name": "Source Platform",
+            "services": [
+                {"source_provider": "aws", "source_service": "EKS", "azure_service": "AKS", "confidence": 0.94},
+                {"source_provider": "gcp", "source_service": "Pub/Sub", "azure_service": "Event Hubs", "confidence": 0.87},
+                {"source_provider": "gcp", "source_service": "Cloud Storage", "azure_service": "Unmapped GCP Archive Target", "confidence": 0.72},
+            ],
+        }
+    ],
+    "mappings": [
+        {"source_provider": "aws", "source_service": "EKS", "azure_service": "AKS", "category": "Containers", "confidence": 0.94},
+        {"source_provider": "gcp", "source_service": "Pub/Sub", "azure_service": "Event Hubs", "category": "Messaging", "confidence": 0.87},
+        {"source_provider": "gcp", "source_service": "Cloud Storage", "azure_service": "Unmapped GCP Archive Target", "category": "Storage", "confidence": 0.72},
+    ],
+}
+
+
 class TestGetAzureStencilId:
     def test_known_service_drawio(self):
         stencil = get_azure_stencil_id("Azure Virtual Machines", target="drawio")
@@ -73,6 +99,48 @@ class TestGenerateDiagram:
         assert root.tag in ("mxfile", "mxGraphModel"), f"Unexpected root: {root.tag}"
         cells = root.findall(".//mxCell")
         assert len(cells) > 0, "Draw.io export had no mxCell elements"
+
+    def test_mixed_cloud_drawio_handoff_labels_sources_and_uses_deterministic_fallback(self):
+        result = generate_diagram(MIXED_CLOUD_ANALYSIS, format="drawio")
+        root = ET.fromstring(result["content"])
+        cells = root.findall(".//mxCell")
+        values = [cell.get("value") or "" for cell in cells]
+        styles = [cell.get("style") or "" for cell in cells]
+
+        assert "Azure Cloud" in values
+        assert "[AWS] EKS → AKS" in values
+        assert "[GCP] Pub/Sub → Event Hubs" in values
+        assert "[GCP] Cloud Storage → Unmapped GCP Archive Target" in values
+        assert any("image=img/lib/azure2/other/Targets_Management.svg;" in style for style in styles)
+
+    def test_mixed_cloud_drawio_multi_page_handoff_labels_source_providers(self):
+        analysis = {**MIXED_CLOUD_ANALYSIS, "multi_page": True}
+        result = generate_diagram(analysis, format="drawio")
+        root = ET.fromstring(result["content"])
+        values = [cell.get("value") or "" for cell in root.findall(".//mxCell")]
+
+        assert result["pages"] == 4
+        assert root.tag == "mxfile"
+        assert [diagram.get("name") for diagram in root.findall("diagram")] == [
+            "1 - Migration Overview",
+            "2 - Azure Target Architecture",
+            "3 - Service Mapping Detail",
+            "4 - Connection Topology",
+        ]
+        assert "[AWS] EKS" in values
+        assert "[GCP] Pub/Sub" in values
+        assert "[GCP] Cloud Storage" in values
+
+    def test_mixed_cloud_excalidraw_handoff_labels_sources_and_parses(self):
+        result = generate_diagram(MIXED_CLOUD_ANALYSIS, format="excalidraw")
+        doc = json.loads(result["content"])
+        texts = [element.get("text") for element in doc["elements"] if element.get("type") == "text"]
+
+        assert doc["type"] == "excalidraw"
+        assert "Azure Cloud" in texts
+        assert "[AWS] EKS → AKS" in texts
+        assert "[GCP] Pub/Sub → Event Hubs" in texts
+        assert "[GCP] Cloud Storage → Unmapped GCP Archive Target" in texts
 
     def test_vsdx_produces_valid_vdx_xml_visio_can_open(self):
         """The Visio exporter emits legacy VDX 2003 XML. Output must be valid


### PR DESCRIPTION
## Summary
- Add provider-prefixed source labels to classic Draw.io and Excalidraw migration labels so mixed AWS/GCP handoffs stay legible.
- Extend multi-page Draw.io handoff pages to carry the same provider labels in migration overview and mapping detail output.
- Add parser tests for mixed AWS/GCP-to-Azure Draw.io, multi-page Draw.io, and Excalidraw exports, including deterministic Draw.io fallback behavior for an unmapped GCP-origin service.

Closes #683.

## Validation
- `cd backend && .venv/bin/python -m pytest tests/test_diagram_export.py tests/test_source_provider.py`