### PR TITLE
fix: hydrate service freshness from durable state

### DIFF
--- a/backend/freshness_registry.py
+++ b/backend/freshness_registry.py
@@ -87,12 +87,17 @@ def register_with_last_success(
                 description=description,
             )
         else:
-            # Allow updating the budget / description, keep last_success.
+            # Allow updating the budget / description and advance seeded
+            # durable state when a cold process discovers a newer success.
             existing = _registry[name]
+            if existing.last_success and last_success:
+                seeded_last_success = max(existing.last_success, last_success)
+            else:
+                seeded_last_success = existing.last_success or last_success
             _registry[name] = _Registration(
                 name=name,
                 budget_hours=float(budget_hours),
-                last_success=existing.last_success or last_success,
+                last_success=seeded_last_success,
                 description=description or existing.description,
             )
 

--- a/backend/service_updater.py
+++ b/backend/service_updater.py
@@ -935,9 +935,8 @@ def _parse_state_timestamp(value: Any) -> Optional[datetime]:
     return parsed.astimezone(timezone.utc)
 
 
-def _last_successful_refresh_timestamp() -> Optional[datetime]:
-    """Return the newest persisted service-refresh timestamp with no errors."""
-    state = _read_state()
+def _last_successful_refresh_timestamp_from_state(state: dict[str, Any]) -> Optional[datetime]:
+    """Return the newest service-refresh timestamp with no provider errors."""
     for check_record in reversed(state.get("checks", [])):
         if check_record.get("errors"):
             continue
@@ -947,11 +946,17 @@ def _last_successful_refresh_timestamp() -> Optional[datetime]:
     return None
 
 
-def _register_service_catalog_freshness() -> None:
+def _last_successful_refresh_timestamp() -> Optional[datetime]:
+    """Return the newest persisted service-refresh timestamp with no errors."""
+    return _last_successful_refresh_timestamp_from_state(_read_state())
+
+
+def _register_service_catalog_freshness(last_success: Optional[datetime] = None) -> None:
     """Register the service catalog refresh job, seeding durable state."""
     from freshness_registry import mark_success, register_with_last_success
 
