### PR TITLE
fix: clarify redis health and k6 diagnostics

### DIFF
--- a/.github/workflows/backend-performance.yml
+++ b/.github/workflows/backend-performance.yml
@@ -30,6 +30,14 @@ jobs:
         run: |
           docker run --rm --network host -i -v ${{ github.workspace }}:/app -w /app -e API_BASE_URL="http://localhost:8000" -e CI=true grafana/k6:latest run backend/tests/performance/api_load_test.js
 
+      - name: Upload k6 summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-k6-summary
+          path: k6-summary.json
+          if-no-files-found: ignore
+
       - name: Dump docker logs on failure
         if: failure()
         run: docker compose logs backend

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -68,14 +68,22 @@ def _run_dependency_checks() -> tuple[dict[str, str], bool, bool]:
         checks["storage"] = "error"
         degraded = True
 
-    # ── Redis (if configured) ─────────────────────────────
+    # ── Redis (optional unless REQUIRE_REDIS/ENFORCE_REDIS is set) ────────
     try:
-        from session_store import redis_configured, _create_redis_client
+        from session_store import (
+            REQUIRE_REDIS,
+            _create_redis_client,
+            redis_configured,
+            session_store_readiness,
+        )
         if redis_configured():
             _create_redis_client(socket_connect_timeout=2)
             checks["redis"] = "ok"
         else:
-            checks["redis"] = "not_configured"
+            checks["redis"] = "missing_required" if REQUIRE_REDIS else "disabled_optional"
+            if REQUIRE_REDIS:
+                degraded = True
+        checks["redis_readiness"] = session_store_readiness()
     except Exception:
         checks["redis"] = "error"
         degraded = True

--- a/backend/tests/performance/api_load_test.js
+++ b/backend/tests/performance/api_load_test.js
@@ -37,6 +37,9 @@ const rateLimitRate = new Rate('rate_limited');
 
 // CI environments (GitHub Actions) have limited CPU; scale load accordingly
 const RATE_MULTIPLIER = isCI ? 0.3 : 1;  // 30 RPS in CI, 100 RPS locally
