### PR TITLE
ci: update GitHub Actions for Node.js 24 readiness

### DIFF
--- a/.github/workflows/architecture-package-smoke.yml
+++ b/.github/workflows/architecture-package-smoke.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run production Architecture Package smoke
         env:

--- a/.github/workflows/backend-performance.yml
+++ b/.github/workflows/backend-performance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Use fallback environment variables
         run: cp backend/.env.example backend/.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -116,10 +116,10 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download backend OpenAPI schema
         uses: actions/download-artifact@v8
@@ -190,7 +190,7 @@ jobs:
           test -f backend/openapi.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -272,7 +272,7 @@ jobs:
       CONTAINER_APP_ENV: ${{ secrets.CONTAINER_APP_ENV }}
       ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure Login (OIDC)
         uses: azure/login@v3
@@ -301,7 +301,7 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
 
       - name: Trivy container security gate
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.ACR_LOGIN_SERVER }}/archmorph-api:${{ github.sha }}
           format: table
@@ -494,7 +494,7 @@ jobs:
     timeout-minutes: 15
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download frontend dist
         uses: actions/download-artifact@v8
@@ -521,7 +521,7 @@ jobs:
     timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run deployed app smoke checks
         run: bash scripts/deployment_smoke.sh

--- a/.github/workflows/freshness-watchdog.yml
+++ b/.github/workflows/freshness-watchdog.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: File alert issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           STALE_JOBS: ${{ needs.watch.outputs.stale_jobs }}
           REPORT: ${{ needs.watch.outputs.report }}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -224,7 +224,7 @@ jobs:
         needs.azure-checks.outputs.failures_found == 'true'
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for existing open issue
         id: check_issue

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,46 +10,46 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
     
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
         
-    - name: Use fallback environment variables
-      run: cp backend/.env.example backend/.env
+      - name: Use fallback environment variables
+        run: cp backend/.env.example backend/.env
       
-    - name: Start Application Locally
-      run: |
-        docker compose up -d
-        echo "Waiting for backend..."
-        for i in {1..30}; do curl -s http://localhost:8000/api/health > /dev/null && break || sleep 2; done
-        echo "Waiting for frontend..."
-        npx wait-on http://localhost:5173 -t 60000 || true
-        docker compose ps
+      - name: Start Application Locally
+        run: |
+          docker compose up -d
+          echo "Waiting for backend..."
+          for i in {1..30}; do curl -s http://localhost:8000/api/health > /dev/null && break || sleep 2; done
+          echo "Waiting for frontend..."
+          npx wait-on http://localhost:5173 -t 60000 || true
+          docker compose ps
         
-    - name: Install dependencies
-      run: npm install --no-fund --no-audit
+      - name: Install dependencies
+        run: npm install --no-fund --no-audit
       
-    - name: Install Playwright Browsers
-      run: npx playwright install chromium --with-deps
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
       
-    - name: Run Playwright tests
-      run: |
-        npx wait-on http://localhost:5173 -t 60000
-        npx playwright test --project=chromium
-      env:
-        FRONTEND_URL: "http://localhost:5173"
-        API_BASE: "http://localhost:8000/api"
-        ADMIN_KEY: "test-admin-key"
+      - name: Run Playwright tests
+        run: |
+          npx wait-on http://localhost:5173 -t 60000
+          npx playwright test --project=chromium
+        env:
+          FRONTEND_URL: "http://localhost:5173"
+          API_BASE: "http://localhost:8000/api"
+          ADMIN_KEY: "test-admin-key"
         
-    - name: Dump docker logs on failure
-      if: failure()
-      run: docker compose logs backend frontend
+      - name: Dump docker logs on failure
+        if: failure()
+        run: docker compose logs backend frontend
       