-    last_success = _last_successful_refresh_timestamp()
+    if last_success is None:
+        last_success = _last_successful_refresh_timestamp()
 
     register_with_last_success(
         "service_catalog_refresh",
@@ -985,27 +990,23 @@ def get_freshness() -> dict[str, Any]:
         }
     """
     state = _read_state()
+    last_success = _last_successful_refresh_timestamp_from_state(state)
     try:
-        _register_service_catalog_freshness()
+        _register_service_catalog_freshness(last_success=last_success)
     except Exception:  # noqa: BLE001
         pass
 
-    last = state.get("last_check")
+    last = last_success.isoformat() if last_success else None
     last_check_record = state["checks"][-1] if state.get("checks") else None
     last_errors = (last_check_record or {}).get("errors") or None
     providers_failed = sorted(last_errors.keys()) if isinstance(last_errors, dict) else []
 
     age_hours: Optional[float] = None
     stale = True
-    if last:
-        try:
-            ts = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
-            age_seconds = (datetime.now(timezone.utc) - ts).total_seconds()
-            age_hours = round(age_seconds / 3600, 2)
-            stale = age_hours > FRESHNESS_BUDGET_HOURS
-        except (ValueError, TypeError):
-            age_hours = None
-            stale = True
+    if last_success is not None:
+        age_seconds = (datetime.now(timezone.utc) - last_success).total_seconds()
+        age_hours = round(age_seconds / 3600, 2)
+        stale = age_hours > FRESHNESS_BUDGET_HOURS
 
     return {
         "last_check": last,

--- a/backend/tests/test_freshness_registry.py
+++ b/backend/tests/test_freshness_registry.py
@@ -59,6 +59,15 @@ class TestRegister:
         assert entry["stale"] is False
         assert entry["description"] == "seeded"
 
+    def test_register_with_last_success_advances_existing_seed(self):
+        older = datetime.now(timezone.utc) - timedelta(hours=8)
+        newer = datetime.now(timezone.utc) - timedelta(hours=1)
+        fr.register_with_last_success("job_seeded", budget_hours=24, last_success=older)
+        fr.register_with_last_success("job_seeded", budget_hours=24, last_success=newer)
+        entry = fr.get_all()[0]
+        assert entry["age_hours"] is not None
+        assert entry["age_hours"] < 2
+
 
 class TestMarkSuccess:
     def test_mark_success_unregistered_is_noop(self):

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -490,6 +490,68 @@ class TestFreshness:
         assert jobs[0]["last_success"] is not None
         assert jobs[0]["stale"] is False
 
+    def test_get_freshness_rehydrates_scheduled_job_registry_from_blob(self, tmp_path):
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock
+        import freshness_registry as fr
+        import json as _json
+        from service_updater import get_freshness
+
+        fr.reset_for_tests()
+        now = datetime.now(timezone.utc).isoformat()
+        blob_state = {
+            "last_check": now,
+            "checks": [{"timestamp": now,
+                        "new_services": {"aws": [], "azure": [], "gcp": []},
+                        "errors": None}],
+            "new_services_found": {"aws": [], "azure": [], "gcp": []},
+            "auto_added": {"aws": [], "azure": [], "gcp": []},
+        }
+        mock_blob = MagicMock()
+        mock_blob.download_blob.return_value.readall.return_value = _json.dumps(blob_state).encode("utf-8")
+
+        with patch("service_updater._get_state_blob_client", return_value=mock_blob), \
+             patch("service_updater._UPDATES_FILE", tmp_path / "missing.json"), \
+             patch("service_updater._DATA_DIR", tmp_path):
+            f = get_freshness()
+            jobs = fr.get_all()
+
+        assert f["last_check"] == now
+        assert f["stale"] is False
+        assert jobs[0]["name"] == "service_catalog_refresh"
+        assert jobs[0]["last_success"] is not None
+        assert jobs[0]["stale"] is False
+
+    def test_get_freshness_uses_last_successful_run_not_failed_check(self, tmp_path):
+        from datetime import datetime, timezone, timedelta
+        import json as _json
+        from service_updater import get_freshness
+
+        successful = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        failed = datetime.now(timezone.utc).isoformat()
+        state_file = tmp_path / "updates.json"
+        state_file.write_text(_json.dumps({
+            "last_check": failed,
+            "checks": [
+                {"timestamp": successful,
+                 "new_services": {"aws": [], "azure": [], "gcp": []},
+                 "errors": None},
+                {"timestamp": failed,
+                 "new_services": {"aws": [], "azure": [], "gcp": []},
+                 "errors": {"gcp": "HTTP 500"}},
+            ],
+            "new_services_found": {"aws": [], "azure": [], "gcp": []},
+            "auto_added": {"aws": [], "azure": [], "gcp": []},
+        }), encoding="utf-8")
+
+        with patch("service_updater._UPDATES_FILE", state_file), \
+             patch("service_updater._get_state_blob_client", return_value=None):
+            f = get_freshness()
+
+        assert f["last_check"] == successful
+        assert f["stale"] is False
+        assert f["providers_failed"] == ["gcp"]
+
     def test_old_run_is_stale(self, tmp_path):
         from datetime import datetime, timezone, timedelta
         import json as _json

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -508,7 +508,8 @@ class TestFreshness:
             "auto_added": {"aws": [], "azure": [], "gcp": []},
         }
         mock_blob = MagicMock()
-        mock_blob.download_blob.return_value.readall.return_value = _json.dumps(blob_state).encode("utf-8")
+        blob_payload = _json.dumps(blob_state).encode("utf-8")
+        mock_blob.download_blob.return_value.readall.return_value = blob_payload
 
         with patch("service_updater._get_state_blob_client", return_value=mock_blob), \
              patch("service_updater._UPDATES_FILE", tmp_path / "missing.json"), \


### PR DESCRIPTION
## Summary
- Bases service catalog freshness on the newest successful persisted refresh rather than the newest check of any outcome.
- Seeds the scheduled-job registry from the same durable state used for the `/api/health.service_catalog_refresh` block.
- Allows registry re-registration to advance to newer durable success timestamps on cold startup.
- Adds blob-backed cold-start regression coverage and failed-latest-check coverage.

Closes #695.

## Validation
- `cd backend && .venv/bin/python -m pytest tests/test_service_updater.py::TestFreshness tests/test_freshness_registry.py -q`
- `cd backend && .venv/bin/python -m pytest tests/test_service_updater.py tests/test_freshness_registry.py -q`