### PR TITLE
test: add Architecture Package production smoke

### DIFF
--- a/.github/workflows/architecture-package-smoke.yml
+++ b/.github/workflows/architecture-package-smoke.yml
@@ -1,0 +1,54 @@
+name: Production Architecture Package Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      sample_id:
+        description: 'Sample architecture ID to analyze'
+        required: false
+        default: 'aws-hub-spoke'
+      strict_freshness:
+        description: 'Fail if scheduled jobs are stale'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: architecture-package-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Validate Architecture Package value spine
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run production Architecture Package smoke
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+          SAMPLE_ID: ${{ inputs.sample_id }}
+          STRICT_FRESHNESS: ${{ inputs.strict_freshness }}
+          ARTIFACT_ROOT: smoke-artifacts/architecture-package/${{ github.run_id }}
+        run: ./scripts/architecture_package_smoke.sh
+
+      - name: Add smoke summary
+        if: always()
+        run: |
+          if [ -f "smoke-artifacts/architecture-package/${{ github.run_id }}/summary.md" ]; then
+            cat "smoke-artifacts/architecture-package/${{ github.run_id }}/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: architecture-package-smoke-${{ github.run_id }}
+          path: smoke-artifacts/architecture-package/${{ github.run_id }}/
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ docker compose -f docker-compose.yml -f docker-compose.parity.yml up --build
 This overlay keeps everything local, but starts the backend with production-like persistence guards:
 `ENVIRONMENT=production`, `ENFORCE_POSTGRES=true`, `REQUIRE_REDIS=true`, PostgreSQL via `DATABASE_URL`, Redis via `REDIS_URL`, and Gunicorn/Uvicorn workers instead of the reload server.
 
+**Production Architecture Package smoke:**
+Run the manual `Production Architecture Package Smoke` GitHub Action, or run [docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md](docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) locally, before release sign-off on changes to the live value spine. The smoke captures health freshness, sample analysis, guided answers, IaC, HLD, cost, Architecture Package HTML/SVG exports, and one classic diagram export as release evidence.
+
 **Refresh the API contract snapshot after intentional backend route/schema changes:**
 ```bash
 cd backend

--- a/docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md
+++ b/docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md
@@ -1,0 +1,46 @@
+# Production Architecture Package Smoke
+
+Use this smoke before release sign-off when the live value spine changes. It validates the production path from a safe sample architecture through guided answers, Azure mapping, generated artifacts, customer-facing Architecture Package exports, a legacy classic export, and scheduled-job freshness evidence.
+
+## Run From GitHub Actions
+
+1. Open **Actions** → **Production Architecture Package Smoke**.
+2. Choose **Run workflow** on `main`.
+3. Keep `sample_id=aws-hub-spoke` unless validating a specific sample.
+4. Keep `strict_freshness=true` for release sign-off.
+5. Download the `architecture-package-smoke-<run id>` artifact and retain the run URL in release evidence.
+
+The workflow requires `API_URL`, `FRONTEND_URL`, and `ADMIN_KEY` GitHub secrets. `API_URL` may include or omit the `/api` suffix.
+
+## Run Locally
+
+```bash
+cd Archmorph
+API_URL="https://api.archmorphai.com/api" \
+FRONTEND_URL="https://agreeable-ground-01012c003.2.azurestaticapps.net" \
+ADMIN_KEY="<redacted>" \
+STRICT_FRESHNESS=true \
+./scripts/architecture_package_smoke.sh
+```
+
+Artifacts are written to `smoke-artifacts/architecture-package/<timestamp>/` by default.
+
+## What It Proves
+
+| Area | Evidence |
+|---|---|
+| Health and scheduled jobs | `/api/health` status, service catalog freshness, scheduled job `last_success`, age, and stale flag |
+| Sample analysis | `diagram_id`, non-empty mappings, non-empty service connections |
+| Guided answers | Questions endpoint responds and applied answers persist `customer_intent` plus IaC parameters |
+| IaC | Terraform output is non-empty and contains provider/resource/module-like content |
+| HLD | Markdown HLD is generated and customer DOCX export decodes to a real document |
+| Cost | Cost JSON contains service rows and the CSV export contains a `TOTAL` row |
+| Architecture Package | HTML contains target, DR, customer intent, constraints, and inline SVG sections |
+| Target and DR SVG | SVG XML parses and contains expected target/DR topology language |
+| Classic diagram | Excalidraw export parses as JSON and has non-empty `elements` |
+
+## Diagnostics Contract
+
+Every failure prints the failed step, endpoint, HTTP status when applicable, and the first response excerpt. Raw responses and generated artifacts are saved in the artifact directory so the release operator can inspect the exact payload without rerunning the smoke.
+
+The smoke intentionally validates structure and customer-visible artifact presence. It does not attempt pixel-perfect diagram comparison, all classic formats, load testing, or model-quality grading; those belong to the hardening backlog.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -78,8 +78,9 @@ After deployment, verify:
 - `/#playground` opens the sample playground.
 - `${API_URL}/health` returns `healthy` or `degraded` with expected version metadata.
 - `${API_ROOT}/openapi.json` loads and reports `Archmorph API`.
