### PR TITLE
fix: enforce export capability boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,7 @@ The landing-zone-svg pipeline (issue #571 → #586) ingests untrusted PDFs / ima
 
 Headline controls in place:
 
+- **Export/download capability boundary**: generated artifact routes (`export-diagram`, `export-architecture-package`, `export-hld`, and report download) require a one-time `X-Export-Capability` token scoped to the specific `diagram_id`. Tokens are opaque, stored only as SHA-256 digests, expire after 15 minutes by default, are consumed on use to block replay, and rotate after each successful export. Local development may explicitly opt out with `ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false`; production and staging fail closed.
 - **XML output is escape-on-render**: every text run goes through `_xml_escape()` which strips invalid XML chars and escapes the 5 XML entities ([backend/azure_landing_zone.py](backend/azure_landing_zone.py)).
 - **Icons are embedded as `data:image/svg+xml;base64` data URIs only** — there is no path to inject `javascript:` or external `http(s):` URIs into a rendered `<image href="…"/>`. Icon bytes come from the server-controlled icon registry.
 - **PII boundary**: the retention pipeline (#580) and LZ render path do not import each other; verified via grep in CI.
@@ -83,10 +84,9 @@ Headline controls in place:
 
 Open follow-ups (filed as separate issues, see threat-model §5):
 
-- **F-1 (P1)** — Diagram capability-URLs must be ≥ 122 bits of entropy. The current `uuid.uuid4().hex[:8]` 32-bit truncation is insufficient.
 - **F-3 (P1)** — `POST /api/icon-packs` must require `Depends(verify_api_key)`; uploaded SVGs must be sanitised through `bleach`/`defusedxml` before they reach the registry.
 
-These two are GA-blocking. P2 findings (webhook SSRF private-IP gap, unbounded analysis size, Pydantic `extra="forbid"`) are tracked but do not block GA.
+F-3 remains GA-blocking. P2 findings (webhook SSRF private-IP gap, unbounded analysis size, Pydantic `extra="forbid"`) are tracked but do not block GA.
 
 ## Security Best Practices for Contributors
 
@@ -97,6 +97,7 @@ These two are GA-blocking. P2 findings (webhook SSRF private-IP gap, unbounded a
 5. **Keep dependencies updated**: Monitor Dependabot PRs
 6. **Follow principle of least privilege**: Minimal permissions for all operations
 7. **Capability URLs** must be at least 122 bits of entropy (`secrets.token_urlsafe(16)` or full UUIDv4 — never truncated)
+8. **Artifact export endpoints** must validate `X-Export-Capability`, scope it to the requested `diagram_id`, consume it on use, issue a fresh token on success, and audit denial reasons without logging raw token values.
 
 ## Acknowledgments
 

--- a/backend/export_capabilities.py
+++ b/backend/export_capabilities.py
@@ -1,0 +1,161 @@
+"""One-time capability tokens for generated artifact exports (#671)."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from fastapi import Header, Query, Request
+
+from error_envelope import ArchmorphException
+from routers.shared import EXPORT_CAPABILITY_STORE
+
+logger = logging.getLogger(__name__)
+
+EXPORT_CAPABILITY_HEADER = "X-Export-Capability"
+EXPORT_CAPABILITY_SCOPE = "artifact:export"
+DEFAULT_EXPORT_CAPABILITY_TTL_SECONDS = 15 * 60
+
+
+@dataclass(frozen=True)
+class ExportCapability:
+    """Validated capability metadata returned by the FastAPI dependency."""
+
+    token_digest: str
+    diagram_id: str
+    scope: str
+    expires_at: float
+
+
+def _ttl_seconds() -> int:
+    raw = os.getenv(
+        "EXPORT_CAPABILITY_TTL_SECONDS",
+        str(DEFAULT_EXPORT_CAPABILITY_TTL_SECONDS),
+    )
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_EXPORT_CAPABILITY_TTL_SECONDS
+
+
+def export_capability_required() -> bool:
+    """Return whether export capability checks are enforced.
+
+    Production/staging default to fail-closed. Local development can opt out
+    explicitly with ``ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false`` for manual
+    API exploration and old scripts.
+    """
+    raw = os.getenv("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED")
+    if raw is not None:
+        return raw.strip().lower() not in {"0", "false", "no", "off"}
+    return os.getenv("ENVIRONMENT", "production").lower() not in {
+        "dev",
+        "development",
+        "local",
+        "test",
+    }
+
+
+def _digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _audit(reason: str, diagram_id: str, token_digest: Optional[str] = None) -> None:
+    details = {"diagram_id": diagram_id, "reason": reason}
+    if token_digest:
+        details["token_digest_prefix"] = token_digest[:12]
+    try:
+        from usage_metrics import record_event
+
+        record_event("export_capability_audit", details)
+    except Exception:  # pragma: no cover - audit must not block auth decisions
+        logger.debug("export capability audit failed", exc_info=True)
+
+
+def issue_export_capability(diagram_id: str, *, ttl_seconds: Optional[int] = None) -> str:
+    """Issue an opaque, URL-safe, single-use export capability for a diagram."""
+    ttl = ttl_seconds or _ttl_seconds()
+    token = secrets.token_urlsafe(32)
+    token_digest = _digest(token)
+    expires_at = time.time() + ttl
+    EXPORT_CAPABILITY_STORE.set(
+        token_digest,
+        {
+            "diagram_id": diagram_id,
+            "scope": EXPORT_CAPABILITY_SCOPE,
+            "expires_at": expires_at,
+            "issued_at": time.time(),
+        },
+        ttl=ttl,
+    )
+    _audit("issued", diagram_id, token_digest)
+    return token
+
+
+def attach_export_capability(payload, diagram_id: str):
+    """Return *payload* with a freshly issued ``export_capability`` field."""
+    token = issue_export_capability(diagram_id)
+    if isinstance(payload, dict):
+        return {
+            **payload,
+            "export_capability": token,
+            "export_capability_expires_in": _ttl_seconds(),
+        }
+    return payload
+
+
+async def verify_export_capability(
+    request: Request,
+    diagram_id: str,
+    x_export_capability: Optional[str] = Header(None, alias=EXPORT_CAPABILITY_HEADER),
+    export_token: Optional[str] = Query(None, include_in_schema=False),
+) -> Optional[ExportCapability]:
+    """Validate and consume a one-time export capability.
+
+    ``X-Export-Capability`` is the preferred transport because it avoids token
+    leakage through URLs. ``export_token`` remains as a hidden query fallback
+    for curl/manual local testing.
+    """
+    if not export_capability_required():
+        _audit("bypass_disabled", diagram_id)
+        return None
+
+    token = x_export_capability or export_token
+    if not token:
+        _audit("missing", diagram_id)
+        raise ArchmorphException(401, "Missing export capability")
+
+    token_digest = _digest(token)
+    record = EXPORT_CAPABILITY_STORE.get(token_digest)
+    if not record:
+        _audit("unknown_or_replayed", diagram_id, token_digest)
+        raise ArchmorphException(401, "Invalid or replayed export capability")
+
+    if record.get("scope") != EXPORT_CAPABILITY_SCOPE:
+        EXPORT_CAPABILITY_STORE.delete(token_digest)
+        _audit("wrong_scope", diagram_id, token_digest)
+        raise ArchmorphException(403, "Export capability is not authorized for this operation")
+
+    if record.get("diagram_id") != diagram_id:
+        _audit("wrong_diagram", diagram_id, token_digest)
+        raise ArchmorphException(403, "Export capability is not authorized for this diagram")
+
+    expires_at = float(record.get("expires_at", 0))
+    if expires_at < time.time():
+        EXPORT_CAPABILITY_STORE.delete(token_digest)
+        _audit("expired", diagram_id, token_digest)
+        raise ArchmorphException(401, "Expired export capability")
+
+    EXPORT_CAPABILITY_STORE.delete(token_digest)
+    _audit("validated", diagram_id, token_digest)
+    return ExportCapability(
+        token_digest=token_digest,
+        diagram_id=diagram_id,
+        scope=str(record.get("scope")),
+        expires_at=expires_at,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -210,7 +210,8 @@ app.add_middleware(
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=False,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
-    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+    allow_headers=["Content-Type", "Authorization", "X-API-Key", "X-Export-Capability"],
+    expose_headers=["X-Export-Capability-Next"],
     max_age=3600,  # Cache preflight for 1 hour
 )
 

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -9268,6 +9268,22 @@
               "title": "Diagram",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
+            }
           }
         ],
         "responses": {
@@ -9336,6 +9352,22 @@
               "title": "Dr Variant",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
+            }
           }
         ],
         "responses": {
@@ -9373,6 +9405,22 @@
             "schema": {
               "title": "Diagram Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
             }
           }
         ],
@@ -10383,6 +10431,22 @@
             "schema": {
               "title": "Diagram Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
             }
           }
         ],
@@ -19984,6 +20048,22 @@
               "title": "Diagram",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
+            }
           }
         ],
         "responses": {
@@ -20055,6 +20135,22 @@
               "title": "Dr Variant",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
+            }
           }
         ],
         "responses": {
@@ -20095,6 +20191,22 @@
             "schema": {
               "title": "Diagram Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
             }
           }
         ],
@@ -20898,6 +21010,22 @@
             "schema": {
               "title": "Diagram Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Export-Capability",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Export-Capability"
             }
           }
         ],

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -1,4 +1,3 @@
-from error_envelope import ArchmorphException
 """
 Analysis routes — guided questions, apply answers, add services, export diagram.
 
@@ -18,6 +17,8 @@ from guided_questions import generate_questions, apply_answers, get_question_con
 from mcp_diagram_generator import mcp_client
 from service_builder import deduplicate_questions, get_smart_defaults_from_analysis, add_services_from_text
 from architecture_package import generate_architecture_package
+from error_envelope import ArchmorphException
+from export_capabilities import attach_export_capability, verify_export_capability
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,7 @@ async def export_architecture_diagram(
     format: str = "excalidraw",
     multi_page: bool = False,
     dr_variant: str = "primary",
+    _capability=Depends(verify_export_capability),
 ):
     """Generate an architecture diagram in Excalidraw, Draw.io, Visio, or
     Landing-Zone-SVG format.
@@ -207,7 +209,7 @@ async def export_architecture_diagram(
             "dr_variant": dr_variant,
         })
         record_funnel_step(diagram_id, "export")
-        return result
+        return attach_export_capability(result, diagram_id)
 
     try:
         content = await mcp_client.generate_diagram(format, analysis)
@@ -233,7 +235,7 @@ async def export_architecture_diagram(
 
     record_event(f"exports_{format}", {"diagram_id": diagram_id})
     record_funnel_step(diagram_id, "export")
-    return result
+    return attach_export_capability(result, diagram_id)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -246,6 +248,7 @@ async def export_architecture_package(
     diagram_id: str,
     format: str = "html",
     diagram: str = "primary",
+    _capability=Depends(verify_export_capability),
 ):
     """Generate the customer-facing Architecture Package.
 
@@ -276,4 +279,4 @@ async def export_architecture_package(
         "diagram": diagram,
     })
     record_funnel_step(diagram_id, "export")
-    return result
+    return attach_export_capability(result, diagram_id)

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -1,4 +1,3 @@
-from error_envelope import ArchmorphException
 """
 Core diagram routes — upload, analyze, session restore, async analysis.
 
@@ -17,7 +16,7 @@ from pydantic import BaseModel
 from typing import Dict, Any, Optional
 import asyncio
 import base64
-import uuid
+import secrets
 import logging
 
 from routers.shared import (
@@ -26,11 +25,13 @@ from routers.shared import (
 )
 from job_queue import job_manager
 from usage_metrics import record_event, record_funnel_step
+from export_capabilities import attach_export_capability
 from image_classifier import classify_image
 from vision_analyzer import analyze_image
 from hld_generator import generate_hld, generate_hld_markdown  # noqa: F401 — re-exported for test monkeypatching
 from auth import get_user_from_request_headers
 from analysis_history import maybe_save_from_session
+from error_envelope import ArchmorphException
 from sku_translator import get_sku_translator
 from confidence_provenance import build_provenance
 from architecture_rules import evaluate as evaluate_architecture_rules
@@ -176,7 +177,7 @@ async def upload_diagram(request: Request, project_id: str, file: UploadFile = F
     if file.content_type not in allowed_types and not is_visio and not is_drawio:
         raise ArchmorphException(400, f"File type {file.content_type} not supported. Accepted: PNG, JPG, JPEG, SVG, PDF, Draw.io, Visio.")
 
-    diagram_id = f"diag-{uuid.uuid4().hex[:8]}"
+    diagram_id = f"diag-{secrets.token_urlsafe(16)}"
     # Read file in chunks with early size limit enforcement
     chunks = []
     total_size = 0
@@ -207,12 +208,12 @@ async def upload_diagram(request: Request, project_id: str, file: UploadFile = F
 
     record_event("diagrams_uploaded", {"filename": file.filename})
     record_funnel_step(diagram_id, "upload")
-    return {
+    return attach_export_capability({
         "diagram_id": diagram_id,
         "filename": file.filename,
         "size": len(image_bytes),
         "status": "uploaded"
-    }
+    }, diagram_id)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -253,7 +254,10 @@ async def restore_session(request: Request, diagram_id: str, body: RestoreSessio
         restored_parts.append("image")
     logger.info("Session restored for %s via client cache (%s)", str(diagram_id).replace('\n', '').replace('\r', ''), str(", ".join(restored_parts)).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom
     record_event("sessions_restored", {"diagram_id": diagram_id, "parts": restored_parts})
-    return {"status": "restored", "diagram_id": diagram_id, "restored": restored_parts}
+    return attach_export_capability(
+        {"status": "restored", "diagram_id": diagram_id, "restored": restored_parts},
+        diagram_id,
+    )
 
 
 # ─────────────────────────────────────────────────────────────
@@ -328,7 +332,7 @@ async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verif
     if user:
         maybe_save_from_session(user.id, result, diagram_id)
 
-    return result
+    return attach_export_capability(result, diagram_id)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -427,7 +431,7 @@ async def _run_analysis_job(job_id: str, diagram_id: str) -> None:
             maybe_save_from_session(job_user_id, result, diagram_id)
 
         job_manager.update_progress(job_id, 95, "Finalizing...")
-        job_manager.complete(job_id, result=result)
+        job_manager.complete(job_id, result=attach_export_capability(result, diagram_id))
 
     except Exception as exc:
         logger.error("Async analysis failed for %s: %s", str(diagram_id).replace('\n', '').replace('\r', ''), str(exc).replace('\n', '').replace('\r', ''), exc_info=True)  # codeql[py/log-injection] Handled by custom

--- a/backend/routers/hld_routes.py
+++ b/backend/routers/hld_routes.py
@@ -1,4 +1,3 @@
-from error_envelope import ArchmorphException
 """
 HLD (High-Level Design) routes — generation, retrieval, export, async generation.
 
@@ -16,9 +15,11 @@ from routers.samples import get_or_recreate_session
 from job_queue import job_manager
 from usage_metrics import record_event
 import routers.diagrams as diagrams_compat
+from error_envelope import ArchmorphException
 from hld_export import export_hld, SUPPORTED_FORMATS
 from services.azure_pricing import estimate_services_cost
 from diagram_export import generate_diagram
+from export_capabilities import attach_export_capability, verify_export_capability
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,12 @@ async def get_hld(request: Request, diagram_id: str):
 
 @router.post("/api/diagrams/{diagram_id}/export-hld")
 @limiter.limit("10/minute")
-async def export_hld_endpoint(request: Request, diagram_id: str, _auth=Depends(verify_api_key)):
+async def export_hld_endpoint(
+    request: Request,
+    diagram_id: str,
+    _auth=Depends(verify_api_key),
+    _capability=Depends(verify_export_capability),
+):
     """Export HLD document to Word, PDF, or PowerPoint format.
 
     Query params:
@@ -226,7 +232,7 @@ async def export_hld_endpoint(request: Request, diagram_id: str, _auth=Depends(v
         logger.error("HLD export failed: %s", str(e).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom
         raise ArchmorphException(500, "Export failed. Please try again or contact support.")
 
-    return result
+    return attach_export_capability(result, diagram_id)
 
 
 # ─────────────────────────────────────────────────────────────

--- a/backend/routers/report_routes.py
+++ b/backend/routers/report_routes.py
@@ -1,4 +1,3 @@
-from error_envelope import ArchmorphException
 """
 Analysis Report Export routes (Issue #236).
 
@@ -11,10 +10,12 @@ import logging
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import StreamingResponse
 
+from error_envelope import ArchmorphException
 from routers.shared import limiter, verify_api_key
 from routers.samples import get_or_recreate_session
 from report_generator import generate_analysis_report_pdf
 from usage_metrics import record_event
+from export_capabilities import issue_export_capability, verify_export_capability
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ async def download_analysis_report(
     request: Request,
     diagram_id: str,
     _auth=Depends(verify_api_key),
+    _capability=Depends(verify_export_capability),
 ):
     """Download a full analysis report as PDF.
 
@@ -56,5 +58,6 @@ async def download_analysis_report(
         headers={
             "Content-Disposition": f'attachment; filename="{filename}"',
             "Content-Length": str(len(pdf_bytes)),
+            "X-Export-Capability-Next": issue_export_capability(diagram_id),
         },
     )

--- a/backend/routers/samples.py
+++ b/backend/routers/samples.py
@@ -1,11 +1,10 @@
-from error_envelope import ArchmorphException
 """
 Sample Diagrams routes — onboarding samples with mock analysis.
 """
 
 from fastapi import APIRouter, Request
-import uuid
 
+from error_envelope import ArchmorphException
 from routers.shared import SESSION_STORE, limiter
 from services import CROSS_CLOUD_MAPPINGS
 from usage_metrics import record_funnel_step
@@ -427,10 +426,22 @@ def build_sample_analysis(sample_id: str, diagram_id: str) -> dict:
     }
 
 
+import secrets as _secrets  # noqa: E402
 import re as _re  # noqa: E402
+from export_capabilities import attach_export_capability  # noqa: E402
 
-# Pattern: "sample-<sample_id>-<hex6>"
-_SAMPLE_ID_RE = _re.compile(r"^sample-(.+)-[0-9a-f]{6}$")
+
+def _sample_id_from_diagram_id(diagram_id: str) -> str | None:
+    """Extract a known sample id from old hex and new URL-safe sample IDs."""
+    for sample in SAMPLE_DIAGRAMS:
+        sample_id = sample["id"]
+        prefix = f"sample-{sample_id}-"
+        if not diagram_id.startswith(prefix):
+            continue
+        suffix = diagram_id[len(prefix):]
+        if _re.fullmatch(r"[0-9a-f]{6}", suffix) or _re.fullmatch(r"[A-Za-z0-9_-]{16,}", suffix):
+            return sample_id
+    return None
 
 
 def get_or_recreate_session(diagram_id: str):
@@ -446,11 +457,10 @@ def get_or_recreate_session(diagram_id: str):
     if session is not None:
         return session
 
-    m = _SAMPLE_ID_RE.match(diagram_id)
-    if not m:
+    sample_id = _sample_id_from_diagram_id(diagram_id)
+    if not sample_id:
         return None  # not a sample — genuinely missing
 
-    sample_id = m.group(1)
     analysis = build_sample_analysis(sample_id, diagram_id)
     if analysis is None:
         return None  # unknown sample name
@@ -468,7 +478,7 @@ async def analyze_sample_diagram(request: Request, sample_id: str):
     every downstream endpoint (questions, apply-answers, export, IaC,
     HLD, cost-estimate) works without special-casing.
     """
-    diagram_id = f"sample-{sample_id}-{uuid.uuid4().hex[:6]}"
+    diagram_id = f"sample-{sample_id}-{_secrets.token_urlsafe(16)}"
     analysis = build_sample_analysis(sample_id, diagram_id)
     if analysis is None:
         raise ArchmorphException(404, f"Sample '{sample_id}' not found")
@@ -476,4 +486,4 @@ async def analyze_sample_diagram(request: Request, sample_id: str):
     SESSION_STORE[diagram_id] = analysis
     record_funnel_step(diagram_id, "analyze")
 
-    return analysis
+    return attach_export_capability(analysis, diagram_id)

--- a/backend/routers/shared.py
+++ b/backend/routers/shared.py
@@ -1,4 +1,3 @@
-from error_envelope import ArchmorphException
 """
 Shared state, dependencies, and models used across Archmorph API routers.
 """
@@ -21,6 +20,7 @@ from admin_auth import (
     validate_session_token,
     is_configured as admin_is_configured,
 )
+from error_envelope import ArchmorphException
 from session_store import get_store
 
 # ─────────────────────────────────────────────────────────────
@@ -94,6 +94,10 @@ IMAGE_STORE = get_store("images", maxsize=int(os.getenv("IMAGE_STORE_MAXSIZE", "
 
 # Share links store (TTL: 24 hours, max 100)
 SHARE_STORE = get_store("shares", maxsize=100, ttl=86400)
+
+# One-time generated-artifact export capabilities (TTL configured in
+# export_capabilities.py; store TTL matches session lifetime as an upper bound).
+EXPORT_CAPABILITY_STORE = get_store("export_capabilities", maxsize=2000, ttl=7200)
 
 # Production guard: warn if in-memory stores are used in production (#494)
 _env = os.getenv("ENVIRONMENT", "development").lower()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # Disable rate limiting for all tests
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "false")
 
 from main import app  # noqa: E402
 

--- a/backend/tests/test_export_capabilities.py
+++ b/backend/tests/test_export_capabilities.py
@@ -1,0 +1,115 @@
+"""Capability-token boundary tests for export endpoints (#671)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from export_capabilities import EXPORT_CAPABILITY_SCOPE, _digest, issue_export_capability
+from routers.shared import EXPORT_CAPABILITY_STORE, SESSION_STORE
+
+
+SAMPLE_ANALYSIS = {
+    "title": "Capability Boundary Test",
+    "source_provider": "aws",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "web-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96},
+        {"source_service": "EKS", "azure_service": "AKS", "category": "Containers", "confidence": 0.94},
+        {"source_service": "RDS", "azure_service": "Azure SQL", "category": "Database", "confidence": 0.88},
+    ],
+    "guided_answers": {
+        "env_target": "Production",
+        "arch_deploy_region": "East US",
+        "arch_ha": "Zone redundant",
+        "sec_compliance": ["SOC 2"],
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def require_export_capabilities(monkeypatch):
+    monkeypatch.setenv("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "true")
+    EXPORT_CAPABILITY_STORE.clear()
+    yield
+    EXPORT_CAPABILITY_STORE.clear()
+
+
+@pytest.fixture()
+def diagram_id():
+    did = "capability-boundary-diagram"
+    SESSION_STORE[did] = dict(SAMPLE_ANALYSIS)
+    yield did
+    try:
+        del SESSION_STORE[did]
+    except (KeyError, Exception):
+        pass
+
+
+def _export_package(client, did: str, token: str | None = None):
+    headers = {"X-Export-Capability": token} if token else {}
+    return client.post(
+        f"/api/diagrams/{did}/export-architecture-package?format=html",
+        headers=headers,
+    )
+
+
+def test_export_without_capability_is_unauthorized(test_client, diagram_id):
+    response = _export_package(test_client, diagram_id)
+
+    assert response.status_code == 401
+    assert "Missing export capability" in response.text
+
+
+def test_export_with_expired_capability_is_unauthorized(test_client, diagram_id):
+    token = issue_export_capability(diagram_id)
+    EXPORT_CAPABILITY_STORE.set(
+        _digest(token),
+        {
+            "diagram_id": diagram_id,
+            "scope": EXPORT_CAPABILITY_SCOPE,
+            "expires_at": time.time() - 1,
+        },
+    )
+
+    response = _export_package(test_client, diagram_id, token)
+
+    assert response.status_code == 401
+    assert "Expired export capability" in response.text
+
+
+def test_export_capability_cannot_cross_diagram_boundary(test_client, diagram_id):
+    other_id = "other-capability-diagram"
+    token = issue_export_capability(other_id)
+
+    response = _export_package(test_client, diagram_id, token)
+
+    assert response.status_code == 403
+    assert "not authorized for this diagram" in response.text
+
+
+def test_export_capability_is_single_use_to_block_replay(test_client, diagram_id):
+    token = issue_export_capability(diagram_id)
+
+    first = _export_package(test_client, diagram_id, token)
+    replay = _export_package(test_client, diagram_id, token)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["format"] == "architecture-package-html"
+    assert first.json()["export_capability"] != token
+    assert replay.status_code == 401
+    assert "Invalid or replayed export capability" in replay.text
+
+
+def test_rotated_capability_allows_next_valid_export(test_client, diagram_id):
+    token = issue_export_capability(diagram_id)
+
+    first = _export_package(test_client, diagram_id, token)
+    next_token = first.json()["export_capability"]
+    second = _export_package(test_client, diagram_id, next_token)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert second.json()["export_capability"] != next_token

--- a/docs/DIAGRAM_EXPORT_SPEC.md
+++ b/docs/DIAGRAM_EXPORT_SPEC.md
@@ -6,6 +6,8 @@
 
 > May 2026 update: the customer-facing Architecture Package is the primary website export. It exposes HTML plus standalone target/DR SVG render targets. Classic editable diagram formats remain legacy/internal API capabilities only and are no longer visible in the customer export UI.
 
+> May 2026 security update (#671): generated artifact export/download endpoints require a caller-held `X-Export-Capability` token scoped to the requested analysis. Tokens are opaque, one-time-use, expire after 15 minutes by default, and rotate after every successful export.
+
 ---
 
 ## 1. Input Data Contract
@@ -43,6 +45,24 @@ Architecture Package exports additionally consume `customer_intent` and optional
 |--------|---------|------------------|-------|
 | Architecture Package | `format=html` or `format=svg` with `diagram=primary` or `diagram=dr` | Customer, CTO, architecture review | Polished review package with Azure topology views, talking points, limitations, and namespaced inline SVG assets. This is the only visible website diagram export family. |
 | Classic Diagram Export | `excalidraw`, `drawio`, `vsdx` | Internal/legacy engineers editing diagrams in external tools | Legacy renderer contract retained for compatibility only; do not surface these options in the customer website export UI. |
+
+## 1.2 Capability Token Boundary
+
+The export/download routes are a bearer-capability boundary, separate from the general API key/admin model. This applies to classic diagram exports, architecture-package exports, HLD exports, and PDF report downloads.
+
+| Requirement | Contract |
+| --- | --- |
+| Header | `X-Export-Capability: <opaque-token>` |
+| Scope | `artifact:export` and exactly one `diagram_id` |
+| Entropy | `secrets.token_urlsafe(32)` for export capabilities; diagram IDs use at least `secrets.token_urlsafe(16)` |
+| Storage | Server stores SHA-256 token digest only, never the raw token |
+| Expiry | Default 15 minutes (`EXPORT_CAPABILITY_TTL_SECONDS`) |
+| Replay | Token is consumed when validated; reuse returns 401 |
+| Rotation | Successful export responses include a fresh `export_capability` and `export_capability_expires_in` |
+| Local/dev | `ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false` may be used for local scripts; production/staging fail closed |
+| Audit | Emit issuance/validation/denial events without raw token values |
+
+Pitfalls: do not put product-flow tokens in URLs, do not persist capabilities in analysis artifacts/history, do not make tokens multi-use for bulk export, and do not treat a guessed `diagram_id` as sufficient authorization.
 
 ---
 

--- a/docs/security/landing_zone_threat_model.md
+++ b/docs/security/landing_zone_threat_model.md
@@ -1,6 +1,6 @@
 # Landing-Zone-SVG pipeline — threat model & CISO security review
 
-**Issue**: #596
+**Issue**: #596; updated for #671
 **Reviewers**: CISO Master, CISO Security Agent
 **Branch reviewed**: `feat/production-ready-alz-epic` @ `d7ef756`
 **Date**: 2026-05-01
@@ -14,7 +14,8 @@ This document is the formal security gate for the production-ready ALZ epic (#58
 
 | # | Component | File | Role in LZ pipeline |
 | --- | --- | --- | --- |
-| C1 | Export endpoint | [backend/routers/analysis.py](../../backend/routers/analysis.py#L149-L213) | `POST /api/diagrams/{diagram_id}/export-diagram` — entry point for `format=landing-zone-svg` |
+| C1 | Export/download endpoints | [backend/routers/analysis.py](../../backend/routers/analysis.py#L149-L213), [backend/routers/hld_routes.py](../../backend/routers/hld_routes.py), [backend/routers/report_routes.py](../../backend/routers/report_routes.py) | `export-diagram`, `export-architecture-package`, `export-hld`, and PDF report download — generated artifact entry points protected by one-time export capability tokens (#671) |
+| C1a | Export capability verifier | [backend/export_capabilities.py](../../backend/export_capabilities.py) | Issues, validates, consumes, rotates, and audits scoped export capabilities |
 | C2 | LZ renderer | [backend/azure_landing_zone.py](../../backend/azure_landing_zone.py) | Schema inference + SVG assembly; consumes `analysis` dict and emits SVG bytes |
 | C3 | LZ schema | [backend/azure_landing_zone_schema.py](../../backend/azure_landing_zone_schema.py) | Provider→category→tier mapping (#572, #589) |
 | C4 | Vision analyzer | [backend/vision_analyzer.py](../../backend/vision_analyzer.py) | GPT-4o native multimodal — produces the `analysis` dict |
@@ -35,9 +36,13 @@ This document is the formal security gate for the production-ready ALZ epic (#58
             │                                            │ analysis dict
             │ POST /export-diagram?format=landing-       ▼
             │      zone-svg&dr_variant=primary    ┌──────────────────┐
-            └────────────────────────────────────►│  C1 export route │
-                                                   │  (no AuthN/AuthZ │
-                                                   │   on this route) │
+            │ X-Export-Capability: opaque token    │ C1a capability   │
+            └────────────────────────────────────►│ verifier         │
+                                                   └──────────┬───────┘
+                                                              │ scoped + one-time
+                                                              ▼
+                                                   ┌──────────────────┐
+                                                   │  C1 export route │
                                                    └──────────┬───────┘
                                                               │ analysis
                                                               ▼
@@ -60,6 +65,7 @@ This document is the formal security gate for the production-ready ALZ epic (#58
 | Customer architecture diagrams (PDF/PNG) | Confidential — may contain customer infra topology | C8 `SESSION_STORE` (TTL 7200s) + transient in C4 |
 | Generated `analysis` JSON | Confidential — same as above, structured | C8 `SESSION_STORE` |
 | Generated landing-zone-svg | Confidential — derived from analysis | Returned in HTTP response; not persisted server-side |
+| Export capability token | Secret bearer capability — grants one generated-artifact export for one diagram | Returned only to the caller, stored server-side as SHA-256 digest with TTL |
 | App Service managed identity | Secret | Azure platform; reachable via `169.254.169.254` from inside the VM |
 | Foundry / OpenAI keys | Secret | Key Vault (referenced by `backend/openai_client.py`) |
 | Icon registry contents | Public (Microsoft / vendor icons) | C6 in-memory store |
@@ -76,8 +82,8 @@ This document is the formal security gate for the production-ready ALZ epic (#58
 
 | # | Risk | Status | Evidence / Finding |
 | --- | --- | --- | --- |
-| API1:2023 | **Broken Object Level Authorization (BOLA)** | ⚠️ **F-1 (P1)** | `diagram_id = f"diag-{uuid.uuid4().hex[:8]}"` — only 32 bits of entropy ([routers/diagrams.py:178](../../backend/routers/diagrams.py#L178)); `get_or_recreate_session(diagram_id)` does no caller-binding ([routers/samples.py:436-460](../../backend/routers/samples.py#L436-L460)); `/export-diagram` has no `Depends(get_current_user)`. See §3.F-1. |
-| API2:2023 | Broken Authentication | OK | Admin routes use `Depends(verify_api_key)` w/ `secrets.compare_digest`; OAuth flows in `auth.py` use signed/timed sessions. LZ export is intentionally session-scoped (capability URL). |
+| API1:2023 | **Broken Object Level Authorization (BOLA)** | ✅ **Mitigated by #671** | Upload/sample IDs now use `secrets.token_urlsafe(16)`, and generated artifact exports require a one-time `X-Export-Capability` scoped to the exact `diagram_id`; wrong-diagram tokens return 403 and missing/expired/replayed tokens return 401. |
+| API2:2023 | Broken Authentication | OK | Admin routes use `Depends(verify_api_key)` w/ `secrets.compare_digest`; OAuth flows in `auth.py` use signed/timed sessions. LZ export is intentionally session-scoped, with a separate bearer capability for generated artifacts. |
 | API3:2023 | Broken Object Property Level Authorization | OK | LZ `analysis` dict is whole-object; Pydantic models in `azure_landing_zone_schema.py` validate field types; `apply_answers` is the only mutation path and it merges by key whitelist. |
 | API4:2023 | Unrestricted Resource Consumption | ⚠️ **F-4 (P2)** | `@limiter.limit("10/minute")` on `/export-diagram`; image upload limited to 25 MB. **Gap**: no upper bound on `analysis["zones"]` / `actors` / `mappings` length entering C2. A 50 000-tier `analysis` payload (e.g. attacker controls via `apply_answers`) would loop unboundedly inside SVG assembly. See §3.F-4. |
 | API5:2023 | Broken Function Level Authorization | OK | Admin/developer routes (e.g. `/api/admin/*`, icon library builder downloads) use `verify_api_key`. LZ export is in the public-capability tier and that's correct for the product surface. |
@@ -105,14 +111,25 @@ Severity scale: **P0** = blocks GA. **P1** = must close in Sprint 1. **P2** = sh
 
 **Threat**: Diagram IDs are 32-bit (4.3B keyspace, ~500 active TTL-bounded sessions). A motivated attacker can guess valid `diagram_id`s by brute-forcing from a single IP at the per-IP rate limit and exfiltrate other users' architecture topologies + IaC + landing-zone diagrams. With per-route IP-rotation the keyspace is reachable in days, and partial wins (lower-entropy keyspaces in practice when many diagrams are created in burst windows) reduce that further.
 
-**Status**: ⚠️ **NOT mitigated**. Capability-URL design is acceptable, but the capability needs to be ≥ 122 bits (full UUIDv4) — the current `[:8]` truncation drops it to 32 bits.
+**Status**: ✅ **Mitigated by #671**. Upload IDs and sample IDs now use `secrets.token_urlsafe(16)`, and export/download behavior no longer relies on the path ID alone. The export endpoints require a separate opaque one-time capability in `X-Export-Capability`.
 
-**Remediation** (Sprint 1, file as separate issue):
-1. Replace `uuid.uuid4().hex[:8]` with `secrets.token_urlsafe(16)` (128 bits, URL-safe). Apply to all `diag-*` and `sample-*` ID generation paths.
-2. (Optional, defense-in-depth) Bind sessions to a server-issued cookie at upload time and require it on `/export-diagram`. This is the long-term fix tracked separately.
-3. Add per-IP failure counter that escalates rate limit when a caller hits ≥ 10 unknown `diagram_id`s/min (probable enumeration).
+**Implemented controls**:
+1. Minimum viable token semantics: opaque `secrets.token_urlsafe(32)` bearer capability, SHA-256 digest stored server-side, scope fixed to `artifact:export`, bound to one `diagram_id`, default TTL 15 minutes.
+2. Replay control: token is consumed during verification; a successful export response carries a fresh `export_capability` for the next export action.
+3. Expiration control: expired capabilities are deleted and denied with HTTP 401.
+4. Audit control: issuance, validation, missing, expired, replayed, wrong-scope, and wrong-diagram outcomes emit `export_capability_audit` events with `diagram_id`, reason, and token digest prefix only. Raw token values must never be logged.
+5. Local/dev ergonomics: `ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false` allows manual legacy scripts in local development. Production/staging default to fail-closed.
 
-**Tracking**: file as new issue **#596-F1**, P1, Sprint 1, blocks GA.
+**Residual risk**: Bearer capabilities remain bearer secrets. XSS, browser extensions, or sessionStorage compromise can still steal the current token. This is acceptable for the current session-scoped export surface but should be revisited when user accounts and team workspaces become the dominant workflow.
+
+**Pitfalls to avoid**:
+1. Do not put export capabilities in URLs for product flows; query-string fallback is hidden from OpenAPI and exists only for local manual testing.
+2. Do not persist raw tokens inside `analysis`, history rows, telemetry, or browser-visible logs.
+3. Do not make tokens multi-use for convenience; rotation after each success is what makes replay detectable and testable.
+4. Do not scope a token only to a caller or only to a route; it must bind both operation scope and `diagram_id`.
+5. Do not silently bypass in production when Redis/file stores are unavailable; fail closed rather than exporting confidential topology data.
+
+**Tracking**: closed by #671.
 
 ### F-2 (P2) — Webhook SSRF (private-IP HTTPS targets)
 

--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -220,7 +220,7 @@ export default function AnalysisResults({
   analysis, loading, generatingIac, iacFormat, exportLoading,
   copyFeedback, genProgress, notifyEmail, onNotifyEmail,
   onSetStep, onGenerateIac, onExportDiagram, onCopyWithFeedback,
-  diagramId,
+  diagramId, exportCapability, onExportCapability,
 }) {
   const [resultsView, setResultsView] = useState('card');
 
@@ -374,7 +374,11 @@ export default function AnalysisResults({
       </div>
 
       {/* Export Hub Modal */}
-      <ExportHub diagramId={diagramId} />
+      <ExportHub
+        diagramId={diagramId}
+        exportCapability={exportCapability}
+        onExportCapability={onExportCapability}
+      />
 
       {/* Generation Progress Indicator (#311) */}
       {generatingIac && (

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -83,7 +83,7 @@ const DELIVERABLES = [
 ];
 
 // Generate a deliverable blob via the appropriate API
-async function generateDeliverable(diagramId, deliverable, format, hldIncludeDiagrams) {
+async function generateDeliverable(diagramId, deliverable, format, hldIncludeDiagrams, exportCapability) {
   const id = deliverable.id;
 
   if (id === 'iac') {
@@ -96,19 +96,31 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
   if (id === 'architecture-package') {
     const packageFormat = format.startsWith('svg') ? 'svg' : format;
     const packageDiagram = format === 'svg-dr' ? '&diagram=dr' : '';
-    const data = await api.post(`/diagrams/${diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`);
+    const data = await api.post(
+      `/diagrams/${diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`,
+      undefined,
+      undefined,
+      undefined,
+      exportCapability ? { 'X-Export-Capability': exportCapability } : {},
+    );
     const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
     const mime = packageFormat === 'html' ? 'text/html' : 'image/svg+xml';
     const filename = data.filename || `archmorph-architecture-package${format === 'svg-dr' ? '-dr' : ''}.${packageFormat}`;
-    return { blob: new Blob([content], { type: mime }), filename };
+    return { blob: new Blob([content], { type: mime }), filename, exportCapability: data.export_capability || null };
   }
 
   if (id === 'hld') {
     const cachedImg = loadCachedImage(diagramId);
     const exportBody = cachedImg?.base64 ? { diagram_image: cachedImg.base64 } : {};
-    const data = await api.post(`/diagrams/${diagramId}/export-hld?format=${format}&include_diagrams=${hldIncludeDiagrams}&export_mode=customer`, exportBody);
+    const data = await api.post(
+      `/diagrams/${diagramId}/export-hld?format=${format}&include_diagrams=${hldIncludeDiagrams}&export_mode=customer`,
+      exportBody,
+      undefined,
+      undefined,
+      exportCapability ? { 'X-Export-Capability': exportCapability } : {},
+    );
     const bytes = Uint8Array.from(atob(data.content_b64), c => c.charCodeAt(0));
-    return { blob: new Blob([bytes], { type: data.content_type }), filename: data.filename };
+    return { blob: new Blob([bytes], { type: data.content_type }), filename: data.filename, exportCapability: data.export_capability || null };
   }
 
   if (id === 'cost') {
@@ -167,9 +179,15 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
   }
 
   if (id === 'pdf-report') {
-    const data = await api.post(`/diagrams/${diagramId}/export-hld?format=pdf&include_diagrams=true&export_mode=customer`, {});
+    const data = await api.post(
+      `/diagrams/${diagramId}/export-hld?format=pdf&include_diagrams=true&export_mode=customer`,
+      {},
+      undefined,
+      undefined,
+      exportCapability ? { 'X-Export-Capability': exportCapability } : {},
+    );
     const bytes = Uint8Array.from(atob(data.content_b64), c => c.charCodeAt(0));
-    return { blob: new Blob([bytes], { type: 'application/pdf' }), filename: data.filename || 'archmorph-report.pdf' };
+    return { blob: new Blob([bytes], { type: 'application/pdf' }), filename: data.filename || 'archmorph-report.pdf', exportCapability: data.export_capability || null };
   }
 
   throw new Error(`Unknown deliverable: ${id}`);
@@ -184,7 +202,7 @@ function downloadBlob(blob, filename) {
   URL.revokeObjectURL(url);
 }
 
-export default function ExportHub({ diagramId, hldIncludeDiagrams = true }) {
+export default function ExportHub({ diagramId, hldIncludeDiagrams = true, exportCapability = null, onExportCapability }) {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState(() => {
     const init = {};
@@ -248,10 +266,15 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true }) {
     setItemStatus(newStatus);
     setResults({});
 
+    let currentExportCapability = exportCapability;
     for (const d of selectedItems) {
       setItemStatus(prev => ({ ...prev, [d.id]: 'loading' }));
       try {
-        const result = await generateDeliverable(diagramId, d, formats[d.id], hldIncludeDiagrams);
+        const result = await generateDeliverable(diagramId, d, formats[d.id], hldIncludeDiagrams, currentExportCapability);
+        if (result.exportCapability) {
+          currentExportCapability = result.exportCapability;
+          if (onExportCapability) onExportCapability(result.exportCapability);
+        }
         newResults[d.id] = result;
         setResults(prev => ({ ...prev, [d.id]: result }));
         setItemStatus(prev => ({ ...prev, [d.id]: 'done' }));

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -120,6 +120,7 @@ export default function DiagramTranslator() {
         iacCode: cached.iacCode || null,
         iacFormat: cached.iacFormat || 'terraform',
         hldData: cached.hldData || null,
+        exportCapability: cached.exportCapability || cached.analysis?.export_capability || null,
         step: cached.iacCode ? 'iac' : 'results',
       });
     }
@@ -195,7 +196,11 @@ export default function DiagramTranslator() {
         payload.image_base64 = cachedImg.base64;
         payload.image_content_type = cachedImg.contentType;
       }
-      await api.post(`/diagrams/${diagramId}/restore-session`, payload);
+      const restoredData = await api.post(`/diagrams/${diagramId}/restore-session`, payload);
+      if (restoredData?.export_capability) {
+        set({ exportCapability: restoredData.export_capability });
+        updateSessionCache({ exportCapability: restoredData.export_capability });
+      }
       return true;
     } catch {
       return false;
@@ -280,7 +285,7 @@ export default function DiagramTranslator() {
       addProgress('Uploading diagram...');
       const uploadData = await api.post('/projects/demo-project/diagrams', formData, signal);
       const { diagram_id } = uploadData;
-      set({ diagramId: diagram_id });
+      set({ diagramId: diagram_id, exportCapability: uploadData.export_capability || null });
 
       // Cache uploaded image for session restore (#333)
       if (file.type.startsWith('image/') && file.size < 1_000_000) {
@@ -380,12 +385,12 @@ export default function DiagramTranslator() {
         addProgress('Analysis complete. ✓');
         await new Promise(r => setTimeout(r, 400));
 
-        set({ analysis: result });
+        set({ analysis: result, exportCapability: result.export_capability || state.exportCapability || null });
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questions = qData.questions || [];
         const defaults = {};
         questions.forEach(q => { defaults[q.id] = q.default; });
-        saveSession(diagram_id, result, questions, defaults);
+        saveSession(diagram_id, result, questions, defaults, { exportCapability: result.export_capability || uploadData.export_capability || null });
         set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
       } else {
         // ── Fallback: sync endpoint with simulated progress ──
@@ -435,12 +440,12 @@ export default function DiagramTranslator() {
         addProgress('Analysis complete. ✓');
         await new Promise(r => setTimeout(r, 800));
 
-        set({ analysis: result });
+        set({ analysis: result, exportCapability: result.export_capability || uploadData.export_capability || null });
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questions = qData.questions || [];
         const defaults = {};
         questions.forEach(q => { defaults[q.id] = q.default; });
-        saveSession(diagram_id, result, questions, defaults);
+        saveSession(diagram_id, result, questions, defaults, { exportCapability: result.export_capability || uploadData.export_capability || null });
         set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
       }
     } catch (err) {
@@ -463,7 +468,7 @@ export default function DiagramTranslator() {
     set({ step: 'analyzing', analyzeProgress: ['Loading sample diagram...'] });
     try {
       const result = await api.post(`/samples/${sample.id}/analyze`);
-      set({ diagramId: result.diagram_id, analysis: result });
+      set({ diagramId: result.diagram_id, analysis: result, exportCapability: result.export_capability || null });
       for (const zone of (result.zones || [])) {
         const svcNames = (zone.services || []).map(s => s.source || s.name || '').filter(Boolean).slice(0, 3);
         addProgress(`Zone ${zone.id}: ${zone.name} (${svcNames.join(', ')})...`);
@@ -477,7 +482,7 @@ export default function DiagramTranslator() {
       const questions = qData.questions || [];
       const defaults = {};
       questions.forEach(q => { defaults[q.id] = q.default; });
-      saveSession(result.diagram_id, result, questions, defaults);
+      saveSession(result.diagram_id, result, questions, defaults, { exportCapability: result.export_capability || null });
       set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
     } catch (err) {
       set({ error: 'Failed to load sample: ' + err.message, step: 'upload' });
@@ -563,10 +568,20 @@ export default function DiagramTranslator() {
         exportBody.diagram_image = cachedImg.base64;
       }
       const data = await withRestore(
-        () => api.post(`/diagrams/${state.diagramId}/export-hld?format=${fmt}&include_diagrams=${state.hldIncludeDiagrams}&export_mode=customer`, exportBody),
+        () => api.post(
+          `/diagrams/${state.diagramId}/export-hld?format=${fmt}&include_diagrams=${state.hldIncludeDiagrams}&export_mode=customer`,
+          exportBody,
+          undefined,
+          undefined,
+          state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+        ),
         { cleanup: () => setHldExportLoading(fmt, false) },
       );
       if (data) {
+        if (data.export_capability) {
+          set({ exportCapability: data.export_capability });
+          updateSessionCache({ exportCapability: data.export_capability });
+        }
         const bytes = Uint8Array.from(atob(data.content_b64), c => c.charCodeAt(0));
         const blob = new Blob([bytes], { type: data.content_type });
         const url = URL.createObjectURL(blob);
@@ -592,11 +607,27 @@ export default function DiagramTranslator() {
       const packageDiagram = packageSelection === 'svg-dr' ? '&diagram=dr' : '';
       const data = await withRestore(
         () => isArchitecturePackage
-          ? api.post(`/diagrams/${state.diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`)
-          : api.post(`/diagrams/${state.diagramId}/export-diagram?format=${format}`),
+          ? api.post(
+              `/diagrams/${state.diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`,
+              undefined,
+              undefined,
+              undefined,
+              state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+            )
+          : api.post(
+              `/diagrams/${state.diagramId}/export-diagram?format=${format}`,
+              undefined,
+              undefined,
+              undefined,
+              state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+            ),
         { cleanup: () => setExportLoading(format, false) },
       );
       if (data) {
+        if (data.export_capability) {
+          set({ exportCapability: data.export_capability });
+          updateSessionCache({ exportCapability: data.export_capability });
+        }
         const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
         const exportMime = isArchitecturePackage
           ? (packageFormat === 'html' ? 'text/html' : 'image/svg+xml')
@@ -929,6 +960,11 @@ export default function DiagramTranslator() {
           onExportDiagram={handleExportDiagram}
           onCopyWithFeedback={copyWithFeedback}
           diagramId={state.diagramId}
+          exportCapability={state.exportCapability}
+          onExportCapability={(token) => {
+            set({ exportCapability: token });
+            updateSessionCache({ exportCapability: token });
+          }}
         />
       )}
 

--- a/frontend/src/components/DiagramTranslator/useWorkflow.js
+++ b/frontend/src/components/DiagramTranslator/useWorkflow.js
@@ -9,6 +9,7 @@ export const DEFAULT_CHAT_MESSAGE = {
 const initialState = {
   step: 'upload',
   diagramId: null,
+  exportCapability: null,
   jobId: null,
   analysis: null,
   questions: [],

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -167,13 +167,14 @@ async function request(path, options = {}, signal) {
 const api = {
   get: (path, signal) => request(path, { method: 'GET' }, signal),
 
-  post: (path, body, signal, timeout) =>
+  post: (path, body, signal, timeout, headers = {}) =>
     request(
       path,
       {
         method: 'POST',
         body: body instanceof FormData ? body : JSON.stringify(body),
-        timeout
+        timeout,
+        headers,
       },
       signal
     ),

--- a/frontend/src/services/sessionCache.js
+++ b/frontend/src/services/sessionCache.js
@@ -41,6 +41,7 @@ export function saveSession(diagramId, analysis, questions = [], answers = {}, e
       iacCode: extra.iacCode || null,
       iacFormat: extra.iacFormat || null,
       hldData: extra.hldData || null,
+      exportCapability: extra.exportCapability || null,
       ts: Date.now(),
     });
     sessionStorage.setItem(_cacheKey(diagramId), payload);

--- a/scripts/architecture_package_smoke.sh
+++ b/scripts/architecture_package_smoke.sh
@@ -24,6 +24,7 @@ fi
 API_BASE="${API_URL%/}"
 API_BASE="${API_BASE%/api}/api"
 FRONTEND_URL="${FRONTEND_URL%/}"
+EXPORT_CAPABILITY=""
 
 mkdir -p "$ARTIFACT_ROOT/raw" "$ARTIFACT_ROOT/artifacts"
 SUMMARY="$ARTIFACT_ROOT/summary.md"
@@ -82,6 +83,10 @@ request() {
     -H "X-API-Key: ${SMOKE_API_KEY}"
   )
 
+  if [[ -n "$EXPORT_CAPABILITY" ]]; then
+    curl_args+=( -H "X-Export-Capability: ${EXPORT_CAPABILITY}" )
+  fi
+
   if [[ -n "$body" ]]; then
     curl_args+=( -H "Content-Type: application/json" -d "$body" )
   fi
@@ -91,6 +96,12 @@ request() {
   echo "$http_code" > "$status_file"
   if [[ ! "$http_code" =~ ^2 ]]; then
     fail "$step_name" "HTTP ${http_code} from ${method} ${url}" "$output_file"
+  fi
+
+  local next_capability
+  next_capability=$(jq -er '.export_capability // empty' "$output_file" 2>/dev/null || true)
+  if [[ -n "$next_capability" ]]; then
+    EXPORT_CAPABILITY="$next_capability"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Adds one-time export capability tokens for generated artifact export/download routes.
- Scopes capabilities to `diagram_id`, consumes them on use, rotates on successful exports, and emits audit events without logging raw tokens.
- Wires frontend/session restore/export hub flows and the production Architecture Package smoke script to carry rotated capabilities.
- Updates security docs, export spec, threat model notes, and OpenAPI snapshot.

Closes #671.

## Validation
- `cd backend && .venv/bin/python -m pytest tests/test_export_capabilities.py -q`
- `cd backend && .venv/bin/python -m pytest tests/test_export_capabilities.py tests/test_sample_session_recreate.py tests/test_architecture_package.py tests/test_api.py tests/test_hld_generator.py -q`
- `cd frontend && npm run lint && npm run build`
- `bash -n scripts/architecture_package_smoke.sh`