### PR TITLE
fix: guard Redis readiness for horizontal scale

### DIFF
--- a/backend/session_store.py
+++ b/backend/session_store.py
@@ -487,14 +487,42 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "development").lower()
 REQUIRE_REDIS = os.getenv("REQUIRE_REDIS", os.getenv("ENFORCE_REDIS", "")).lower() in ("1", "true", "yes")
 
 
+def _env_int(name: str, default: int = 1) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
 def _is_multi_worker() -> bool:
     """Detect if the application is running with multiple workers."""
-    return WORKER_COUNT > 1
+    return _env_int("WEB_CONCURRENCY", _env_int("UVICORN_WORKERS", WORKER_COUNT)) > 1
+
+
+def _declared_replica_count() -> int:
+    """Return the deployment-declared replica count, if provided."""
+    return max(
+        _env_int("CONTAINER_APP_REPLICA_COUNT", 1),
+        _env_int("CONTAINER_APP_MIN_REPLICAS", 1),
+    )
+
+
+def _is_multi_replica() -> bool:
+    """Detect if the deployment has declared multiple active/min replicas."""
+    return _declared_replica_count() > 1
 
 
 def _is_production() -> bool:
     """Detect if the application is running in a production-like environment."""
-    return ENVIRONMENT in ("production", "prod", "staging")
+    return os.getenv("ENVIRONMENT", ENVIRONMENT).lower() in ("production", "prod", "staging")
+
+
+def _redis_required() -> bool:
+    """Return True when Redis is an explicit hard dependency."""
+    return os.getenv(
+        "REQUIRE_REDIS",
+        os.getenv("ENFORCE_REDIS", "true" if REQUIRE_REDIS else ""),
+    ).lower() in ("1", "true", "yes")
 
 
 def session_store_backend() -> str:
@@ -509,13 +537,25 @@ def session_store_backend() -> str:
 def session_store_readiness() -> dict[str, Any]:
     """Return operator-facing readiness metadata for release gates."""
     backend = session_store_backend()
+    redis_ready = backend == "redis"
+    requires_redis_for_scale = _is_multi_worker() or _is_multi_replica()
+    scale_blocked = requires_redis_for_scale and not redis_ready
     return {
         "backend": backend,
         "redis_configured": redis_configured(),
-        "require_redis": REQUIRE_REDIS,
+        "require_redis": _redis_required(),
         "production_like": _is_production(),
         "multi_worker": _is_multi_worker(),
-        "ready_for_horizontal_scale": backend == "redis",
+        "declared_replica_count": _declared_replica_count(),
+        "multi_replica": _is_multi_replica(),
+        "requires_redis_for_scale": requires_redis_for_scale,
+        "ready_for_horizontal_scale": redis_ready,
+        "scale_blocked": scale_blocked,
+        "scale_blocked_reason": (
+            "Redis is required when WEB_CONCURRENCY/UVICORN_WORKERS or declared replicas exceed 1"
+            if scale_blocked
+            else None
+        ),
     }
 
 

--- a/backend/tests/test_health_gate_script.py
+++ b/backend/tests/test_health_gate_script.py
@@ -39,8 +39,13 @@ def healthy_payload() -> dict:
                 "redis_configured": False,
                 "require_redis": False,
                 "production_like": True,
-                "multi_worker": True,
+                "multi_worker": False,
+                "declared_replica_count": 1,
+                "multi_replica": False,
+                "requires_redis_for_scale": False,
                 "ready_for_horizontal_scale": False,
+                "scale_blocked": False,
+                "scale_blocked_reason": None,
             },
             "service_catalog": "ok",
         },
@@ -77,6 +82,22 @@ def test_health_gate_fails_required_redis_missing_even_if_status_is_wrongly_heal
 
     assert result.returncode == 1
     assert "Redis is required but not configured" in result.stdout
+
+
+def test_health_gate_fails_redis_scale_blocker_even_if_status_is_wrongly_healthy():
+    payload = healthy_payload()
+    payload["checks"]["redis_readiness"]["multi_worker"] = True
+    payload["checks"]["redis_readiness"]["requires_redis_for_scale"] = True
+    payload["checks"]["redis_readiness"]["scale_blocked"] = True
+    payload["checks"]["redis_readiness"]["scale_blocked_reason"] = (
+        "Redis is required when WEB_CONCURRENCY/UVICORN_WORKERS or declared replicas exceed 1"
+    )
+
+    result = run_gate(payload)
+
+    assert result.returncode == 1
+    assert "Redis is required before horizontal scale" in result.stdout
+    assert "scale_blocked" in result.stdout
 
 
 def test_health_gate_fails_degraded_service_catalog_refresh():

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -103,6 +103,52 @@ class TestGetStore:
         readiness = session_store_readiness()
         assert readiness["backend"] in {"memory", "file", "redis"}
         assert "ready_for_horizontal_scale" in readiness
