### PR TITLE
fix: handle false freshness in refresh workflow

### DIFF
--- a/.github/workflows/service-catalog-refresh.yml
+++ b/.github/workflows/service-catalog-refresh.yml
@@ -116,13 +116,14 @@ jobs:
           BASE="${API_URL%/}"
           BASE="${BASE%/api}"
           BODY=$(curl -sS --max-time 30 "${BASE}/api/health")
-          AGE=$(echo "$BODY" | jq -r '.service_catalog_refresh.age_hours // "null"')
-          STALE=$(echo "$BODY" | jq -r '.service_catalog_refresh.stale // "missing"')
-          echo "post-refresh age=${AGE}h stale=${STALE}"
-          if [ "$STALE" = "missing" ]; then
+          HAS_REFRESH=$(echo "$BODY" | jq -r 'has("service_catalog_refresh")')
+          if [ "$HAS_REFRESH" != "true" ]; then
             echo "::error::/api/health does not expose service_catalog_refresh; cannot verify refresh freshness"
             exit 1
           fi
+          AGE=$(echo "$BODY" | jq -r '.service_catalog_refresh.age_hours // "null"')
+          STALE=$(echo "$BODY" | jq -r '.service_catalog_refresh.stale | tostring')
+          echo "post-refresh age=${AGE}h stale=${STALE}"
           if [ "$STALE" != "false" ]; then
             echo "::error::Refresh succeeded but /api/health still reports stale catalog"
             exit 1

--- a/backend/service_updater.py
+++ b/backend/service_updater.py
@@ -949,14 +949,18 @@ def _last_successful_refresh_timestamp() -> Optional[datetime]:
 
 def _register_service_catalog_freshness() -> None:
     """Register the service catalog refresh job, seeding durable state."""
-    from freshness_registry import register_with_last_success
+    from freshness_registry import mark_success, register_with_last_success
+
+    last_success = _last_successful_refresh_timestamp()
 
     register_with_last_success(
         "service_catalog_refresh",
         budget_hours=FRESHNESS_BUDGET_HOURS,
-        last_success=_last_successful_refresh_timestamp(),
+        last_success=last_success,
         description="Daily AWS/Azure/GCP service catalog discovery (issue #571)",
     )
+    if last_success is not None:
+        mark_success("service_catalog_refresh", when=last_success)
 
 # Issue #640 — register with the centralised freshness registry so this job
 # shows up in the /api/health.scheduled_jobs block alongside any other periodic
@@ -981,6 +985,11 @@ def get_freshness() -> dict[str, Any]:
         }
     """
     state = _read_state()
+    try:
+        _register_service_catalog_freshness()
+    except Exception:  # noqa: BLE001
+        pass
+
     last = state.get("last_check")
     last_check_record = state["checks"][-1] if state.get("checks") else None
     last_errors = (last_check_record or {}).get("errors") or None

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -462,6 +462,34 @@ class TestFreshness:
             assert f["age_hours"] is not None
             assert f["age_hours"] < 1.0
 
+    def test_get_freshness_rehydrates_scheduled_job_registry(self, tmp_path):
+        from datetime import datetime, timezone
+        import freshness_registry as fr
+        import json as _json
+        from service_updater import get_freshness
+
+        fr.reset_for_tests()
+        now = datetime.now(timezone.utc).isoformat()
+        state_file = tmp_path / "updates.json"
+        state_file.write_text(_json.dumps({
+            "last_check": now,
+            "checks": [{"timestamp": now,
+                        "new_services": {"aws": [], "azure": [], "gcp": []},
+                        "errors": None}],
+            "new_services_found": {"aws": [], "azure": [], "gcp": []},
+            "auto_added": {"aws": [], "azure": [], "gcp": []},
+        }), encoding="utf-8")
+
+        with patch("service_updater._UPDATES_FILE", state_file), \
+             patch("service_updater._get_state_blob_client", return_value=None):
+            f = get_freshness()
+            jobs = fr.get_all()
+
+        assert f["stale"] is False
+        assert jobs[0]["name"] == "service_catalog_refresh"
+        assert jobs[0]["last_success"] is not None
+        assert jobs[0]["stale"] is False
+
     def test_old_run_is_stale(self, tmp_path):
         from datetime import datetime, timezone, timedelta
         import json as _json


### PR DESCRIPTION
## Summary
- distinguish a missing `service_catalog_refresh` block from `stale=false` in the refresh workflow
- convert the boolean stale value with `tostring` so jq does not coalesce `false` to missing
- rehydrate the in-process scheduled-job registry from durable service-update state during health reads, covering multi-replica Container Apps

Follow-up for #668 after refresh run 25259879222 proved production wrote fresh service catalog state (`age=0.0`) but the workflow misclassified `stale=false`, and `/api/health.scheduled_jobs` still needed durable-state rehydration.

## Validation
- local jq smoke for `{service_catalog_refresh:{age_hours:0,stale:false}}`
- `git diff --check`
- `cd backend && .venv/bin/python -m pytest tests/test_service_updater.py tests/test_freshness_registry.py tests/test_contract.py tests/test_api.py::TestServiceUpdates -q`