+const CATALOG_P95_THRESHOLD_MS = Number(
+  __ENV.K6_CATALOG_P95_MS || (isCI ? 3000 : 1500),
+);
 
 export const options = {
   scenarios: {
@@ -79,7 +82,7 @@ export const options = {
     http_req_failed: ['rate<0.10'],
     errors: ['rate<0.01'],
     chat_latency: ['p(95)<5000'],
-    catalog_latency: [isCI ? 'p(95)<3000' : 'p(95)<1500'],
+    catalog_latency: [`p(95)<${CATALOG_P95_THRESHOLD_MS}`],
   },
 };
 
@@ -152,4 +155,68 @@ export function uncachedLlmEndpoints() {
   chatLatency.add(res.timings.duration);
   rateLimitRate.add(res.status === 429);
   errorRate.add(res.status >= 500);
+}
+
+function metricValue(data, metricName, valueName) {
+  const metric = data.metrics[metricName];
+  if (!metric || !metric.values) return null;
+  const value = metric.values[valueName];
+  return typeof value === 'number' ? value : null;
+}
+
+function thresholdRows(data) {
+  const rows = [];
+  for (const [metricName, metric] of Object.entries(data.metrics)) {
+    if (!metric.thresholds) continue;
+    for (const [threshold, result] of Object.entries(metric.thresholds)) {
+      rows.push({
+        metric: metricName,
+        threshold,
+        ok: !!result.ok,
+      });
+    }
+  }
+  return rows.sort((a, b) => `${a.metric}:${a.threshold}`.localeCompare(`${b.metric}:${b.threshold}`));
+}
+
+export function handleSummary(data) {
+  const rows = thresholdRows(data);
+  const failed = rows.filter((row) => !row.ok);
+  const catalogP95 = metricValue(data, 'catalog_latency', 'p(95)');
+  const httpP95 = metricValue(data, 'http_req_duration', 'p(95)');
+  const httpFailed = metricValue(data, 'http_req_failed', 'rate');
+  const checksFailed = metricValue(data, 'checks', 'fails');
+
+  const summary = {
+    ci: isCI,
+    target_rps: Math.ceil(100 * RATE_MULTIPLIER),
+    thresholds: rows,
+    failed_thresholds: failed,
+    key_metrics: {
+      catalog_latency_p95_ms: catalogP95,
+      catalog_latency_threshold_ms: CATALOG_P95_THRESHOLD_MS,
+      http_req_duration_p95_ms: httpP95,
+      http_req_failed_rate: httpFailed,
+      checks_failed: checksFailed,
+    },
+  };
+
+  const failedText = failed.length
+    ? failed.map((row) => `- ${row.metric} ${row.threshold}`).join('\n')
+    : '- none';
+  const stdout = [
+    'Archmorph k6 summary',
+    `target_rps=${summary.target_rps}`,
+    `catalog_latency_p95_ms=${catalogP95 ?? 'n/a'} threshold_ms=${CATALOG_P95_THRESHOLD_MS}`,
+    `http_req_duration_p95_ms=${httpP95 ?? 'n/a'}`,
+    `http_req_failed_rate=${httpFailed ?? 'n/a'}`,
+    'failed_thresholds:',
+    failedText,
+    '',
+  ].join('\n');
+
+  return {
+    stdout,
+    'k6-summary.json': JSON.stringify(summary, null, 2),
+  };
 }

--- a/backend/tests/test_contract.py
+++ b/backend/tests/test_contract.py
@@ -144,6 +144,72 @@ class TestHealthContract:
         checks = client.get("/api/health").json()["checks"]
         assert_fields(checks, {"openai": str, "storage": str})
 
+    def test_optional_redis_is_explicitly_classified(self, client, monkeypatch):
+        import routers.health as health_router
+
+        def fake_checks():
+            return {
+                "openai": "ok",
+                "storage": "ok",
+                "redis": "disabled_optional",
+                "redis_readiness": {
+                    "backend": "file",
+                    "redis_configured": False,
+                    "require_redis": False,
+                    "production_like": True,
+                    "multi_worker": True,
+                    "ready_for_horizontal_scale": False,
+                },
+            }, False, False
+
+        monkeypatch.setattr(health_router, "_run_dependency_checks", fake_checks)
+        data = client.get("/api/health").json()
+
+        assert data["checks"]["redis"] == "disabled_optional"
+        assert data["checks"]["redis_readiness"]["require_redis"] is False
+
+    def test_health_reads_freshness_before_scheduled_jobs(self, client, monkeypatch):
+        import routers.health as health_router
+
+        calls = []
+
+        def fake_freshness():
+            calls.append("freshness")
+            return {
+                "last_check": "2026-01-01T00:00:00+00:00",
+                "age_hours": 1.0,
+                "budget_hours": 36.0,
+                "stale": False,
+                "last_errors": None,
+                "providers_failed": [],
+            }
+
+        def fake_scheduled_jobs():
+            calls.append("scheduled_jobs")
+            return [
+                {
+                    "name": "service_catalog_refresh",
+                    "budget_hours": 36.0,
+                    "last_success": "2026-01-01T00:00:00+00:00",
+                    "age_hours": 1.0,
+                    "stale": False,
+                    "description": "test job",
+                }
+            ]
+
+        monkeypatch.setattr(health_router, "get_freshness", fake_freshness)
+        monkeypatch.setattr(health_router, "get_scheduled_jobs", fake_scheduled_jobs)
+        monkeypatch.setattr(
+            health_router,
+            "_run_dependency_checks",
+            lambda: ({"openai": "ok", "storage": "ok"}, False, False),
+        )
+
+        data = client.get("/api/health").json()
+
+        assert data["status"] == "healthy"
+        assert calls == ["freshness", "scheduled_jobs"]
+
     def test_health_scheduled_jobs_schema(self, client):
         data = client.get("/api/health").json()
         assert "scheduled_jobs" in data

--- a/backend/tests/test_health_gate_script.py
+++ b/backend/tests/test_health_gate_script.py
@@ -33,7 +33,15 @@ def healthy_payload() -> dict:
         "checks": {
             "openai": "ok",
             "storage": "ok",
-            "redis": "not_configured",
+            "redis": "disabled_optional",
+            "redis_readiness": {
+                "backend": "file",
+                "redis_configured": False,
+                "require_redis": False,
+                "production_like": True,
+                "multi_worker": True,
+                "ready_for_horizontal_scale": False,
+            },
             "service_catalog": "ok",
         },
         "service_catalog_refresh": {
@@ -57,7 +65,18 @@ def test_health_gate_passes_healthy_with_optional_redis_warning():
 
     assert result.returncode == 0
     assert "Production health gate passed" in result.stdout
-    assert "Redis is not configured" in result.stdout
+    assert "Redis is disabled as an optional dependency" in result.stdout
+
+
+def test_health_gate_fails_required_redis_missing_even_if_status_is_wrongly_healthy():
+    payload = healthy_payload()
+    payload["checks"]["redis"] = "missing_required"
+    payload["checks"]["redis_readiness"]["require_redis"] = True
+
+    result = run_gate(payload)
+
+    assert result.returncode == 1
+    assert "Redis is required but not configured" in result.stdout
 
 
 def test_health_gate_fails_degraded_service_catalog_refresh():

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -78,7 +78,7 @@ After deployment, verify:
 - Frontend root loads without console-blocking errors.
 - `/#translator` opens the translator workflow.
 - `/#playground` opens the sample playground.
-- `${API_URL}/health` passes `scripts/health_gate.sh`: status must be `healthy`, scheduled jobs must be fresh, and optional Redis absence may warn only when overall health remains healthy.
+- `${API_URL}/health` passes `scripts/health_gate.sh`: status must be `healthy`, scheduled jobs must be fresh, and Redis must report either `ok` or `disabled_optional`. `missing_required` is release-blocking.
 - `${API_ROOT}/openapi.json` loads and reports `Archmorph API`.
 - Run the [Production Architecture Package Smoke](PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) workflow with `strict_freshness=true`; retain the summary and artifact bundle for release evidence.
 - Confirm each changed generated artifact has an owner, validation command or explicit gap note, fixture, release evidence location, and gap tracking entry in the [Generated Artifact Validation Matrix](GENERATED_ARTIFACT_VALIDATION_MATRIX.md).
@@ -122,4 +122,4 @@ Before enabling any scaffolded feature, confirm:
 - GitHub Actions run URL.
 - Smoke-test output summary and Architecture Package smoke artifact manifest.
 - Enabled feature flags and tenant scope.
-- Any known optional dependency warnings accepted for release. Required `degraded` or `unhealthy` production health is release-blocking.
+- Any known optional dependency warnings accepted for release, including the Redis `disabled_optional` mode when `checks.redis_readiness.require_redis=false`. Required `degraded`, `unhealthy`, or `missing_required` production health is release-blocking.

--- a/scripts/health_gate.sh
+++ b/scripts/health_gate.sh
@@ -71,8 +71,12 @@ if [[ -n "$stale_jobs" ]]; then
 fi
 
 redis_status="$(printf '%s' "$health_json" | jq -r '.checks.redis // empty')"
-if [[ "$redis_status" == "not_configured" ]]; then
-  echo "::warning::Redis is not configured; accepted as optional because overall production health is healthy"
+if [[ "$redis_status" == "missing_required" ]]; then
+  echo "::error::Redis is required but not configured"
+  printf '%s' "$health_json" | jq -c '.checks.redis_readiness // {redis: .checks.redis}'
+  exit 1
+elif [[ "$redis_status" == "not_configured" || "$redis_status" == "disabled_optional" ]]; then
+  echo "::warning::Redis is disabled as an optional dependency; accepted because overall production health is healthy"
 fi
 
 echo "Production health gate passed: status=${status} version=${version}"


### PR DESCRIPTION
## Summary

Addresses the remaining queue after #712:

- Classifies Redis health explicitly as `disabled_optional` when Redis is not required, and `missing_required` when `REQUIRE_REDIS`/`ENFORCE_REDIS` is set without Redis configuration.
- Surfaces `checks.redis_readiness` in `/api/health` so operators can see backend selection, required-vs-optional mode, and horizontal-scale readiness.
- Updates `scripts/health_gate.sh` to fail on `missing_required` Redis and continue warning for optional Redis absence only when overall health is healthy.
- Locks the `/api/health` ordering that reads service catalog freshness before scheduled jobs, preserving durable-state rehydration before stale-job evaluation.
- Adds a k6 `handleSummary` output with failed thresholds and key p95/error metrics, uploads `k6-summary.json`, and keeps the catalog p95 threshold configurable via `K6_CATALOG_P95_MS`.
- Updates the release checklist with the explicit Redis release contract.

## Validation

- `git diff --check`
- `bash -n scripts/health_gate.sh`
- `node --check backend/tests/performance/api_load_test.js`
- `./.venv/bin/python -m pytest tests/test_health_gate_script.py tests/test_contract.py tests/test_service_updater.py tests/test_freshness_registry.py tests/test_production_parity.py -q` from `backend/` — 161 passed

## Notes

Docker is not available in the local shell, so the real `grafana/k6` runtime validation is left to GitHub Actions. This keeps the deployment gate strict and improves performance-failure diagnostics without relaxing the SLA threshold by default.

Closes #709.
Refs #713.