### PR TITLE
ci: fail deployments on required production health degradation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,16 +406,7 @@ jobs:
           fi
 
           echo "Running smoke tests against: $TEST_URL$HEALTH_PATH"
-          for i in 1 2 3; do
-            HEALTH=$(curl -s --max-time 30 "$TEST_URL$HEALTH_PATH" | jq -r '.status' 2>/dev/null || echo 'failed')
-            if [ "$HEALTH" = "healthy" ] || [ "$HEALTH" = "degraded" ]; then break; fi
-            echo "Health check attempt $i returned: $HEALTH — retrying in 15s..."
-            sleep 15
-          done
-          if [ "$HEALTH" != "healthy" ] && [ "$HEALTH" != "degraded" ]; then
-            echo "::error::Green revision health check failed: $HEALTH"
-            exit 1
-          fi
+          HEALTH_RETRIES=3 HEALTH_RETRY_SECONDS=15 ./scripts/health_gate.sh "$TEST_URL$HEALTH_PATH"
           VERSION=$(curl -s --max-time 30 "$TEST_URL$HEALTH_PATH" | jq -r '.version' 2>/dev/null || echo 'unknown')
           echo "Green revision version: $VERSION — all smoke tests passed"
 
@@ -449,12 +440,9 @@ jobs:
       - name: Verify production deployment
         run: |
           sleep 10
+          HEALTH_RETRIES=3 HEALTH_RETRY_SECONDS=10 ./scripts/health_gate.sh "${{ env.API_URL }}/health"
           HEALTH=$(curl -s --max-time 30 ${{ env.API_URL }}/health | jq -r '.status')
           VERSION=$(curl -s --max-time 30 ${{ env.API_URL }}/health | jq -r '.version')
-          if [ "$HEALTH" != "healthy" ] && [ "$HEALTH" != "degraded" ]; then
-            echo "::error::Production health check failed: $HEALTH"
-            exit 1
-          fi
           echo "Deployed version: $VERSION — status: $HEALTH (blue-green complete)"
 
   # ============================================