+        assert "scale_blocked" in readiness
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "production",
+        "WEB_CONCURRENCY": "1",
+        "UVICORN_WORKERS": "1",
+        "CONTAINER_APP_REPLICA_COUNT": "1",
+        "CONTAINER_APP_MIN_REPLICAS": "1",
+        "REDIS_URL": "",
+        "REDIS_HOST": "",
+        "REQUIRE_REDIS": "",
+    })
+    def test_optional_redis_single_replica_does_not_block_scale(self):
+        readiness = session_store_readiness()
+        assert readiness["backend"] == "file"
+        assert readiness["requires_redis_for_scale"] is False
+        assert readiness["scale_blocked"] is False
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "production",
+        "WEB_CONCURRENCY": "2",
+        "REDIS_URL": "",
+        "REDIS_HOST": "",
+        "REQUIRE_REDIS": "",
+    })
+    def test_multi_worker_without_redis_blocks_horizontal_scale(self):
+        readiness = session_store_readiness()
+        assert readiness["multi_worker"] is True
+        assert readiness["requires_redis_for_scale"] is True
+        assert readiness["scale_blocked"] is True
+        assert readiness["scale_blocked_reason"]
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "production",
+        "WEB_CONCURRENCY": "1",
+        "CONTAINER_APP_MIN_REPLICAS": "2",
+        "REDIS_URL": "",
+        "REDIS_HOST": "",
+        "REQUIRE_REDIS": "",
+    })
+    def test_declared_multi_replica_without_redis_blocks_horizontal_scale(self):
+        readiness = session_store_readiness()
+        assert readiness["declared_replica_count"] == 2
+        assert readiness["multi_replica"] is True
+        assert readiness["requires_redis_for_scale"] is True
+        assert readiness["scale_blocked"] is True
 
 
 class TestSessionStoreInterface:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -37,6 +37,7 @@ Application secrets:
 - `LOG_ANALYTICS_WORKSPACE_ID`
 - `DATABASE_URL` — PostgreSQL connection string for production
 - `REDIS_HOST` or `REDIS_URL` — Redis-backed session/cache store for scaled deployments
+- `CONTAINER_APP_REPLICA_COUNT` or `CONTAINER_APP_MIN_REPLICAS` — declare intentional multi-replica runtime to the health gate
 
 Production guard env vars:
 
@@ -122,4 +123,4 @@ Before enabling any scaffolded feature, confirm:
 - GitHub Actions run URL.
 - Smoke-test output summary and Architecture Package smoke artifact manifest.
 - Enabled feature flags and tenant scope.
-- Any known optional dependency warnings accepted for release, including the Redis `disabled_optional` mode when `checks.redis_readiness.require_redis=false`. Required `degraded`, `unhealthy`, or `missing_required` production health is release-blocking.
+- Any known optional dependency warnings accepted for release, including the Redis `disabled_optional` mode when `checks.redis_readiness.require_redis=false` and `checks.redis_readiness.scale_blocked=false`. Required `degraded`, `unhealthy`, `missing_required`, or `scale_blocked=true` production health is release-blocking.

--- a/scripts/health_gate.sh
+++ b/scripts/health_gate.sh
@@ -71,9 +71,14 @@ if [[ -n "$stale_jobs" ]]; then
 fi
 
 redis_status="$(printf '%s' "$health_json" | jq -r '.checks.redis // empty')"
+redis_scale_blocked="$(printf '%s' "$health_json" | jq -r '.checks.redis_readiness.scale_blocked // false')"
 if [[ "$redis_status" == "missing_required" ]]; then
   echo "::error::Redis is required but not configured"
   printf '%s' "$health_json" | jq -c '.checks.redis_readiness // {redis: .checks.redis}'
+  exit 1
+elif [[ "$redis_scale_blocked" == "true" ]]; then
+  echo "::error::Redis is required before horizontal scale"
+  printf '%s' "$health_json" | jq -c '.checks.redis_readiness'
   exit 1
 elif [[ "$redis_status" == "not_configured" || "$redis_status" == "disabled_optional" ]]; then
   echo "::warning::Redis is disabled as an optional dependency; accepted because overall production health is healthy"


### PR DESCRIPTION
## Summary

- Add Redis scale-readiness metadata to `session_store_readiness()`, including declared replica count, `requires_redis_for_scale`, `multi_replica`, `scale_blocked`, and a blocker reason.
- Keep optional Redis acceptable for single-worker/single-replica health.
- Make `scripts/health_gate.sh` fail when health reports `checks.redis_readiness.scale_blocked=true`.
- Update release evidence guidance for the new scale-blocker field.
- Add focused tests for optional single-replica mode, multi-worker blocker, declared multi-replica blocker, and health-gate failure.

Fixes #718.

## Validation

- `./.venv/bin/python -m pytest tests/test_session_store.py tests/test_health_gate_script.py -q`
- `./.venv/bin/python -m pytest tests/test_contract.py::TestHealthContract tests/test_production_parity.py -q`
- `./.venv/bin/python -m py_compile session_store.py tests/test_session_store.py tests/test_health_gate_script.py`
- `./.venv/bin/ruff check session_store.py tests/test_session_store.py tests/test_health_gate_script.py`
- `git diff --check`
- VS Code diagnostics: no errors in changed files