-- A sample diagram can complete analysis without requiring production-only secrets.
-- Export actions that are part of the live path still produce files.
+- Run the [Production Architecture Package Smoke](PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) workflow with `strict_freshness=true`; retain the summary and artifact bundle for release evidence.
+- A sample diagram can complete analysis without requiring customer data.
+- Export actions that are part of the live path still produce files: Architecture Package HTML, target SVG, DR SVG, HLD, cost CSV, IaC, and at least one classic diagram format.
 - Drift baseline smoke: run the sample drift audit, accept/reject one non-green finding, and export the Markdown report.
 
 ## 5. Scaffolded Feature Gate
@@ -116,6 +117,6 @@ Before enabling any scaffolded feature, confirm:
 
 - Git commit SHA.
 - GitHub Actions run URL.
-- Smoke-test output summary.
+- Smoke-test output summary and Architecture Package smoke artifact manifest.
 - Enabled feature flags and tenant scope.
 - Any known degraded dependencies accepted for release.

--- a/scripts/architecture_package_smoke.sh
+++ b/scripts/architecture_package_smoke.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:-}"
+FRONTEND_URL="${FRONTEND_URL:-}"
+SAMPLE_ID="${SAMPLE_ID:-aws-hub-spoke}"
+STRICT_FRESHNESS="${STRICT_FRESHNESS:-false}"
+SMOKE_API_KEY="${ARCHMORPH_API_KEY:-${API_KEY:-${ADMIN_KEY:-}}}"
+RUN_ID="${GITHUB_RUN_ID:-local}"
+COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-smoke-artifacts/architecture-package/$(date -u +%Y%m%dT%H%M%SZ)}"
+HTTP_TIMEOUT="${HTTP_TIMEOUT:-180}"
+
+if [[ -z "$API_URL" ]]; then
+  echo "::error::API_URL is required"
+  exit 1
+fi
+
+if [[ -z "$SMOKE_API_KEY" ]]; then
+  echo "::error::ARCHMORPH_API_KEY, API_KEY, or ADMIN_KEY is required for the full Architecture Package smoke"
+  exit 1
+fi
+
+API_BASE="${API_URL%/}"
+API_BASE="${API_BASE%/api}/api"
+FRONTEND_URL="${FRONTEND_URL%/}"
+
+mkdir -p "$ARTIFACT_ROOT/raw" "$ARTIFACT_ROOT/artifacts"
+SUMMARY="$ARTIFACT_ROOT/summary.md"
+MANIFEST="$ARTIFACT_ROOT/manifest.jsonl"
+
+fail() {
+  local step_name="$1"
+  local message="$2"
+  local body_file="${3:-}"
+  echo "::error::${step_name}: ${message}"
+  {
+    echo ""
+    echo "## Failure"
+    echo ""
+    echo "- Step: ${step_name}"
+    echo "- Message: ${message}"
+    if [[ -n "$body_file" && -f "$body_file" ]]; then
+      echo "- Response excerpt:"
+      echo '```'
+      head -c 1200 "$body_file" || true
+      echo
+      echo '```'
+    fi
+  } >> "$SUMMARY"
+  exit 1
+}
+
+record_step() {
+  local step_name="$1"
+  local status="$2"
+  local detail="$3"
+  printf '| %s | %s | %s |\n' "$step_name" "$status" "$detail" >> "$SUMMARY"
+}
+
+json_value() {
+  local file_path="$1"
+  local jq_filter="$2"
+  jq -er "$jq_filter" "$file_path" >/dev/null
+}
+
+request() {
+  local step_name="$1"
+  local method="$2"
+  local url="$3"
+  local output_file="$4"
+  local body="${5:-}"
+  local headers_file="${output_file}.headers"
+  local status_file="${output_file}.status"
+  local curl_args=(
+    -sS
+    -D "$headers_file"
+    -o "$output_file"
+    -w "%{http_code}"
+    --max-time "$HTTP_TIMEOUT"
+    -X "$method"
+    -H "X-API-Key: ${SMOKE_API_KEY}"
+  )
+
+  if [[ -n "$body" ]]; then
+    curl_args+=( -H "Content-Type: application/json" -d "$body" )
+  fi
+
+  local http_code
+  http_code=$(curl "${curl_args[@]}" "$url" || echo "000")
+  echo "$http_code" > "$status_file"
+  if [[ ! "$http_code" =~ ^2 ]]; then
+    fail "$step_name" "HTTP ${http_code} from ${method} ${url}" "$output_file"
+  fi
+}
+
+write_content_artifact() {
+  local response_file="$1"
+  local jq_filter="$2"
+  local artifact_path="$3"
+  jq -r "$jq_filter" "$response_file" > "$artifact_path"
+  if [[ ! -s "$artifact_path" ]]; then
+    fail "artifact-write" "Artifact ${artifact_path} is empty" "$response_file"
+  fi
+}
+
+validate_svg() {
+  local step_name="$1"
+  local svg_path="$2"
+  local expected_text="$3"
+  python3 - "$svg_path" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+path = sys.argv[1]
+root = ET.parse(path).getroot()
+if not root.tag.lower().endswith('svg'):
+    raise SystemExit(f"root tag is {root.tag}, expected svg")
+PY
+  grep -qi "$expected_text" "$svg_path" || fail "$step_name" "SVG missing expected text: ${expected_text}" "$svg_path"
+}
+
+validate_json_field() {
+  local step_name="$1"
+  local file_path="$2"
+  local jq_filter="$3"
+  local message="$4"
+  json_value "$file_path" "$jq_filter" || fail "$step_name" "$message" "$file_path"
+}
+
+cat > "$SUMMARY" <<EOF
+# Architecture Package Production Smoke
+
+- API base: \`${API_BASE}\`
+- Frontend: \`${FRONTEND_URL:-not provided}\`
+- Sample: \`${SAMPLE_ID}\`
+- Strict freshness: \`${STRICT_FRESHNESS}\`
+- Commit: \`${COMMIT_SHA}\`
+- Run: \`${RUN_ID}\`
+
+| Step | Result | Evidence |
+|---|---|---|
+EOF
+
+echo "Running Architecture Package smoke against ${API_BASE}"
+echo "Artifacts: ${ARTIFACT_ROOT}"
+
+HEALTH_JSON="$ARTIFACT_ROOT/raw/01-health.json"
+request "health" GET "${API_BASE}/health" "$HEALTH_JSON"
+validate_json_field "health" "$HEALTH_JSON" '.status == "healthy" or .status == "degraded"' "Health status must be healthy or degraded"
+if jq -e '.scheduled_jobs[]? | select(.stale == true)' "$HEALTH_JSON" >/dev/null; then
+  if [[ "$STRICT_FRESHNESS" == "true" ]]; then
+    fail "health" "Scheduled jobs are stale while STRICT_FRESHNESS=true" "$HEALTH_JSON"
+  fi
+  record_step "Health and scheduled jobs" "warn" "$(jq -rc '[.scheduled_jobs[]? | select(.stale == true) | {name, age_hours, budget_hours}]' "$HEALTH_JSON")"
+else
+  record_step "Health and scheduled jobs" "pass" "$(jq -rc '{status, service_catalog_refresh, scheduled_jobs}' "$HEALTH_JSON")"
+fi
+
+ANALYSIS_JSON="$ARTIFACT_ROOT/raw/02-sample-analysis.json"
+request "sample-analysis" POST "${API_BASE}/samples/${SAMPLE_ID}/analyze" "$ANALYSIS_JSON" '{}'
+validate_json_field "sample-analysis" "$ANALYSIS_JSON" '.diagram_id | type == "string" and length > 0' "Sample analysis must return diagram_id"
+validate_json_field "sample-analysis" "$ANALYSIS_JSON" '(.mappings // []) | length > 0' "Sample analysis must include mappings"
+validate_json_field "sample-analysis" "$ANALYSIS_JSON" '(.service_connections // []) | length > 0' "Sample analysis must include service connections"
+DIAGRAM_ID=$(jq -r '.diagram_id' "$ANALYSIS_JSON")
+record_step "Sample analysis" "pass" "diagram_id=${DIAGRAM_ID}, mappings=$(jq -r '(.mappings // []) | length' "$ANALYSIS_JSON")"
+
+QUESTIONS_JSON="$ARTIFACT_ROOT/raw/03-guided-questions.json"
+request "guided-questions" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/questions" "$QUESTIONS_JSON" '{}'
+validate_json_field "guided-questions" "$QUESTIONS_JSON" '.diagram_id == "'"$DIAGRAM_ID"'"' "Guided questions must reference the smoke diagram"
+record_step "Guided questions" "pass" "questions=$(jq -r '.total // ((.questions // []) | length)' "$QUESTIONS_JSON")"
+
+ANSWERS_BODY='{
+  "arch_deploy_region": "West Europe",
+  "arch_ha": "Multi-region active-passive (99.99 %)",
+  "sec_compliance": "GDPR",
+  "sec_network_isolation": "Full private endpoints",
+  "arch_sku_strategy": "Balanced (good performance-to-cost ratio)"
+}'
+ANSWERS_JSON="$ARTIFACT_ROOT/raw/04-apply-answers.json"
+request "apply-answers" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/apply-answers" "$ANSWERS_JSON" "$ANSWERS_BODY"
+validate_json_field "apply-answers" "$ANSWERS_JSON" '.customer_intent | type == "object"' "Applied answers must create customer_intent"
+validate_json_field "apply-answers" "$ANSWERS_JSON" '.iac_parameters.deploy_region == "westeurope"' "Applied answers must persist deploy_region=westeurope"
+validate_json_field "apply-answers" "$ANSWERS_JSON" '.iac_parameters.network_isolation == "Full private endpoints"' "Applied answers must persist network isolation"
+validate_json_field "apply-answers" "$ANSWERS_JSON" '.iac_parameters.sku_strategy == "Balanced (good performance-to-cost ratio)"' "Applied answers must persist SKU strategy"
+record_step "Apply guided answers" "pass" "customer_intent and iac_parameters persisted"
+
+IAC_JSON="$ARTIFACT_ROOT/raw/05-iac.json"
+request "iac" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/generate?format=terraform&force=true" "$IAC_JSON" '{}'
+validate_json_field "iac" "$IAC_JSON" '.code | type == "string" and length > 80' "IaC response must include non-empty Terraform code"
+write_content_artifact "$IAC_JSON" '.code' "$ARTIFACT_ROOT/artifacts/archmorph-iac.tf"
+grep -Eq 'resource |module |provider ' "$ARTIFACT_ROOT/artifacts/archmorph-iac.tf" || fail "iac" "Terraform output lacks provider/resource/module content" "$ARTIFACT_ROOT/artifacts/archmorph-iac.tf"
+record_step "IaC Terraform" "pass" "artifacts/archmorph-iac.tf ($(wc -c < "$ARTIFACT_ROOT/artifacts/archmorph-iac.tf") bytes)"
+
+HLD_JSON="$ARTIFACT_ROOT/raw/06-hld.json"
+request "hld" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/generate-hld" "$HLD_JSON" '{}'
+validate_json_field "hld" "$HLD_JSON" '.markdown | type == "string" and length > 200' "HLD must include non-empty markdown"
+write_content_artifact "$HLD_JSON" '.markdown' "$ARTIFACT_ROOT/artifacts/hld.md"
+grep -qi 'Azure' "$ARTIFACT_ROOT/artifacts/hld.md" || fail "hld" "HLD markdown must reference Azure" "$ARTIFACT_ROOT/artifacts/hld.md"
+record_step "HLD markdown" "pass" "artifacts/hld.md ($(wc -c < "$ARTIFACT_ROOT/artifacts/hld.md") bytes)"
+
+HLD_DOCX_JSON="$ARTIFACT_ROOT/raw/07-hld-docx.json"
+request "hld-docx" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/export-hld?format=docx&include_diagrams=true&export_mode=customer" "$HLD_DOCX_JSON" '{}'
+validate_json_field "hld-docx" "$HLD_DOCX_JSON" '.content_b64 | type == "string" and length > 100' "HLD DOCX export must include content_b64"
+python3 - "$HLD_DOCX_JSON" "$ARTIFACT_ROOT/artifacts/hld.docx" <<'PY'
+import base64
+import json
+import sys
+
+with open(sys.argv[1], encoding='utf-8') as handle:
+  payload = json.load(handle)
+with open(sys.argv[2], 'wb') as handle:
+  handle.write(base64.b64decode(payload['content_b64']))
+PY
+if [[ $(wc -c < "$ARTIFACT_ROOT/artifacts/hld.docx") -lt 1000 ]]; then
+  fail "hld-docx" "Decoded DOCX is unexpectedly small" "$HLD_DOCX_JSON"
+fi
+record_step "HLD DOCX" "pass" "artifacts/hld.docx ($(wc -c < "$ARTIFACT_ROOT/artifacts/hld.docx") bytes)"
+
+COST_JSON="$ARTIFACT_ROOT/raw/08-cost.json"
+request "cost" GET "${API_BASE}/diagrams/${DIAGRAM_ID}/cost-estimate" "$COST_JSON"
+validate_json_field "cost" "$COST_JSON" '.currency == "USD"' "Cost estimate must include USD currency"
+validate_json_field "cost" "$COST_JSON" '(.services // []) | length > 0' "Cost estimate must include service rows"
+record_step "Cost estimate" "pass" "services=$(jq -r '(.services // []) | length' "$COST_JSON"), total=$(jq -rc '.total_monthly_estimate' "$COST_JSON")"
+
+COST_CSV="$ARTIFACT_ROOT/artifacts/cost-estimate.csv"
+request "cost-csv" GET "${API_BASE}/diagrams/${DIAGRAM_ID}/cost-estimate/export" "$COST_CSV"
+grep -q '^Service,' "$COST_CSV" || fail "cost-csv" "Cost CSV missing header" "$COST_CSV"
+grep -q '^TOTAL,' "$COST_CSV" || fail "cost-csv" "Cost CSV missing TOTAL row" "$COST_CSV"
+record_step "Cost CSV" "pass" "artifacts/cost-estimate.csv ($(wc -l < "$COST_CSV") rows)"
+
+PACKAGE_HTML_JSON="$ARTIFACT_ROOT/raw/09-architecture-package-html.json"
+request "architecture-package-html" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/export-architecture-package?format=html" "$PACKAGE_HTML_JSON" '{}'
+write_content_artifact "$PACKAGE_HTML_JSON" '.content' "$ARTIFACT_ROOT/artifacts/architecture-package.html"
+for expected_text in 'A — Target Azure Topology' 'B — DR Topology' 'Customer Intent' 'Assumptions And Constraints' '<svg'; do
+  grep -q "$expected_text" "$ARTIFACT_ROOT/artifacts/architecture-package.html" || fail "architecture-package-html" "HTML package missing ${expected_text}" "$ARTIFACT_ROOT/artifacts/architecture-package.html"
+done
+record_step "Architecture Package HTML" "pass" "artifacts/architecture-package.html ($(wc -c < "$ARTIFACT_ROOT/artifacts/architecture-package.html") bytes)"
+
+TARGET_SVG_JSON="$ARTIFACT_ROOT/raw/10-target-svg.json"
+request "target-svg" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/export-architecture-package?format=svg&diagram=primary" "$TARGET_SVG_JSON" '{}'
+write_content_artifact "$TARGET_SVG_JSON" '.content' "$ARTIFACT_ROOT/artifacts/target.svg"
+validate_svg "target-svg" "$ARTIFACT_ROOT/artifacts/target.svg" "Target"
+record_step "Target SVG" "pass" "artifacts/target.svg ($(wc -c < "$ARTIFACT_ROOT/artifacts/target.svg") bytes)"
+
+DR_SVG_JSON="$ARTIFACT_ROOT/raw/11-dr-svg.json"
+request "dr-svg" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/export-architecture-package?format=svg&diagram=dr" "$DR_SVG_JSON" '{}'
+write_content_artifact "$DR_SVG_JSON" '.content' "$ARTIFACT_ROOT/artifacts/dr.svg"
+validate_svg "dr-svg" "$ARTIFACT_ROOT/artifacts/dr.svg" "DR"
+grep -Eqi 'replication|resilience|secondary|region' "$ARTIFACT_ROOT/artifacts/dr.svg" || fail "dr-svg" "DR SVG missing resilience/region language" "$ARTIFACT_ROOT/artifacts/dr.svg"
+record_step "DR SVG" "pass" "artifacts/dr.svg ($(wc -c < "$ARTIFACT_ROOT/artifacts/dr.svg") bytes)"
+
+CLASSIC_JSON="$ARTIFACT_ROOT/raw/12-classic-excalidraw.json"
+request "classic-excalidraw" POST "${API_BASE}/diagrams/${DIAGRAM_ID}/export-diagram?format=excalidraw" "$CLASSIC_JSON" '{}'
+write_content_artifact "$CLASSIC_JSON" '.content' "$ARTIFACT_ROOT/artifacts/classic.excalidraw"
+python3 - "$ARTIFACT_ROOT/artifacts/classic.excalidraw" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding='utf-8') as handle:
+    payload = json.load(handle)
+elements = payload.get('elements') if isinstance(payload, dict) else None
+if not isinstance(elements, list) or not elements:
+    raise SystemExit('classic Excalidraw export has no elements')
+PY
+record_step "Classic Excalidraw" "pass" "artifacts/classic.excalidraw ($(jq -r '.elements | length' "$ARTIFACT_ROOT/artifacts/classic.excalidraw") elements)"
+
+jq -nc \
+  --arg api_base "$API_BASE" \
+  --arg frontend_url "${FRONTEND_URL:-}" \
+  --arg sample_id "$SAMPLE_ID" \
+  --arg diagram_id "$DIAGRAM_ID" \
+  --arg commit_sha "$COMMIT_SHA" \
+  --arg run_id "$RUN_ID" \
+  --arg artifact_root "$ARTIFACT_ROOT" \
+  '{api_base:$api_base, frontend_url:$frontend_url, sample_id:$sample_id, diagram_id:$diagram_id, commit_sha:$commit_sha, run_id:$run_id, artifact_root:$artifact_root, status:"passed"}' > "$ARTIFACT_ROOT/manifest.json"
+
+for artifact_path in "$ARTIFACT_ROOT"/artifacts/*; do
+  [[ -f "$artifact_path" ]] || continue
+  jq -nc --arg path "$artifact_path" --arg bytes "$(wc -c < "$artifact_path")" '{path:$path, bytes:($bytes|tonumber)}' >> "$MANIFEST"
+done
+
+echo "" >> "$SUMMARY"
+echo "Smoke passed. Artifact root: \`${ARTIFACT_ROOT}\`" >> "$SUMMARY"
+echo "Architecture Package production smoke passed."


### PR DESCRIPTION
## Summary
- add a dedicated production Architecture Package smoke script that exercises the live value spine and saves raw responses/generated artifacts
- add a manual `Production Architecture Package Smoke` workflow with artifact upload and step summary output
- document the smoke path and link it from the release checklist and README

Closes #673 after merge plus one successful manual smoke run against production.

## Smoke coverage
- `/api/health` with scheduled job freshness evidence
- sample analysis for `aws-hub-spoke`
- guided questions and applied answers/customer intent
- Terraform IaC generation
- HLD markdown and customer DOCX export
- cost estimate JSON and CSV export
- Architecture Package HTML, target SVG, DR SVG
- classic Excalidraw export

## Validation
- `bash -n scripts/architecture_package_smoke.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/architecture-package-smoke.yml`

## Post-merge verification
- run `Production Architecture Package Smoke` on `main` with `sample_id=aws-hub-spoke` and `strict_freshness=true`
- attach the workflow run/artifact evidence to #673 before closing