--- a/backend/tests/test_health_gate_script.py
+++ b/backend/tests/test_health_gate_script.py
@@ -1,0 +1,114 @@
+"""Tests for the production health gate used by deployment smoke."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "health_gate.sh"
+
+
+def run_gate(payload: dict) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HEALTH_BODY"] = json.dumps(payload)
+    env["HEALTH_RETRIES"] = "1"
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def healthy_payload() -> dict:
+    return {
+        "status": "healthy",
+        "version": "4.0.0",
+        "checks": {
+            "openai": "ok",
+            "storage": "ok",
+            "redis": "not_configured",
+            "service_catalog": "ok",
+        },
+        "service_catalog_refresh": {
+            "age_hours": 0.1,
+            "budget_hours": 36.0,
+            "stale": False,
+        },
+        "scheduled_jobs": [
+            {
+                "name": "service_catalog_refresh",
+                "age_hours": 0.1,
+                "budget_hours": 36.0,
+                "stale": False,
+            }
+        ],
+    }
+
+
+def test_health_gate_passes_healthy_with_optional_redis_warning():
+    result = run_gate(healthy_payload())
+
+    assert result.returncode == 0
+    assert "Production health gate passed" in result.stdout
+    assert "Redis is not configured" in result.stdout
+
+
+def test_health_gate_fails_degraded_service_catalog_refresh():
+    payload = healthy_payload()
+    payload["status"] = "degraded"
+    payload["checks"]["service_catalog_refresh"] = "never_ran"
+    payload["service_catalog_refresh"]["stale"] = True
+    payload["service_catalog_refresh"]["age_hours"] = None
+
+    result = run_gate(payload)
+
+    assert result.returncode == 1
+    assert "requires status=healthy" in result.stdout
+    assert "service_catalog_refresh" in result.stdout
+
+
+def test_health_gate_fails_stale_service_catalog_refresh_even_if_status_is_wrongly_healthy():
+    payload = healthy_payload()
+    payload["service_catalog_refresh"]["stale"] = True
+    payload["service_catalog_refresh"]["age_hours"] = None
+
+    result = run_gate(payload)
+
+    assert result.returncode == 1
+    assert "service_catalog_refresh is stale" in result.stdout
+
+
+def test_health_gate_fails_stale_scheduled_job_even_if_status_is_wrongly_healthy():
+    payload = healthy_payload()
+    payload["scheduled_jobs"][0]["stale"] = True
+
+    result = run_gate(payload)
+
+    assert result.returncode == 1
+    assert "Scheduled jobs are stale" in result.stdout
+    assert "service_catalog_refresh" in result.stdout
+
+
+def test_health_gate_fails_invalid_json_with_clear_error():
+    env = os.environ.copy()
+    env["HEALTH_BODY"] = "<html>not json</html>"
+    env["HEALTH_RETRIES"] = "1"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "could not parse a valid health JSON status" in result.stdout

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -78,7 +78,7 @@ After deployment, verify:
 - Frontend root loads without console-blocking errors.
 - `/#translator` opens the translator workflow.
 - `/#playground` opens the sample playground.
-- `${API_URL}/health` returns `healthy` or `degraded` with expected version metadata.
+- `${API_URL}/health` passes `scripts/health_gate.sh`: status must be `healthy`, scheduled jobs must be fresh, and optional Redis absence may warn only when overall health remains healthy.
 - `${API_ROOT}/openapi.json` loads and reports `Archmorph API`.
 - Run the [Production Architecture Package Smoke](PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) workflow with `strict_freshness=true`; retain the summary and artifact bundle for release evidence.
 - Confirm each changed generated artifact has an owner, validation command or explicit gap note, fixture, release evidence location, and gap tracking entry in the [Generated Artifact Validation Matrix](GENERATED_ARTIFACT_VALIDATION_MATRIX.md).
@@ -122,4 +122,4 @@ Before enabling any scaffolded feature, confirm:
 - GitHub Actions run URL.
 - Smoke-test output summary and Architecture Package smoke artifact manifest.
 - Enabled feature flags and tenant scope.
-- Any known degraded dependencies accepted for release.
+- Any known optional dependency warnings accepted for release. Required `degraded` or `unhealthy` production health is release-blocking.

--- a/scripts/deployment_smoke.sh
+++ b/scripts/deployment_smoke.sh
@@ -37,14 +37,7 @@ check_status() {
 check_status "Frontend root" "$FRONTEND_URL"
 check_status "Frontend translator route" "$FRONTEND_URL/#translator"
 
-HEALTH_BODY=$(curl -sS --max-time 30 "$API_URL/health")
-HEALTH_STATUS=$(echo "$HEALTH_BODY" | jq -r '.status // "unknown"')
-if [[ "$HEALTH_STATUS" != "healthy" && "$HEALTH_STATUS" != "degraded" ]]; then
-  echo "::error::API health status is $HEALTH_STATUS"
-  echo "$HEALTH_BODY"
-  exit 1
-fi
-echo "API health OK ($HEALTH_STATUS)"
+HEALTH_RETRIES=3 HEALTH_RETRY_SECONDS=10 "$(dirname "$0")/health_gate.sh" "$API_URL/health"
 
 OPENAPI_STATUS=$(curl -sS -o /tmp/archmorph-openapi -w "%{http_code}" --max-time 30 "$API_ROOT/openapi.json")
 if [[ "$OPENAPI_STATUS" != "200" ]]; then

--- a/scripts/health_gate.sh
+++ b/scripts/health_gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HEALTH_URL="${1:-${HEALTH_URL:-}}"
+HEALTH_BODY="${HEALTH_BODY:-}"
+HEALTH_RETRIES="${HEALTH_RETRIES:-3}"
+HEALTH_RETRY_SECONDS="${HEALTH_RETRY_SECONDS:-10}"
+
+if [[ -z "$HEALTH_URL" && -z "$HEALTH_BODY" ]]; then
+  echo "::error::health gate requires a URL argument, HEALTH_URL, or HEALTH_BODY"
+  exit 1
+fi
+
+fetch_health() {
+  if [[ -n "$HEALTH_BODY" ]]; then
+    printf '%s' "$HEALTH_BODY"
+    return 0
+  fi
+
+  curl -sS --max-time 30 "$HEALTH_URL"
+}
+
+health_json=""
+for attempt in $(seq 1 "$HEALTH_RETRIES"); do
+  if health_json="$(fetch_health)"; then
+    status="$(printf '%s' "$health_json" | jq -r '.status // "unknown"' 2>/dev/null || echo failed)"
+    if [[ "$status" == "healthy" ]]; then
+      break
+    fi
+  else
+    status="failed"
+  fi
+
+  if [[ "$attempt" -lt "$HEALTH_RETRIES" ]]; then
+    echo "Health gate attempt $attempt returned $status; retrying in ${HEALTH_RETRY_SECONDS}s..."
+    sleep "$HEALTH_RETRY_SECONDS"
+  fi
+done
+
+if [[ -z "$health_json" ]]; then
+  echo "::error::Health gate could not retrieve a health response"
+  exit 1
+fi
+
+status="$(printf '%s' "$health_json" | jq -r '.status // "unknown"' 2>/dev/null || echo failed)"
+version="$(printf '%s' "$health_json" | jq -r '.version // "unknown"' 2>/dev/null || echo unknown)"
+
+if [[ "$status" == "failed" || "$status" == "unknown" ]]; then
+  echo "::error::Health gate could not parse a valid health JSON status after ${HEALTH_RETRIES} attempt(s)"
+  printf '%s\n' "$health_json"
+  exit 1
+fi
+
+if [[ "$status" != "healthy" ]]; then
+  echo "::error::Production health gate requires status=healthy, got status=${status}"
+  printf '%s' "$health_json" | jq -c '{status, version, checks, service_catalog_refresh, scheduled_jobs}' || printf '%s\n' "$health_json"
+  exit 1
+fi
+
+if printf '%s' "$health_json" | jq -e '.service_catalog_refresh.stale == true' >/dev/null; then
+  echo "::error::service_catalog_refresh is stale"
+  printf '%s' "$health_json" | jq -c '.service_catalog_refresh'
+  exit 1
+fi
+
+stale_jobs="$(printf '%s' "$health_json" | jq -r '[.scheduled_jobs[]? | select(.stale == true) | .name] | join(",")')"
+if [[ -n "$stale_jobs" ]]; then
+  echo "::error::Scheduled jobs are stale: ${stale_jobs}"
+  printf '%s' "$health_json" | jq -c '[.scheduled_jobs[]? | select(.stale == true)]'
+  exit 1
+fi
+
+redis_status="$(printf '%s' "$health_json" | jq -r '.checks.redis // empty')"
+if [[ "$redis_status" == "not_configured" ]]; then
+  echo "::warning::Redis is not configured; accepted as optional because overall production health is healthy"
+fi
+
+echo "Production health gate passed: status=${status} version=${version}"


### PR DESCRIPTION
## Summary

Closes #710.

- Add `scripts/health_gate.sh` as the shared production health contract for deploy verification and post-deploy smoke.
- Require deployed API health to be `healthy`; stale `service_catalog_refresh` or stale scheduled jobs now fail the gate.
- Treat Redis `not_configured` as an optional warning only when overall health is already healthy.
- Wire the gate into green revision smoke, production deployment verification, and `scripts/deployment_smoke.sh`.
- Update the release checklist so required `degraded`/`unhealthy` production health is release-blocking.

## Validation

- `bash -n scripts/health_gate.sh scripts/deployment_smoke.sh`
- `git diff --check`
- `cd backend && .venv/bin/python -m pytest tests/test_health_gate_script.py -q`
- `cd backend && .venv/bin/python -m ruff check tests/test_health_gate_script.py`
- `API_URL=https://api.archmorphai.com/api FRONTEND_URL=https://agreeable-ground-01012c003.2.azurestaticapps.net scripts/deployment_smoke.sh`

## Production evidence

Current production health after service catalog remediation:

- `status`: `healthy`
- `service_catalog_refresh.stale`: `false`
- `scheduled_jobs[service_catalog_refresh].stale`: `false`
- Redis absence is surfaced as an optional warning, not a degraded status.