-    - uses: actions/upload-artifact@v7
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 10
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 10

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         language: [python, javascript]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -63,7 +63,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy vulnerability scan (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: archmorph-api:scan
           format: sarif
@@ -73,7 +73,7 @@ jobs:
           scanners: vuln
 
       - name: Trivy vulnerability scan (table — CI log)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         if: always()
         with:
           image-ref: archmorph-api:scan

--- a/.github/workflows/service-catalog-refresh.yml
+++ b/.github/workflows/service-catalog-refresh.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: File alert issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### CI and release maintenance
+
+- **GitHub Actions Node.js 24 readiness** — audited workflow action runtimes, moved deprecated Node.js 20 action pins to Node.js 24-compatible majors, pinned Trivy to a release tag, and documented the workflow runtime inventory for release maintenance.
+
 #### Architecture Package quality recovery
 
 - **Customer-grade package shell** — Architecture Package HTML exports now use the richer Archmorph review structure with branded header metadata, source-to-target story strip, A/B/C/D tab semantics, and grouped talking-point/limitation rows.

--- a/docs/GITHUB_ACTIONS_RUNTIME_INVENTORY.md
+++ b/docs/GITHUB_ACTIONS_RUNTIME_INVENTORY.md
@@ -1,0 +1,36 @@
+# GitHub Actions Runtime Inventory
+
+Issue: #720
+Date: 2026-05-03
+
+This inventory tracks the workflow action runtime migration away from deprecated Node.js 20 actions before GitHub hosted runners force Node.js 24 defaults.
+
+## Runtime Evidence
+
+| Action | Previous pin | Latest observed | Runtime before | New pin | Runtime after | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `actions/checkout` | `v4` | `v6.0.2` | `node20` | `v6` | `node24` | Upgraded; major pin tracks Node 24-compatible patch releases. |
+| `actions/setup-node` | `v4` | `v6.4.0` | `node20` | `v6` | `node24` | Upgraded; application Node version remains controlled by `node-version`. |
+| `actions/setup-python` | `v5` | `v6.2.0` | `node20` | `v6` | `node24` | Upgraded; Python version remains `3.12`. |
+| `actions/github-script` | `v7` | `v9.0.0` | `node20` | `v9` | `node24` | Upgraded for alert-issue workflows. |
+| `actions/upload-artifact` | `v7` | `v7` | `node24` | unchanged | `node24` | Already compatible. |
+| `actions/download-artifact` | `v8` | `v8` | `node24` | unchanged | `node24` | Already compatible. |
+| `actions/labeler` | `v6` | `v6` | `node24` | unchanged | `node24` | Already compatible. |
+| `actions/stale` | `v10` | `v10` | `node24` | unchanged | `node24` | Already compatible. |
+| `amannn/action-semantic-pull-request` | `v6.1.1` | `v6.1.1` | `node24` | unchanged | `node24` | Already compatible. |
+| `anchore/scan-action` | `v7` | `v7` | `node24` | unchanged | `node24` | Already compatible. |
+| `astral-sh/setup-uv` | `v7` | `v7` | `node24` | unchanged | `node24` | Already compatible. |
+| `docker/setup-buildx-action` | `v4` | `v4` | `node24` | unchanged | `node24` | Already compatible. |
+| `docker/build-push-action` | `v7` | `v7` | `node24` | unchanged | `node24` | Already compatible. |
+| `github/codeql-action/*` | `v4` | `v4.35.3` | `node24` | unchanged | `node24` | Latest CodeQL major is already in use; `init`, `analyze`, and `upload-sarif` all report `node24`. |
+| `azure/login` | `v3` | `v3.0.0` | `node24` | unchanged | `node24` | Latest Azure login major is already in use. |
+| `Azure/static-web-apps-deploy` | `v1` | `v1` | docker action | unchanged | docker action | No newer stable major exists. |
+| `aquasecurity/trivy-action` | `master` | `v0.36.0` | unpinned composite action | `v0.36.0` | composite release tag | Pinned to the latest release tag observed during audit. |
+
+Blocked actions: none as of this audit. If a future action cannot be moved, record the owner and review date here before merging workflow changes.
+
+## Validation Expectations
+
+- Required PR checks pass.
+- Main CI/CD proves Azure Container Apps blue-green deploy, Static Web Apps deploy, post-deploy smoke, K6 diagnostics, Playwright, and security scanning still work.
+- Any future action that remains on a deprecated runtime should be listed here with owner and review date.


### PR DESCRIPTION
## Summary

- Upgrade deprecated Node.js 20 workflow action pins to Node.js 24-compatible majors:
  - `actions/checkout@v4` -> `actions/checkout@v6`
  - `actions/setup-node@v4` -> `actions/setup-node@v6`
  - `actions/setup-python@v5` -> `actions/setup-python@v6`
  - `actions/github-script@v7` -> `actions/github-script@v9`
- Pin `aquasecurity/trivy-action` from `master` to `v0.36.0`.
- Add a workflow runtime inventory at `docs/GITHUB_ACTIONS_RUNTIME_INVENTORY.md` with latest observed versions and runtime evidence.
- Add changelog entry for CI runtime maintenance.

Fixes #720.

## Validation

- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`
- `grep -RInE 'actions/checkout@v4|actions/setup-node@v4|actions/setup-python@v5|actions/github-script@v7|aquasecurity/trivy-action@master' .github/workflows || true`
- `git diff --check`
- Verified action metadata for `actions/checkout@v6`, `actions/setup-node@v6`, `actions/setup-python@v6`, and `actions/github-script@v9` reports `node24`.

## Deployment safety

This PR changes action runtime pins only. It does not alter Azure credentials, Container Apps deployment commands, Static Web Apps deployment inputs, health-gate behavior, or smoke-test semantics.