### PR TITLE
test: add FastAPI query-only request guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           uv pip install --system ruff
           uv pip install --system -r requirements.txt
           ruff check .
+          python scripts/lint_fastapi_query_body_tests.py
 
       - name: Run tests with coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **GitHub Actions Node.js 24 readiness** — audited workflow action runtimes, moved deprecated Node.js 20 action pins to Node.js 24-compatible majors, pinned Trivy to a release tag, and documented the workflow runtime inventory for release maintenance.
 
+#### QA guardrails
+
+- **FastAPI query-parameter test guard** — CI now fails when tests send `json=` bodies to query-only FastAPI routes, and the E2E step helper converts `has_X=False` detail flags into failed steps.
+
 #### Architecture Package quality recovery
 
 - **Customer-grade package shell** — Architecture Package HTML exports now use the richer Archmorph review structure with branded header metadata, source-to-target story strip, A/B/C/D tab semantics, and grouped talking-point/limitation rows.

--- a/backend/scripts/lint_fastapi_query_body_tests.py
+++ b/backend/scripts/lint_fastapi_query_body_tests.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Fail when tests send JSON bodies to query-only FastAPI routes."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parent
+HTTP_METHODS = {"delete", "get", "patch", "post", "put"}
+ROUTE_PARAM_RE = re.compile(r"\{[^}/]+\}")
+
+
+@dataclass(frozen=True)
+class Route:
+    method: str
+    path: str
+    key: tuple[str, str]
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line: int
+    route: Route
+
+    def render(self) -> str:
+        try:
+            location = self.path.relative_to(REPO_ROOT)
+        except ValueError:
+            location = self.path
+        return (
+            f"{location}:{self.line}: route {self.route.method} {self.route.path} "
+            "is query-only; replace json= with params="
+        )
+
+
+def main() -> int:
+    schema = _load_openapi_schema()
+    query_only_routes = collect_query_only_routes(schema)
+    violations = scan_test_files(query_only_routes)
+
+    if not violations:
+        print("FastAPI query-only JSON body lint passed")
+        return 0
+
+    print("FastAPI query-only JSON body lint failed:", file=sys.stderr)
+    for violation in violations:
+        print(f"  {violation.render()}", file=sys.stderr)
+    return 1
+
+
+def _load_openapi_schema() -> dict:
+    sys.path.insert(0, str(BACKEND_ROOT))
+    from export_openapi import export_schema  # noqa: PLC0415
+
+    return json.loads(export_schema())
+
+
+def collect_query_only_routes(schema: dict) -> dict[tuple[str, str], Route]:
+    manual_body_routes = _collect_manual_body_routes()
+    query_only: dict[tuple[str, str], Route] = {}
+
+    for path, operations in schema.get("paths", {}).items():
+        for method, operation in operations.items():
+            if method not in HTTP_METHODS:
+                continue
+            route = Route(method.upper(), path, _route_key(method, path))
+            if "requestBody" in operation or route.key in manual_body_routes:
+                continue
+            query_only[route.key] = route
+
+    return query_only
+
+
+def scan_test_files(query_only_routes: dict[tuple[str, str], Route]) -> list[Violation]:
+    violations: list[Violation] = []
+    for test_file in _iter_test_files():
+        violations.extend(scan_file(test_file, query_only_routes))
+    return violations
+
+
+def scan_file(
+    path: Path,
+    query_only_routes: dict[tuple[str, str], Route],
+) -> list[Violation]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[Violation] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        method = _http_method(node)
+        if method is None or not _has_json_keyword(node):
+            continue
+        request_path = _request_path(node)
+        if request_path is None:
+            continue
+        route = query_only_routes.get(_route_key(method, request_path))
+        if route is not None:
+            violations.append(Violation(path, node.lineno, route))
+
+    return violations
+
+
+def _collect_manual_body_routes() -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    routers_root = BACKEND_ROOT / "routers"
+    if not routers_root.exists():
+        return routes
+
+    for source_path in routers_root.rglob("*.py"):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _function_reads_request_body(node):
+                continue
+            routes.update(_decorated_routes(node))
+    return routes
+
+
+def _decorated_routes(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        method = _decorator_method(decorator.func)
+        if method is None or not decorator.args:
+            continue
+        path = _static_path(decorator.args[0])
+        if path is not None:
+            routes.add(_route_key(method, path))
+    return routes
+
+
+def _function_reads_request_body(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+            if child.func.attr in {"body", "json"}:
+                return True
+    return False
+
+
+def _iter_test_files() -> list[Path]:
+    roots = [BACKEND_ROOT / "tests", REPO_ROOT / "tests"]
+    files: list[Path] = []
+    for root in roots:
+        if root.exists():
+            files.extend(sorted(root.rglob("*.py")))
+    return files
+
+
+def _http_method(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Attribute) and node.func.attr in HTTP_METHODS:
+        return node.func.attr
+    return None
+
+
+def _decorator_method(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Attribute) and node.attr in HTTP_METHODS:
+        return node.attr
+    return None
+
+
+def _has_json_keyword(node: ast.Call) -> bool:
+    for keyword in node.keywords:
+        if keyword.arg == "json" and not _is_none(keyword.value):
+            return True
+    return False
+
+
+def _is_none(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _request_path(node: ast.Call) -> str | None:
+    if node.args:
+        return _static_path(node.args[0])
+    for keyword in node.keywords:
+        if keyword.arg == "url":
+            return _static_path(keyword.value)
+    return None
+
+
+def _static_path(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return _normalize_path(node.value)
+    if isinstance(node, ast.JoinedStr):
+        chunks: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                chunks.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                chunks.append("{}")
+            else:
+                return None
+        return _normalize_path("".join(chunks))
+    return None
+
+
+def _normalize_path(value: str) -> str:
+    parsed = urlparse(value)
+    path = parsed.path if parsed.scheme and parsed.netloc else value.split("?", 1)[0]
+    return path.rstrip("/") or "/"
+
+
+def _route_key(method: str, path: str) -> tuple[str, str]:
+    return method.upper(), ROUTE_PARAM_RE.sub("{}", _normalize_path(path))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_fastapi_query_body_lint.py
+++ b/backend/tests/test_fastapi_query_body_lint.py
@@ -1,0 +1,61 @@
+import textwrap
+
+from scripts.lint_fastapi_query_body_tests import Route, scan_file
+
+
+def test_query_only_route_rejects_json_body(tmp_path):
+    test_file = tmp_path / "test_e2e.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            def test_export(client, diagram_id):
+                client.post(f"/api/diagrams/{diagram_id}/export-diagram", json={"format": "drawio"})
+            """
+        ),
+        encoding="utf-8",
+    )
+    route = Route(
+        "POST",
+        "/api/diagrams/{diagram_id}/export-diagram",
+        ("POST", "/api/diagrams/{}/export-diagram"),
+    )
+
+    violations = scan_file(test_file, {route.key: route})
+
+    assert len(violations) == 1
+    assert "replace json= with params=" in violations[0].render()
+
+
+def test_query_only_route_allows_params(tmp_path):
+    test_file = tmp_path / "test_e2e.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            def test_export(client, diagram_id):
+                client.post(f"/api/diagrams/{diagram_id}/export-diagram", params={"format": "drawio"})
+            """
+        ),
+        encoding="utf-8",
+    )
+    route = Route(
+        "POST",
+        "/api/diagrams/{diagram_id}/export-diagram",
+        ("POST", "/api/diagrams/{}/export-diagram"),
+    )
+
+    assert scan_file(test_file, {route.key: route}) == []
+
+
+def test_body_route_allows_json_body(tmp_path):
+    test_file = tmp_path / "test_apply_answers.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            def test_apply_answers(client, diagram_id):
+                client.post(f"/api/diagrams/{diagram_id}/apply-answers", json={"answers": {}})
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert scan_file(test_file, {}) == []

--- a/docs/TESTING_STANDARDS.md
+++ b/docs/TESTING_STANDARDS.md
@@ -1,0 +1,25 @@
+# Testing Standards
+
+## FastAPI Parameter Testing
+
+FastAPI treats plain scalar handler arguments as query parameters unless the route declares a body model, `Body(...)`, or explicitly reads the request body. Tests must send those values with `params=`, not `json=`. A JSON body sent to a query-only route is ignored by FastAPI and can make a test pass while it is exercising the default query value.
+
+Use this pattern for query parameters:
+
+```python
+resp = client.post(
+    f"/api/diagrams/{diagram_id}/export-diagram",
+    params={"format": "drawio"},
+)
+```
+
+Use `json=` only for routes that declare a request body in the OpenAPI contract:
+
+```python
+resp = client.post(
+    f"/api/diagrams/{diagram_id}/apply-answers",
+    json={"answers": {}},
+)
+```
+
+CI runs `backend/scripts/lint_fastapi_query_body_tests.py` to catch `json=` calls that target query-only FastAPI routes in `backend/tests/**/*.py` and `tests/**/*.py`.

--- a/tests/e2e_flow_test.py
+++ b/tests/e2e_flow_test.py
@@ -10,6 +10,7 @@ Tests the full 9-step translation flow for each diagram:
 """
 
 import json
+import re
 import sys
 import httpx
 
@@ -54,9 +55,12 @@ FAIL = "\033[91mFAIL\033[0m"
 SKIP = "\033[93mSKIP\033[0m"
 
 results = []
+FALSE_DETAIL_RE = re.compile(r"\bhas(?:_[A-Za-z0-9_]+|\s+[^=,]+)\s*=\s*False\b")
 
 
 def step(name: str, ok: bool, detail: str = ""):
+    if ok and detail and FALSE_DETAIL_RE.search(detail):
+        ok = False
     tag = PASS if ok else FAIL
     print(f"  {tag}  {name}" + (f"  ({detail})" if detail else ""))
     results.append((name, ok, detail))


### PR DESCRIPTION
## Summary

Closes #570.

- Add an AST/OpenAPI-based lint gate that fails when tests send `json=` to FastAPI routes without request bodies.
- Wire the guard into backend CI after Ruff and dependency install.
- Harden the live E2E `step()` helper so `has...=False` detail flags force a failed step.
- Document FastAPI query-parameter testing standards and add changelog notes.

## Validation

- `cd backend && .venv/bin/python scripts/lint_fastapi_query_body_tests.py`
- `cd backend && .venv/bin/python -m pytest -q tests/test_fastapi_query_body_lint.py`
- `cd backend && .venv/bin/python -m ruff check scripts/lint_fastapi_query_body_tests.py tests/test_fastapi_query_body_lint.py ../tests/e2e_flow_test.py`