### PR TITLE
fix: tolerate unsupported diagrams in HLD DOCX export

### DIFF
--- a/backend/hld_export.py
+++ b/backend/hld_export.py
@@ -174,10 +174,19 @@ def export_hld_docx(hld: Dict[str, Any], include_diagrams: bool = True,
         img_bytes = _decode_diagram_image(diagram_b64)
         if img_bytes:
             add_section("Architecture Diagram", level=2)
-            stream = io.BytesIO(img_bytes)
-            doc.add_picture(stream, width=Inches(6))
-            last_para = doc.paragraphs[-1]
-            last_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            try:
+                stream = io.BytesIO(img_bytes)
+                doc.add_picture(stream, width=Inches(6))
+                last_para = doc.paragraphs[-1]
+                last_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            except Exception as exc:
+                sanitized_exc = str(exc).replace('\n', '').replace('\r', '')
+                logger.warning(
+                    "Failed to embed architecture diagram in DOCX export: %s",
+                    sanitized_exc,
+                    exc_info=True,
+                )  # codeql[py/log-injection] Handled by custom
+                doc.add_paragraph("[Architecture diagram could not be embedded in this DOCX export.]")
 
     # ── 3. Services ──
     services = hld.get("services", [])

--- a/backend/tests/test_hld_export.py
+++ b/backend/tests/test_hld_export.py
@@ -209,6 +209,12 @@ class TestDocxExport:
         result = export_hld_docx(minimal, include_diagrams=False)
         assert isinstance(result, bytes)
 
+    def test_docx_with_unembeddable_diagram_still_exports(self):
+        diagram_b64 = base64.b64encode(b'{"type":"excalidraw","elements":[]}').decode("ascii")
+        result = export_hld_docx(MOCK_HLD, include_diagrams=True, diagram_b64=diagram_b64)
+        assert isinstance(result, bytes)
+        assert result[:2] == b"PK"
+
 
 # ====================================================================
 # 3. PDF Export


### PR DESCRIPTION
## Summary
- prevent customer-mode HLD DOCX export from failing when the auto-generated diagram payload is not a DOCX-embeddable image
- add a regression test for base64-encoded non-image diagram content

## Production evidence
The post-merge Architecture Package smoke for #673 failed at DOCX export:
- Run: https://github.com/idokatz86/Archmorph/actions/runs/25260439381
- Failing step: `hld-docx`
- Endpoint: `POST /api/diagrams/sample-aws-hub-spoke-cf2f95/export-hld?format=docx&include_diagrams=true&export_mode=customer`
- Correlation ID: `4d693c29-7e15-4933-a152-3e74e700b767`

## Validation
- `cd backend && .venv/bin/python -m pytest tests/test_hld_export.py::TestDocxExport -q`
- `git diff --check`

Related to #673.