### PR TITLE
test: add mappings freshness guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  mappings-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Lint mapping freshness
+        run: python scripts/lint_mappings_freshness.py
+
   # ============================================
   # BACKEND TESTS (3.12 only — production version)
   # ============================================

--- a/.github/workflows/mappings-quarterly-review.yml
+++ b/.github/workflows/mappings-quarterly-review.yml
@@ -1,0 +1,60 @@
+name: Mappings Quarterly Review
+
+on:
+  schedule:
+    - cron: '0 9 1 1,4,7,10 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  open-review-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Generate freshness report
+        run: python scripts/lint_mappings_freshness.py --output markdown > mappings-freshness-report.md
+        continue-on-error: true
+
+      - name: Open quarterly review issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('mappings-freshness-report.md', 'utf8');
+            const now = new Date();
+            const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
+            const title = `Mappings quarterly review ${now.getUTCFullYear()} Q${quarter}`;
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+              per_page: 1,
+            });
+            if (existing.data.total_count > 0) {
+              core.info(`Open review issue already exists: ${existing.data.items[0].html_url}`);
+              return;
+            }
+
+            const body = [
+              'Owner: Cloud Master agent',
+              'Human backup: idokatz86',
+              '',
+              'Review stale or low-confidence rows, update product names/notes where needed, and refresh `last_reviewed` for rows validated this quarter.',
+              '',
+              report,
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['mappings', 'maintenance', 'mapping-staleness'],
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### QA guardrails
 
 - **FastAPI query-parameter test guard** — CI now fails when tests send `json=` bodies to query-only FastAPI routes, and the E2E step helper converts `has_X=False` detail flags into failed steps.
+- **Mappings freshness guard** — cross-cloud service mappings now carry `last_reviewed` metadata, with non-blocking CI freshness lint and a quarterly review issue workflow.
 
 #### Architecture Package quality recovery
 

--- a/backend/services/mappings.py
+++ b/backend/services/mappings.py
@@ -7,36 +7,36 @@ CROSS_CLOUD_MAPPINGS = [
     # ═══════════════════════════════════════════════════════════
     # COMPUTE
     # ═══════════════════════════════════════════════════════════
-    {"aws": "EC2", "azure": "Virtual Machines", "gcp": "Compute Engine", "category": "Compute", "confidence": 0.95, "notes": "Direct equivalent — IaaS virtual machines"},
-    {"aws": "Lambda", "azure": "Azure Functions", "gcp": "Cloud Functions", "category": "Compute", "confidence": 0.95, "notes": "Event-driven serverless compute"},
-    {"aws": "ECS", "azure": "Container Instances", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.85, "notes": "Container orchestration — different abstractions"},
-    {"aws": "EKS", "azure": "AKS", "gcp": "GKE", "category": "Compute", "confidence": 0.95, "notes": "Managed Kubernetes — all based on upstream K8s"},
-    {"aws": "Fargate", "azure": "Container Apps", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.90, "notes": "Serverless container execution"},
-    {"aws": "Lightsail", "azure": "App Service", "gcp": "App Engine", "category": "Compute", "confidence": 0.80, "notes": "Simplified PaaS — different feature sets"},
-    {"aws": "Batch", "azure": "Azure Batch", "gcp": "Batch", "category": "Compute", "confidence": 0.95, "notes": "Managed batch computing"},
-    {"aws": "Elastic Beanstalk", "azure": "App Service", "gcp": "App Engine", "category": "Compute", "confidence": 0.90, "notes": "PaaS for web applications"},
-    {"aws": "Outposts", "azure": "Azure Stack", "gcp": "Anthos", "category": "Compute", "confidence": 0.85, "notes": "Hybrid/on-premises cloud extension"},
-    {"aws": "App Runner", "azure": "Container Apps", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.90, "notes": "Simple containerized app deployment"},
-    {"aws": "EC2 Auto Scaling", "azure": "VM Scale Sets", "gcp": "Managed Instance Groups", "category": "Compute", "confidence": 0.95, "notes": "Auto-scaling VM groups"},
-    {"aws": "EC2 Image Builder", "azure": "Image Builder", "gcp": "Compute Engine (custom images)", "category": "Compute", "confidence": 0.85, "notes": "VM image creation pipelines"},
+    {"aws": "EC2", "azure": "Virtual Machines", "gcp": "Compute Engine", "category": "Compute", "confidence": 0.95, "notes": "Direct equivalent — IaaS virtual machines", "last_reviewed": "2026-05-03"},
+    {"aws": "Lambda", "azure": "Azure Functions", "gcp": "Cloud Functions", "category": "Compute", "confidence": 0.95, "notes": "Event-driven serverless compute", "last_reviewed": "2026-05-03"},
+    {"aws": "ECS", "azure": "Container Instances", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.85, "notes": "Container orchestration — different abstractions", "last_reviewed": "2026-05-03"},
+    {"aws": "EKS", "azure": "AKS", "gcp": "GKE", "category": "Compute", "confidence": 0.95, "notes": "Managed Kubernetes — all based on upstream K8s", "last_reviewed": "2026-05-03"},
+    {"aws": "Fargate", "azure": "Container Apps", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.90, "notes": "Serverless container execution", "last_reviewed": "2026-05-03"},
+    {"aws": "Lightsail", "azure": "App Service", "gcp": "App Engine", "category": "Compute", "confidence": 0.80, "notes": "Simplified PaaS — different feature sets", "last_reviewed": "2026-05-03"},
+    {"aws": "Batch", "azure": "Azure Batch", "gcp": "Batch", "category": "Compute", "confidence": 0.95, "notes": "Managed batch computing", "last_reviewed": "2026-05-03"},
+    {"aws": "Elastic Beanstalk", "azure": "App Service", "gcp": "App Engine", "category": "Compute", "confidence": 0.90, "notes": "PaaS for web applications", "last_reviewed": "2026-05-03"},
+    {"aws": "Outposts", "azure": "Azure Stack", "gcp": "Anthos", "category": "Compute", "confidence": 0.85, "notes": "Hybrid/on-premises cloud extension", "last_reviewed": "2026-05-03"},
+    {"aws": "App Runner", "azure": "Container Apps", "gcp": "Cloud Run", "category": "Compute", "confidence": 0.90, "notes": "Simple containerized app deployment", "last_reviewed": "2026-05-03"},
+    {"aws": "EC2 Auto Scaling", "azure": "VM Scale Sets", "gcp": "Managed Instance Groups", "category": "Compute", "confidence": 0.95, "notes": "Auto-scaling VM groups", "last_reviewed": "2026-05-03"},
+    {"aws": "EC2 Image Builder", "azure": "Image Builder", "gcp": "Compute Engine (custom images)", "category": "Compute", "confidence": 0.85, "notes": "VM image creation pipelines", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # STORAGE
     # ═══════════════════════════════════════════════════════════
-    {"aws": "S3", "azure": "Blob Storage", "gcp": "Cloud Storage", "category": "Storage", "confidence": 0.95, "notes": "Object storage — near-identical capabilities"},
-    {"aws": "EBS", "azure": "Managed Disks", "gcp": "Persistent Disk", "category": "Storage", "confidence": 0.95, "notes": "Block storage for VMs"},
-    {"aws": "EFS", "azure": "Azure Files", "gcp": "Filestore", "category": "Storage", "confidence": 0.90, "notes": "Managed NFS file storage"},
-    {"aws": "FSx", "azure": "NetApp Files", "gcp": "NetApp Volumes", "category": "Storage", "confidence": 0.85, "notes": "Enterprise file systems (Windows/Lustre/NetApp)"},
-    {"aws": "S3 Glacier", "azure": "Archive Storage", "gcp": "Archive Storage", "category": "Storage", "confidence": 0.95, "notes": "Cold/archive data storage"},
-    {"aws": "Storage Gateway", "azure": "StorSimple", "gcp": "Storage Transfer Service", "category": "Storage", "confidence": 0.80, "notes": "Hybrid storage — different approaches"},
-    {"aws": "Snow Family", "azure": "Data Box", "gcp": "Transfer Appliance", "category": "Storage", "confidence": 0.90, "notes": "Physical data transfer devices"},
-    {"aws": "Backup", "azure": "Azure Backup", "gcp": "Backup and DR", "category": "Storage", "confidence": 0.90, "notes": "Centralized backup service"},
-    {"aws": "DataSync", "azure": "File Sync", "gcp": "Storage Transfer Service", "category": "Storage", "confidence": 0.85, "notes": "Data transfer and synchronization"},
+    {"aws": "S3", "azure": "Blob Storage", "gcp": "Cloud Storage", "category": "Storage", "confidence": 0.95, "notes": "Object storage — near-identical capabilities", "last_reviewed": "2026-05-03"},
+    {"aws": "EBS", "azure": "Managed Disks", "gcp": "Persistent Disk", "category": "Storage", "confidence": 0.95, "notes": "Block storage for VMs", "last_reviewed": "2026-05-03"},
+    {"aws": "EFS", "azure": "Azure Files", "gcp": "Filestore", "category": "Storage", "confidence": 0.90, "notes": "Managed NFS file storage", "last_reviewed": "2026-05-03"},
+    {"aws": "FSx", "azure": "NetApp Files", "gcp": "NetApp Volumes", "category": "Storage", "confidence": 0.85, "notes": "Enterprise file systems (Windows/Lustre/NetApp)", "last_reviewed": "2026-05-03"},
+    {"aws": "S3 Glacier", "azure": "Archive Storage", "gcp": "Archive Storage", "category": "Storage", "confidence": 0.95, "notes": "Cold/archive data storage", "last_reviewed": "2026-05-03"},
+    {"aws": "Storage Gateway", "azure": "StorSimple", "gcp": "Storage Transfer Service", "category": "Storage", "confidence": 0.80, "notes": "Hybrid storage — different approaches", "last_reviewed": "2026-05-03"},
+    {"aws": "Snow Family", "azure": "Data Box", "gcp": "Transfer Appliance", "category": "Storage", "confidence": 0.90, "notes": "Physical data transfer devices", "last_reviewed": "2026-05-03"},
+    {"aws": "Backup", "azure": "Azure Backup", "gcp": "Backup and DR", "category": "Storage", "confidence": 0.90, "notes": "Centralized backup service", "last_reviewed": "2026-05-03"},
+    {"aws": "DataSync", "azure": "File Sync", "gcp": "Storage Transfer Service", "category": "Storage", "confidence": 0.85, "notes": "Data transfer and synchronization", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # DATABASE
     # ═══════════════════════════════════════════════════════════
-    {"aws": "RDS", "azure": "SQL Database", "gcp": "Cloud SQL", "category": "Database", "confidence": 0.90, "notes": "Managed relational database (multi-engine)"},
+    {"aws": "RDS", "azure": "SQL Database", "gcp": "Cloud SQL", "category": "Database", "confidence": 0.90, "notes": "Managed relational database (multi-engine)", "last_reviewed": "2026-05-03"},
     # #590 — Aurora is PostgreSQL- or MySQL-compatible; SQL Database is Microsoft
     # SQL Server. The previous "SQL Database (Hyperscale)" mapping silently moves
     # the customer to a different engine + a SQL Server licence cost surprise.
@@ -44,212 +44,212 @@ CROSS_CLOUD_MAPPINGS = [
     # offering (current Azure GA recommendation as of 2026-05-01).
     {"aws": "Aurora PostgreSQL", "azure": "Azure Database for PostgreSQL Flexible Server", "gcp": "AlloyDB", "category": "Database", "confidence": 0.90, "notes": "Engine-correct PostgreSQL mapping. Aurora PG → Azure DB for PostgreSQL Flexible Server. (Pre-#590 mapped to SQL Server — wrong engine.)", "last_reviewed": "2026-05-01"},
     {"aws": "Aurora MySQL", "azure": "Azure Database for MySQL Flexible Server", "gcp": "Cloud SQL for MySQL", "category": "Database", "confidence": 0.90, "notes": "Engine-correct MySQL mapping. Aurora MySQL → Azure DB for MySQL Flexible Server.", "last_reviewed": "2026-05-01"},
-    {"aws": "DynamoDB", "azure": "Cosmos DB", "gcp": "Firestore / Bigtable", "category": "Database", "confidence": 0.85, "notes": "Managed NoSQL — Cosmos DB is multi-model"},
-    {"aws": "ElastiCache", "azure": "Cache for Redis", "gcp": "Memorystore", "category": "Database", "confidence": 0.95, "notes": "Managed Redis/Memcached"},
-    {"aws": "Redshift", "azure": "Synapse Analytics", "gcp": "BigQuery", "category": "Database", "confidence": 0.90, "notes": "Data warehouse — different architectures"},
-    {"aws": "Neptune", "azure": "Cosmos DB (Gremlin)", "gcp": "Vertex AI (graph features)", "category": "Database", "confidence": 0.80, "notes": "Graph database — Azure uses Cosmos Gremlin API"},
-    {"aws": "DocumentDB", "azure": "Cosmos DB (MongoDB API)", "gcp": "Firestore", "category": "Database", "confidence": 0.85, "notes": "Document database"},
-    {"aws": "Keyspaces", "azure": "Cosmos DB (Cassandra)", "gcp": "Bigtable", "category": "Database", "confidence": 0.80, "notes": "Wide-column NoSQL database"},
-    {"aws": "Timestream", "azure": "Time Series Insights / Data Explorer", "gcp": "BigQuery (time series)", "category": "Database", "confidence": 0.80, "notes": "Time series database"},
-    {"aws": "QLDB", "azure": "Confidential Ledger", "gcp": "Cloud Spanner (immutable)", "category": "Database", "confidence": 0.75, "notes": "Ledger/immutable database — limited equivalents"},
-    {"aws": "MemoryDB", "azure": "Cache for Redis (Enterprise)", "gcp": "Memorystore (Redis Cluster)", "category": "Database", "confidence": 0.85, "notes": "In-memory database"},
-    {"aws": "DMS", "azure": "Database Migration Service", "gcp": "Database Migration Service", "category": "Database", "confidence": 0.90, "notes": "Database migration tooling"},
+    {"aws": "DynamoDB", "azure": "Cosmos DB", "gcp": "Firestore / Bigtable", "category": "Database", "confidence": 0.85, "notes": "Managed NoSQL — Cosmos DB is multi-model", "last_reviewed": "2026-05-03"},
+    {"aws": "ElastiCache", "azure": "Cache for Redis", "gcp": "Memorystore", "category": "Database", "confidence": 0.95, "notes": "Managed Redis/Memcached", "last_reviewed": "2026-05-03"},
+    {"aws": "Redshift", "azure": "Synapse Analytics", "gcp": "BigQuery", "category": "Database", "confidence": 0.90, "notes": "Data warehouse — different architectures", "last_reviewed": "2026-05-03"},
+    {"aws": "Neptune", "azure": "Cosmos DB (Gremlin)", "gcp": "Vertex AI (graph features)", "category": "Database", "confidence": 0.80, "notes": "Graph database — Azure uses Cosmos Gremlin API", "last_reviewed": "2026-05-03"},
+    {"aws": "DocumentDB", "azure": "Cosmos DB (MongoDB API)", "gcp": "Firestore", "category": "Database", "confidence": 0.85, "notes": "Document database", "last_reviewed": "2026-05-03"},
+    {"aws": "Keyspaces", "azure": "Cosmos DB (Cassandra)", "gcp": "Bigtable", "category": "Database", "confidence": 0.80, "notes": "Wide-column NoSQL database", "last_reviewed": "2026-05-03"},
+    {"aws": "Timestream", "azure": "Time Series Insights / Data Explorer", "gcp": "BigQuery (time series)", "category": "Database", "confidence": 0.80, "notes": "Time series database", "last_reviewed": "2026-05-03"},
+    {"aws": "QLDB", "azure": "Confidential Ledger", "gcp": "Cloud Spanner (immutable)", "category": "Database", "confidence": 0.75, "notes": "Ledger/immutable database — limited equivalents", "last_reviewed": "2026-05-03"},
+    {"aws": "MemoryDB", "azure": "Cache for Redis (Enterprise)", "gcp": "Memorystore (Redis Cluster)", "category": "Database", "confidence": 0.85, "notes": "In-memory database", "last_reviewed": "2026-05-03"},
+    {"aws": "DMS", "azure": "Database Migration Service", "gcp": "Database Migration Service", "category": "Database", "confidence": 0.90, "notes": "Database migration tooling", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # NETWORKING
     # ═══════════════════════════════════════════════════════════
-    {"aws": "VPC", "azure": "Virtual Network", "gcp": "VPC", "category": "Networking", "confidence": 0.95, "notes": "Virtual private cloud networking"},
+    {"aws": "VPC", "azure": "Virtual Network", "gcp": "VPC", "category": "Networking", "confidence": 0.95, "notes": "Virtual private cloud networking", "last_reviewed": "2026-05-03"},
     # #590 — Azure CDN Standard is retiring; modern equivalent is Azure Front
     # Door (Standard/Premium with built-in CDN).
     {"aws": "CloudFront", "azure": "Front Door", "gcp": "Cloud CDN", "category": "Networking", "confidence": 0.90, "notes": "Content delivery + global routing. Azure CDN Standard is retiring — use Front Door Standard/Premium.", "last_reviewed": "2026-05-01"},
-    {"aws": "Route 53", "azure": "Azure DNS / Traffic Manager", "gcp": "Cloud DNS", "category": "Networking", "confidence": 0.90, "notes": "DNS service — Route 53 includes health checks"},
-    {"aws": "API Gateway", "azure": "API Management", "gcp": "Apigee", "category": "Networking", "confidence": 0.85, "notes": "API management — different feature depth"},
-    {"aws": "ELB", "azure": "Load Balancer / Application Gateway", "gcp": "Cloud Load Balancing", "category": "Networking", "confidence": 0.90, "notes": "Load balancing (L4/L7)"},
-    {"aws": "Direct Connect", "azure": "ExpressRoute", "gcp": "Cloud Interconnect", "category": "Networking", "confidence": 0.95, "notes": "Dedicated private network connection"},
-    {"aws": "Global Accelerator", "azure": "Front Door", "gcp": "Cloud Load Balancing (Premium)", "category": "Networking", "confidence": 0.85, "notes": "Global traffic acceleration"},
-    {"aws": "Transit Gateway", "azure": "Virtual WAN", "gcp": "Network Connectivity Center", "category": "Networking", "confidence": 0.85, "notes": "Hub-and-spoke network topology"},
-    {"aws": "PrivateLink", "azure": "Private Link", "gcp": "Private Service Connect", "category": "Networking", "confidence": 0.95, "notes": "Private endpoint connectivity"},
-    {"aws": "App Mesh", "azure": "Open Service Mesh", "gcp": "Traffic Director", "category": "Networking", "confidence": 0.80, "notes": "Service mesh — different maturity levels"},
-    {"aws": "Cloud Map", "azure": "Azure DNS (private zones)", "gcp": "Service Directory", "category": "Networking", "confidence": 0.80, "notes": "Service discovery"},
-    {"aws": "VPN", "azure": "VPN Gateway", "gcp": "Cloud VPN", "category": "Networking", "confidence": 0.95, "notes": "Site-to-site VPN connectivity"},
-    {"aws": "Network Firewall", "azure": "Azure Firewall", "gcp": "Cloud Firewall", "category": "Networking", "confidence": 0.90, "notes": "Managed network firewall"},
+    {"aws": "Route 53", "azure": "Azure DNS / Traffic Manager", "gcp": "Cloud DNS", "category": "Networking", "confidence": 0.90, "notes": "DNS service — Route 53 includes health checks", "last_reviewed": "2026-05-03"},
+    {"aws": "API Gateway", "azure": "API Management", "gcp": "Apigee", "category": "Networking", "confidence": 0.85, "notes": "API management — different feature depth", "last_reviewed": "2026-05-03"},
+    {"aws": "ELB", "azure": "Load Balancer / Application Gateway", "gcp": "Cloud Load Balancing", "category": "Networking", "confidence": 0.90, "notes": "Load balancing (L4/L7)", "last_reviewed": "2026-05-03"},
+    {"aws": "Direct Connect", "azure": "ExpressRoute", "gcp": "Cloud Interconnect", "category": "Networking", "confidence": 0.95, "notes": "Dedicated private network connection", "last_reviewed": "2026-05-03"},
+    {"aws": "Global Accelerator", "azure": "Front Door", "gcp": "Cloud Load Balancing (Premium)", "category": "Networking", "confidence": 0.85, "notes": "Global traffic acceleration", "last_reviewed": "2026-05-03"},
+    {"aws": "Transit Gateway", "azure": "Virtual WAN", "gcp": "Network Connectivity Center", "category": "Networking", "confidence": 0.85, "notes": "Hub-and-spoke network topology", "last_reviewed": "2026-05-03"},
+    {"aws": "PrivateLink", "azure": "Private Link", "gcp": "Private Service Connect", "category": "Networking", "confidence": 0.95, "notes": "Private endpoint connectivity", "last_reviewed": "2026-05-03"},
+    {"aws": "App Mesh", "azure": "Open Service Mesh", "gcp": "Traffic Director", "category": "Networking", "confidence": 0.80, "notes": "Service mesh — different maturity levels", "last_reviewed": "2026-05-03"},
+    {"aws": "Cloud Map", "azure": "Azure DNS (private zones)", "gcp": "Service Directory", "category": "Networking", "confidence": 0.80, "notes": "Service discovery", "last_reviewed": "2026-05-03"},
+    {"aws": "VPN", "azure": "VPN Gateway", "gcp": "Cloud VPN", "category": "Networking", "confidence": 0.95, "notes": "Site-to-site VPN connectivity", "last_reviewed": "2026-05-03"},
+    {"aws": "Network Firewall", "azure": "Azure Firewall", "gcp": "Cloud Firewall", "category": "Networking", "confidence": 0.90, "notes": "Managed network firewall", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # SECURITY
     # ═══════════════════════════════════════════════════════════
-    {"aws": "IAM", "azure": "Entra ID / RBAC", "gcp": "Cloud IAM", "category": "Security", "confidence": 0.90, "notes": "Identity and access management"},
+    {"aws": "IAM", "azure": "Entra ID / RBAC", "gcp": "Cloud IAM", "category": "Security", "confidence": 0.90, "notes": "Identity and access management", "last_reviewed": "2026-05-03"},
     # #590 — Microsoft retired the "B2C" sub-brand in late 2024; the product is
     # now "Entra External ID". Drop the parenthetical to avoid stale branding.
     {"aws": "Cognito", "azure": "Entra External ID", "gcp": "Identity Platform", "category": "Security", "confidence": 0.90, "notes": "Customer identity management. (Pre-#590 said ‘Entra External ID (B2C)’ — the B2C name was retired late 2024.)", "last_reviewed": "2026-05-01"},
     # #590 — GuardDuty (detection) maps to Defender for Cloud + Microsoft
     # Sentinel (SIEM) together; either alone loses architectural intent.
     {"aws": "GuardDuty", "azure": "Defender for Cloud + Microsoft Sentinel", "gcp": "Security Command Center", "category": "Security", "confidence": 0.85, "notes": "Threat detection + SIEM. Defender for Cloud detects; Sentinel is the SIEM/SOAR pair. Pre-#590 only listed Defender (lossy).", "last_reviewed": "2026-05-01"},
-    {"aws": "Inspector", "azure": "Defender for Cloud", "gcp": "Web Security Scanner", "category": "Security", "confidence": 0.80, "notes": "Vulnerability assessment"},
-    {"aws": "Macie", "azure": "Information Protection", "gcp": "Cloud DLP", "category": "Security", "confidence": 0.85, "notes": "Sensitive data discovery and protection"},
+    {"aws": "Inspector", "azure": "Defender for Cloud", "gcp": "Web Security Scanner", "category": "Security", "confidence": 0.80, "notes": "Vulnerability assessment", "last_reviewed": "2026-05-03"},
+    {"aws": "Macie", "azure": "Information Protection", "gcp": "Cloud DLP", "category": "Security", "confidence": 0.85, "notes": "Sensitive data discovery and protection", "last_reviewed": "2026-05-03"},
     {"aws": "KMS", "azure": "Key Vault", "gcp": "Cloud KMS", "category": "Security", "confidence": 0.95, "notes": "Encryption key management (software-protected)", "last_reviewed": "2026-05-01"},
     # #590 — Add the FIPS 140-3 / Dedicated-HSM tier explicitly. KMS Custom Key
     # Stores backed by CloudHSM map to Azure Managed HSM, not generic Key Vault.
     {"aws": "KMS (FIPS 140-3)", "azure": "Managed HSM", "gcp": "Cloud HSM", "category": "Security", "confidence": 0.90, "notes": "FIPS 140-3 / dedicated-HSM-backed key management. Use when KMS is configured with a CloudHSM Custom Key Store.", "last_reviewed": "2026-05-01"},
-    {"aws": "Secrets Manager", "azure": "Key Vault (Secrets)", "gcp": "Secret Manager", "category": "Security", "confidence": 0.95, "notes": "Secrets management — Azure vaults combine keys+secrets"},
-    {"aws": "WAF", "azure": "Web Application Firewall", "gcp": "Cloud Armor", "category": "Security", "confidence": 0.90, "notes": "Web application firewall"},
-    {"aws": "Shield", "azure": "DDoS Protection", "gcp": "Cloud Armor (DDoS)", "category": "Security", "confidence": 0.90, "notes": "DDoS mitigation"},
-    {"aws": "Certificate Manager", "azure": "Key Vault (Certificates)", "gcp": "Certificate Manager", "category": "Security", "confidence": 0.90, "notes": "TLS/SSL certificate management"},
-    {"aws": "IAM Identity Center", "azure": "Entra ID (SSO)", "gcp": "BeyondCorp Enterprise", "category": "Security", "confidence": 0.85, "notes": "Single sign-on"},
-    {"aws": "Directory Service", "azure": "Entra Domain Services", "gcp": "Managed AD (via Anthos)", "category": "Security", "confidence": 0.80, "notes": "Managed Active Directory"},
-    {"aws": "Security Hub", "azure": "Microsoft Sentinel", "gcp": "Chronicle", "category": "Security", "confidence": 0.85, "notes": "Centralized security management / SIEM"},
-    {"aws": "CloudHSM", "azure": "Dedicated HSM", "gcp": "Cloud HSM", "category": "Security", "confidence": 0.95, "notes": "Hardware security modules"},
+    {"aws": "Secrets Manager", "azure": "Key Vault (Secrets)", "gcp": "Secret Manager", "category": "Security", "confidence": 0.95, "notes": "Secrets management — Azure vaults combine keys+secrets", "last_reviewed": "2026-05-03"},
+    {"aws": "WAF", "azure": "Web Application Firewall", "gcp": "Cloud Armor", "category": "Security", "confidence": 0.90, "notes": "Web application firewall", "last_reviewed": "2026-05-03"},
+    {"aws": "Shield", "azure": "DDoS Protection", "gcp": "Cloud Armor (DDoS)", "category": "Security", "confidence": 0.90, "notes": "DDoS mitigation", "last_reviewed": "2026-05-03"},
+    {"aws": "Certificate Manager", "azure": "Key Vault (Certificates)", "gcp": "Certificate Manager", "category": "Security", "confidence": 0.90, "notes": "TLS/SSL certificate management", "last_reviewed": "2026-05-03"},
+    {"aws": "IAM Identity Center", "azure": "Entra ID (SSO)", "gcp": "BeyondCorp Enterprise", "category": "Security", "confidence": 0.85, "notes": "Single sign-on", "last_reviewed": "2026-05-03"},
+    {"aws": "Directory Service", "azure": "Entra Domain Services", "gcp": "Managed AD (via Anthos)", "category": "Security", "confidence": 0.80, "notes": "Managed Active Directory", "last_reviewed": "2026-05-03"},
+    {"aws": "Security Hub", "azure": "Microsoft Sentinel", "gcp": "Chronicle", "category": "Security", "confidence": 0.85, "notes": "Centralized security management / SIEM", "last_reviewed": "2026-05-03"},
+    {"aws": "CloudHSM", "azure": "Dedicated HSM", "gcp": "Cloud HSM", "category": "Security", "confidence": 0.95, "notes": "Hardware security modules", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # AI / ML
     # ═══════════════════════════════════════════════════════════
-    {"aws": "SageMaker", "azure": "Azure Machine Learning", "gcp": "Vertex AI", "category": "AI/ML", "confidence": 0.90, "notes": "End-to-end ML platform"},
-    {"aws": "Bedrock", "azure": "Azure OpenAI Service", "gcp": "Gemini on Vertex AI", "category": "AI/ML", "confidence": 0.85, "notes": "Foundation model access — different model families"},
-    {"aws": "Rekognition", "azure": "AI Vision", "gcp": "Vision AI", "category": "AI/ML", "confidence": 0.90, "notes": "Image/video analysis"},
-    {"aws": "Comprehend", "azure": "AI Language", "gcp": "Natural Language AI", "category": "AI/ML", "confidence": 0.90, "notes": "Natural language processing"},
-    {"aws": "Polly", "azure": "AI Speech (TTS)", "gcp": "Text-to-Speech", "category": "AI/ML", "confidence": 0.95, "notes": "Text-to-speech synthesis"},
-    {"aws": "Transcribe", "azure": "AI Speech (STT)", "gcp": "Speech-to-Text", "category": "AI/ML", "confidence": 0.95, "notes": "Speech-to-text transcription"},
-    {"aws": "Translate", "azure": "AI Translator", "gcp": "Translation AI", "category": "AI/ML", "confidence": 0.95, "notes": "Machine translation"},
-    {"aws": "Lex", "azure": "Bot Service", "gcp": "Dialogflow", "category": "AI/ML", "confidence": 0.90, "notes": "Conversational AI / chatbot"},
-    {"aws": "Textract", "azure": "AI Document Intelligence", "gcp": "Document AI", "category": "AI/ML", "confidence": 0.90, "notes": "Document data extraction (OCR+)"},
-    {"aws": "Personalize", "azure": "Personalizer", "gcp": "Recommendations AI", "category": "AI/ML", "confidence": 0.85, "notes": "Personalization and recommendations"},
-    {"aws": "Kendra", "azure": "AI Search", "gcp": "Vertex AI Search", "category": "AI/ML", "confidence": 0.85, "notes": "Enterprise AI-powered search"},
-    {"aws": "HealthLake", "azure": "Health Insights", "gcp": "Healthcare API", "category": "AI/ML", "confidence": 0.80, "notes": "Healthcare data analysis"},
-    {"aws": "CodeWhisperer", "azure": "Copilot Studio", "gcp": "Gemini Code Assist", "category": "AI/ML", "confidence": 0.85, "notes": "AI code assistant"},
+    {"aws": "SageMaker", "azure": "Azure Machine Learning", "gcp": "Vertex AI", "category": "AI/ML", "confidence": 0.90, "notes": "End-to-end ML platform", "last_reviewed": "2026-05-03"},
+    {"aws": "Bedrock", "azure": "Azure OpenAI Service", "gcp": "Gemini on Vertex AI", "category": "AI/ML", "confidence": 0.85, "notes": "Foundation model access — different model families", "last_reviewed": "2026-05-03"},
+    {"aws": "Rekognition", "azure": "AI Vision", "gcp": "Vision AI", "category": "AI/ML", "confidence": 0.90, "notes": "Image/video analysis", "last_reviewed": "2026-05-03"},
+    {"aws": "Comprehend", "azure": "AI Language", "gcp": "Natural Language AI", "category": "AI/ML", "confidence": 0.90, "notes": "Natural language processing", "last_reviewed": "2026-05-03"},
+    {"aws": "Polly", "azure": "AI Speech (TTS)", "gcp": "Text-to-Speech", "category": "AI/ML", "confidence": 0.95, "notes": "Text-to-speech synthesis", "last_reviewed": "2026-05-03"},
+    {"aws": "Transcribe", "azure": "AI Speech (STT)", "gcp": "Speech-to-Text", "category": "AI/ML", "confidence": 0.95, "notes": "Speech-to-text transcription", "last_reviewed": "2026-05-03"},
+    {"aws": "Translate", "azure": "AI Translator", "gcp": "Translation AI", "category": "AI/ML", "confidence": 0.95, "notes": "Machine translation", "last_reviewed": "2026-05-03"},
+    {"aws": "Lex", "azure": "Bot Service", "gcp": "Dialogflow", "category": "AI/ML", "confidence": 0.90, "notes": "Conversational AI / chatbot", "last_reviewed": "2026-05-03"},
+    {"aws": "Textract", "azure": "AI Document Intelligence", "gcp": "Document AI", "category": "AI/ML", "confidence": 0.90, "notes": "Document data extraction (OCR+)", "last_reviewed": "2026-05-03"},
+    {"aws": "Personalize", "azure": "Personalizer", "gcp": "Recommendations AI", "category": "AI/ML", "confidence": 0.85, "notes": "Personalization and recommendations", "last_reviewed": "2026-05-03"},
+    {"aws": "Kendra", "azure": "AI Search", "gcp": "Vertex AI Search", "category": "AI/ML", "confidence": 0.85, "notes": "Enterprise AI-powered search", "last_reviewed": "2026-05-03"},
+    {"aws": "HealthLake", "azure": "Health Insights", "gcp": "Healthcare API", "category": "AI/ML", "confidence": 0.80, "notes": "Healthcare data analysis", "last_reviewed": "2026-05-03"},
+    {"aws": "CodeWhisperer", "azure": "Copilot Studio", "gcp": "Gemini Code Assist", "category": "AI/ML", "confidence": 0.85, "notes": "AI code assistant", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # ANALYTICS
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Athena", "azure": "Synapse Analytics (Serverless SQL)", "gcp": "BigQuery", "category": "Analytics", "confidence": 0.85, "notes": "Serverless SQL query on data lake"},
-    {"aws": "EMR", "azure": "HDInsight / Databricks", "gcp": "Dataproc", "category": "Analytics", "confidence": 0.85, "notes": "Managed Spark/Hadoop"},
-    {"aws": "Kinesis", "azure": "Event Hubs / Stream Analytics", "gcp": "Dataflow / Pub/Sub", "category": "Analytics", "confidence": 0.85, "notes": "Real-time data streaming"},
-    {"aws": "QuickSight", "azure": "Power BI", "gcp": "Looker", "category": "Analytics", "confidence": 0.90, "notes": "Business intelligence and visualization"},
-    {"aws": "Glue", "azure": "Data Factory", "gcp": "Data Fusion / Dataflow", "category": "Analytics", "confidence": 0.85, "notes": "Data integration and ETL"},
-    {"aws": "Lake Formation", "azure": "Microsoft Purview", "gcp": "Dataplex", "category": "Analytics", "confidence": 0.80, "notes": "Data lake governance and management"},
-    {"aws": "MSK", "azure": "Event Hubs (Kafka)", "gcp": "Pub/Sub", "category": "Analytics", "confidence": 0.85, "notes": "Managed messaging/streaming — Kafka on Azure Event Hubs"},
-    {"aws": "OpenSearch", "azure": "Data Explorer / AI Search", "gcp": "Elasticsearch on GKE", "category": "Analytics", "confidence": 0.80, "notes": "Search and analytics engine"},
-    {"aws": "MWAA", "azure": "Data Factory (orchestration)", "gcp": "Cloud Composer", "category": "Analytics", "confidence": 0.85, "notes": "Managed Apache Airflow"},
-    {"aws": "Data Exchange", "azure": "Data Share", "gcp": "Analytics Hub", "category": "Analytics", "confidence": 0.80, "notes": "Data sharing/exchange marketplace"},
+    {"aws": "Athena", "azure": "Synapse Analytics (Serverless SQL)", "gcp": "BigQuery", "category": "Analytics", "confidence": 0.85, "notes": "Serverless SQL query on data lake", "last_reviewed": "2026-05-03"},
+    {"aws": "EMR", "azure": "HDInsight / Databricks", "gcp": "Dataproc", "category": "Analytics", "confidence": 0.85, "notes": "Managed Spark/Hadoop", "last_reviewed": "2026-05-03"},
+    {"aws": "Kinesis", "azure": "Event Hubs / Stream Analytics", "gcp": "Dataflow / Pub/Sub", "category": "Analytics", "confidence": 0.85, "notes": "Real-time data streaming", "last_reviewed": "2026-05-03"},
+    {"aws": "QuickSight", "azure": "Power BI", "gcp": "Looker", "category": "Analytics", "confidence": 0.90, "notes": "Business intelligence and visualization", "last_reviewed": "2026-05-03"},
+    {"aws": "Glue", "azure": "Data Factory", "gcp": "Data Fusion / Dataflow", "category": "Analytics", "confidence": 0.85, "notes": "Data integration and ETL", "last_reviewed": "2026-05-03"},
+    {"aws": "Lake Formation", "azure": "Microsoft Purview", "gcp": "Dataplex", "category": "Analytics", "confidence": 0.80, "notes": "Data lake governance and management", "last_reviewed": "2026-05-03"},
+    {"aws": "MSK", "azure": "Event Hubs (Kafka)", "gcp": "Pub/Sub", "category": "Analytics", "confidence": 0.85, "notes": "Managed messaging/streaming — Kafka on Azure Event Hubs", "last_reviewed": "2026-05-03"},
+    {"aws": "OpenSearch", "azure": "Data Explorer / AI Search", "gcp": "Elasticsearch on GKE", "category": "Analytics", "confidence": 0.80, "notes": "Search and analytics engine", "last_reviewed": "2026-05-03"},
+    {"aws": "MWAA", "azure": "Data Factory (orchestration)", "gcp": "Cloud Composer", "category": "Analytics", "confidence": 0.85, "notes": "Managed Apache Airflow", "last_reviewed": "2026-05-03"},
+    {"aws": "Data Exchange", "azure": "Data Share", "gcp": "Analytics Hub", "category": "Analytics", "confidence": 0.80, "notes": "Data sharing/exchange marketplace", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # APPLICATION INTEGRATION
     # ═══════════════════════════════════════════════════════════
-    {"aws": "SQS", "azure": "Service Bus (Queues)", "gcp": "Cloud Tasks / Pub/Sub", "category": "Integration", "confidence": 0.90, "notes": "Message queuing"},
-    {"aws": "SNS", "azure": "Event Grid / Notification Hubs", "gcp": "Pub/Sub / Firebase Cloud Messaging", "category": "Integration", "confidence": 0.85, "notes": "Pub/sub and notifications"},
-    {"aws": "EventBridge", "azure": "Event Grid", "gcp": "Eventarc", "category": "Integration", "confidence": 0.90, "notes": "Serverless event bus"},
-    {"aws": "Step Functions", "azure": "Logic Apps", "gcp": "Workflows", "category": "Integration", "confidence": 0.85, "notes": "Workflow orchestration"},
-    {"aws": "Amazon MQ", "azure": "Service Bus (Premium)", "gcp": "Pub/Sub", "category": "Integration", "confidence": 0.80, "notes": "Managed message broker"},
-    {"aws": "AppSync", "azure": "API Apps (with GraphQL)", "gcp": "Apigee (GraphQL)", "category": "Integration", "confidence": 0.75, "notes": "GraphQL APIs — different maturity levels"},
+    {"aws": "SQS", "azure": "Service Bus (Queues)", "gcp": "Cloud Tasks / Pub/Sub", "category": "Integration", "confidence": 0.90, "notes": "Message queuing", "last_reviewed": "2026-05-03"},
+    {"aws": "SNS", "azure": "Event Grid / Notification Hubs", "gcp": "Pub/Sub / Firebase Cloud Messaging", "category": "Integration", "confidence": 0.85, "notes": "Pub/sub and notifications", "last_reviewed": "2026-05-03"},
+    {"aws": "EventBridge", "azure": "Event Grid", "gcp": "Eventarc", "category": "Integration", "confidence": 0.90, "notes": "Serverless event bus", "last_reviewed": "2026-05-03"},
+    {"aws": "Step Functions", "azure": "Logic Apps", "gcp": "Workflows", "category": "Integration", "confidence": 0.85, "notes": "Workflow orchestration", "last_reviewed": "2026-05-03"},
+    {"aws": "Amazon MQ", "azure": "Service Bus (Premium)", "gcp": "Pub/Sub", "category": "Integration", "confidence": 0.80, "notes": "Managed message broker", "last_reviewed": "2026-05-03"},
+    {"aws": "AppSync", "azure": "API Apps (with GraphQL)", "gcp": "Apigee (GraphQL)", "category": "Integration", "confidence": 0.75, "notes": "GraphQL APIs — different maturity levels", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # DEVELOPER TOOLS
     # ═══════════════════════════════════════════════════════════
-    {"aws": "CodeCommit", "azure": "Azure DevOps Repos", "gcp": "Cloud Source Repositories", "category": "DevTools", "confidence": 0.90, "notes": "Git repository hosting"},
-    {"aws": "CodeBuild", "azure": "Azure Pipelines (Build)", "gcp": "Cloud Build", "category": "DevTools", "confidence": 0.90, "notes": "CI build service"},
-    {"aws": "CodeDeploy", "azure": "Azure Pipelines (Deploy)", "gcp": "Cloud Deploy", "category": "DevTools", "confidence": 0.85, "notes": "Continuous deployment"},
-    {"aws": "CodePipeline", "azure": "Azure Pipelines", "gcp": "Cloud Build triggers", "category": "DevTools", "confidence": 0.90, "notes": "CI/CD pipeline orchestration"},
-    {"aws": "CloudFormation", "azure": "ARM Templates / Bicep", "gcp": "Deployment Manager", "category": "DevTools", "confidence": 0.90, "notes": "Infrastructure as code"},
-    {"aws": "X-Ray", "azure": "Application Insights", "gcp": "Cloud Trace", "category": "DevTools", "confidence": 0.90, "notes": "Distributed tracing"},
-    {"aws": "CodeArtifact", "azure": "Azure Artifacts", "gcp": "Artifact Registry", "category": "DevTools", "confidence": 0.90, "notes": "Package/artifact repository"},
-    {"aws": "ECR", "azure": "Container Registry", "gcp": "Artifact Registry / Container Registry", "category": "DevTools", "confidence": 0.95, "notes": "Container image registry"},
-    {"aws": "FIS", "azure": "Chaos Studio", "gcp": "Litmus (OSS on GKE)", "category": "DevTools", "confidence": 0.80, "notes": "Chaos engineering"},
+    {"aws": "CodeCommit", "azure": "Azure DevOps Repos", "gcp": "Cloud Source Repositories", "category": "DevTools", "confidence": 0.90, "notes": "Git repository hosting", "last_reviewed": "2026-05-03"},
+    {"aws": "CodeBuild", "azure": "Azure Pipelines (Build)", "gcp": "Cloud Build", "category": "DevTools", "confidence": 0.90, "notes": "CI build service", "last_reviewed": "2026-05-03"},
+    {"aws": "CodeDeploy", "azure": "Azure Pipelines (Deploy)", "gcp": "Cloud Deploy", "category": "DevTools", "confidence": 0.85, "notes": "Continuous deployment", "last_reviewed": "2026-05-03"},
+    {"aws": "CodePipeline", "azure": "Azure Pipelines", "gcp": "Cloud Build triggers", "category": "DevTools", "confidence": 0.90, "notes": "CI/CD pipeline orchestration", "last_reviewed": "2026-05-03"},
+    {"aws": "CloudFormation", "azure": "ARM Templates / Bicep", "gcp": "Deployment Manager", "category": "DevTools", "confidence": 0.90, "notes": "Infrastructure as code", "last_reviewed": "2026-05-03"},
+    {"aws": "X-Ray", "azure": "Application Insights", "gcp": "Cloud Trace", "category": "DevTools", "confidence": 0.90, "notes": "Distributed tracing", "last_reviewed": "2026-05-03"},
+    {"aws": "CodeArtifact", "azure": "Azure Artifacts", "gcp": "Artifact Registry", "category": "DevTools", "confidence": 0.90, "notes": "Package/artifact repository", "last_reviewed": "2026-05-03"},
+    {"aws": "ECR", "azure": "Container Registry", "gcp": "Artifact Registry / Container Registry", "category": "DevTools", "confidence": 0.95, "notes": "Container image registry", "last_reviewed": "2026-05-03"},
+    {"aws": "FIS", "azure": "Chaos Studio", "gcp": "Litmus (OSS on GKE)", "category": "DevTools", "confidence": 0.80, "notes": "Chaos engineering", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # MANAGEMENT & GOVERNANCE
     # ═══════════════════════════════════════════════════════════
-    {"aws": "CloudWatch", "azure": "Azure Monitor / Log Analytics", "gcp": "Cloud Monitoring", "category": "Management", "confidence": 0.90, "notes": "Monitoring and observability"},
-    {"aws": "CloudTrail", "azure": "Azure Monitor (Activity Logs)", "gcp": "Cloud Audit Logs", "category": "Management", "confidence": 0.90, "notes": "API activity auditing"},
-    {"aws": "Config", "azure": "Azure Policy", "gcp": "Organization Policy", "category": "Management", "confidence": 0.85, "notes": "Resource configuration compliance"},
-    {"aws": "Systems Manager", "azure": "Azure Automation", "gcp": "OS Config (via VM Manager)", "category": "Management", "confidence": 0.80, "notes": "Operations management — different scope"},
-    {"aws": "Organizations", "azure": "Management Groups", "gcp": "Resource Manager", "category": "Management", "confidence": 0.90, "notes": "Multi-account/subscription governance"},
-    {"aws": "Control Tower", "azure": "Azure Blueprints / Landing Zones", "gcp": "Assured Workloads", "category": "Management", "confidence": 0.80, "notes": "Multi-account best practice setup"},
-    {"aws": "Trusted Advisor", "azure": "Azure Advisor", "gcp": "Recommender", "category": "Management", "confidence": 0.90, "notes": "Best practice recommendations"},
-    {"aws": "Cost Explorer", "azure": "Cost Management", "gcp": "Cloud Billing", "category": "Management", "confidence": 0.90, "notes": "Cost analysis and optimization"},
-    {"aws": "Health Dashboard", "azure": "Service Health", "gcp": "Service Health", "category": "Management", "confidence": 0.95, "notes": "Service status dashboard"},
+    {"aws": "CloudWatch", "azure": "Azure Monitor / Log Analytics", "gcp": "Cloud Monitoring", "category": "Management", "confidence": 0.90, "notes": "Monitoring and observability", "last_reviewed": "2026-05-03"},
+    {"aws": "CloudTrail", "azure": "Azure Monitor (Activity Logs)", "gcp": "Cloud Audit Logs", "category": "Management", "confidence": 0.90, "notes": "API activity auditing", "last_reviewed": "2026-05-03"},
+    {"aws": "Config", "azure": "Azure Policy", "gcp": "Organization Policy", "category": "Management", "confidence": 0.85, "notes": "Resource configuration compliance", "last_reviewed": "2026-05-03"},
+    {"aws": "Systems Manager", "azure": "Azure Automation", "gcp": "OS Config (via VM Manager)", "category": "Management", "confidence": 0.80, "notes": "Operations management — different scope", "last_reviewed": "2026-05-03"},
+    {"aws": "Organizations", "azure": "Management Groups", "gcp": "Resource Manager", "category": "Management", "confidence": 0.90, "notes": "Multi-account/subscription governance", "last_reviewed": "2026-05-03"},
+    {"aws": "Control Tower", "azure": "Azure Blueprints / Landing Zones", "gcp": "Assured Workloads", "category": "Management", "confidence": 0.80, "notes": "Multi-account best practice setup", "last_reviewed": "2026-05-03"},
+    {"aws": "Trusted Advisor", "azure": "Azure Advisor", "gcp": "Recommender", "category": "Management", "confidence": 0.90, "notes": "Best practice recommendations", "last_reviewed": "2026-05-03"},
+    {"aws": "Cost Explorer", "azure": "Cost Management", "gcp": "Cloud Billing", "category": "Management", "confidence": 0.90, "notes": "Cost analysis and optimization", "last_reviewed": "2026-05-03"},
+    {"aws": "Health Dashboard", "azure": "Service Health", "gcp": "Service Health", "category": "Management", "confidence": 0.95, "notes": "Service status dashboard", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # IOT
     # ═══════════════════════════════════════════════════════════
-    {"aws": "IoT Core", "azure": "IoT Hub", "gcp": "Cloud IoT Core", "category": "IoT", "confidence": 0.90, "notes": "IoT device connectivity and management"},
-    {"aws": "IoT Greengrass", "azure": "IoT Edge", "gcp": "Anthos (edge)", "category": "IoT", "confidence": 0.85, "notes": "Edge computing for IoT"},
-    {"aws": "IoT Analytics", "azure": "Time Series Insights / Stream Analytics", "gcp": "BigQuery (IoT data)", "category": "IoT", "confidence": 0.80, "notes": "IoT data analytics"},
-    {"aws": "IoT SiteWise", "azure": "IoT Hub + Digital Twins", "gcp": "Cloud IoT + Dataflow", "category": "IoT", "confidence": 0.75, "notes": "Industrial IoT"},
-    {"aws": "IoT TwinMaker", "azure": "Digital Twins", "gcp": "Supply Chain Twin (limited)", "category": "IoT", "confidence": 0.80, "notes": "Digital twin modeling"},
-    {"aws": "IoT FleetWise", "azure": "IoT Hub + Stream Analytics", "gcp": "Cloud IoT + Pub/Sub", "category": "IoT", "confidence": 0.70, "notes": "Vehicle data — AWS-specific, limited equivalents"},
+    {"aws": "IoT Core", "azure": "IoT Hub", "gcp": "Cloud IoT Core", "category": "IoT", "confidence": 0.90, "notes": "IoT device connectivity and management", "last_reviewed": "2026-05-03"},
+    {"aws": "IoT Greengrass", "azure": "IoT Edge", "gcp": "Anthos (edge)", "category": "IoT", "confidence": 0.85, "notes": "Edge computing for IoT", "last_reviewed": "2026-05-03"},
+    {"aws": "IoT Analytics", "azure": "Time Series Insights / Stream Analytics", "gcp": "BigQuery (IoT data)", "category": "IoT", "confidence": 0.80, "notes": "IoT data analytics", "last_reviewed": "2026-05-03"},
+    {"aws": "IoT SiteWise", "azure": "IoT Hub + Digital Twins", "gcp": "Cloud IoT + Dataflow", "category": "IoT", "confidence": 0.75, "notes": "Industrial IoT", "last_reviewed": "2026-05-03"},
+    {"aws": "IoT TwinMaker", "azure": "Digital Twins", "gcp": "Supply Chain Twin (limited)", "category": "IoT", "confidence": 0.80, "notes": "Digital twin modeling", "last_reviewed": "2026-05-03"},
+    {"aws": "IoT FleetWise", "azure": "IoT Hub + Stream Analytics", "gcp": "Cloud IoT + Pub/Sub", "category": "IoT", "confidence": 0.70, "notes": "Vehicle data — AWS-specific, limited equivalents", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # MEDIA
     # ═══════════════════════════════════════════════════════════
-    {"aws": "MediaConvert", "azure": "Media Services (encoding)", "gcp": "Transcoder API", "category": "Media", "confidence": 0.90, "notes": "Video transcoding"},
-    {"aws": "MediaLive", "azure": "Media Services (live)", "gcp": "Live Stream API", "category": "Media", "confidence": 0.85, "notes": "Live video processing"},
-    {"aws": "IVS", "azure": "Communication Services", "gcp": "Live Stream API", "category": "Media", "confidence": 0.75, "notes": "Interactive live streaming"},
+    {"aws": "MediaConvert", "azure": "Media Services (encoding)", "gcp": "Transcoder API", "category": "Media", "confidence": 0.90, "notes": "Video transcoding", "last_reviewed": "2026-05-03"},
+    {"aws": "MediaLive", "azure": "Media Services (live)", "gcp": "Live Stream API", "category": "Media", "confidence": 0.85, "notes": "Live video processing", "last_reviewed": "2026-05-03"},
+    {"aws": "IVS", "azure": "Communication Services", "gcp": "Live Stream API", "category": "Media", "confidence": 0.75, "notes": "Interactive live streaming", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # MIGRATION
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Migration Hub", "azure": "Azure Migrate", "gcp": "Migrate to VMs", "category": "Migration", "confidence": 0.85, "notes": "Migration tracking and assessment"},
-    {"aws": "Application Migration Service", "azure": "Site Recovery", "gcp": "Migrate to VMs", "category": "Migration", "confidence": 0.85, "notes": "Server migration (lift and shift)"},
+    {"aws": "Migration Hub", "azure": "Azure Migrate", "gcp": "Migrate to VMs", "category": "Migration", "confidence": 0.85, "notes": "Migration tracking and assessment", "last_reviewed": "2026-05-03"},
+    {"aws": "Application Migration Service", "azure": "Site Recovery", "gcp": "Migrate to VMs", "category": "Migration", "confidence": 0.85, "notes": "Server migration (lift and shift)", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # BUSINESS APPLICATIONS
     # ═══════════════════════════════════════════════════════════
-    {"aws": "SES", "azure": "Email Communication", "gcp": "Google Workspace (Gmail API)", "category": "Business", "confidence": 0.80, "notes": "Email sending service"},
-    {"aws": "Connect", "azure": "Dynamics 365 Contact Center", "gcp": "Contact Center AI", "category": "Business", "confidence": 0.80, "notes": "Cloud contact center"},
-    {"aws": "WorkSpaces", "azure": "Virtual Desktop", "gcp": "Chrome Remote Desktop / VDI on GCE", "category": "Business", "confidence": 0.85, "notes": "Virtual desktop infrastructure"},
-    {"aws": "Pinpoint", "azure": "Notification Hubs", "gcp": "Firebase Cloud Messaging", "category": "Business", "confidence": 0.75, "notes": "Multi-channel marketing/notifications"},
+    {"aws": "SES", "azure": "Email Communication", "gcp": "Google Workspace (Gmail API)", "category": "Business", "confidence": 0.80, "notes": "Email sending service", "last_reviewed": "2026-05-03"},
+    {"aws": "Connect", "azure": "Dynamics 365 Contact Center", "gcp": "Contact Center AI", "category": "Business", "confidence": 0.80, "notes": "Cloud contact center", "last_reviewed": "2026-05-03"},
+    {"aws": "WorkSpaces", "azure": "Virtual Desktop", "gcp": "Chrome Remote Desktop / VDI on GCE", "category": "Business", "confidence": 0.85, "notes": "Virtual desktop infrastructure", "last_reviewed": "2026-05-03"},
+    {"aws": "Pinpoint", "azure": "Notification Hubs", "gcp": "Firebase Cloud Messaging", "category": "Business", "confidence": 0.75, "notes": "Multi-channel marketing/notifications", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # HYBRID & MULTI-CLOUD  (#60 — Azure Arc & Hybrid Management)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "EKS Anywhere", "azure": "Azure Arc-enabled Kubernetes", "gcp": "Anthos (multi-cloud)", "category": "Hybrid", "confidence": 0.85, "notes": "Managed Kubernetes across on-prem and multi-cloud — Arc projects Azure control plane anywhere"},
-    {"aws": "SSM (hybrid nodes)", "azure": "Azure Arc-enabled Servers", "gcp": "Anthos for VMs", "category": "Hybrid", "confidence": 0.80, "notes": "Manage on-prem/multi-cloud servers from the cloud control plane"},
-    {"aws": "RDS on Outposts", "azure": "Azure Arc-enabled SQL", "gcp": "AlloyDB Omni", "category": "Hybrid", "confidence": 0.75, "notes": "Run managed database engine outside the cloud provider's region"},
-    {"aws": "Control Tower (multi-account)", "azure": "Azure Lighthouse", "gcp": "Cloud Foundation Toolkit", "category": "Hybrid", "confidence": 0.80, "notes": "Multi-tenant / multi-subscription governance and delegation"},
-    {"aws": "Outposts (rack)", "azure": "Azure Stack HCI", "gcp": "Google Distributed Cloud (GDC)", "category": "Hybrid", "confidence": 0.85, "notes": "Full cloud stack running on-premises on customer-owned hardware"},
+    {"aws": "EKS Anywhere", "azure": "Azure Arc-enabled Kubernetes", "gcp": "Anthos (multi-cloud)", "category": "Hybrid", "confidence": 0.85, "notes": "Managed Kubernetes across on-prem and multi-cloud — Arc projects Azure control plane anywhere", "last_reviewed": "2026-05-03"},
+    {"aws": "SSM (hybrid nodes)", "azure": "Azure Arc-enabled Servers", "gcp": "Anthos for VMs", "category": "Hybrid", "confidence": 0.80, "notes": "Manage on-prem/multi-cloud servers from the cloud control plane", "last_reviewed": "2026-05-03"},
+    {"aws": "RDS on Outposts", "azure": "Azure Arc-enabled SQL", "gcp": "AlloyDB Omni", "category": "Hybrid", "confidence": 0.75, "notes": "Run managed database engine outside the cloud provider's region", "last_reviewed": "2026-05-03"},
+    {"aws": "Control Tower (multi-account)", "azure": "Azure Lighthouse", "gcp": "Cloud Foundation Toolkit", "category": "Hybrid", "confidence": 0.80, "notes": "Multi-tenant / multi-subscription governance and delegation", "last_reviewed": "2026-05-03"},
+    {"aws": "Outposts (rack)", "azure": "Azure Stack HCI", "gcp": "Google Distributed Cloud (GDC)", "category": "Hybrid", "confidence": 0.85, "notes": "Full cloud stack running on-premises on customer-owned hardware", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # GENERATIVE AI & AI AGENTS  (#61)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Bedrock Agents", "azure": "Azure AI Agent Service", "gcp": "Vertex AI Agents", "category": "AI/ML", "confidence": 0.80, "notes": "Autonomous AI agents with tool-use — rapidly evolving across all providers"},
-    {"aws": "Bedrock Knowledge Bases", "azure": "Azure AI Search (RAG)", "gcp": "Vertex AI Search", "category": "AI/ML", "confidence": 0.80, "notes": "Retrieval-Augmented Generation with managed vector stores"},
-    {"aws": "Q Business", "azure": "Microsoft 365 Copilot / AI Foundry", "gcp": "Gemini for Workspace", "category": "AI/ML", "confidence": 0.75, "notes": "Enterprise AI assistant grounded in organizational data"},
-    {"aws": "SageMaker Canvas", "azure": "Azure ML AutoML", "gcp": "Vertex AI AutoML", "category": "AI/ML", "confidence": 0.85, "notes": "No-code / low-code ML model building"},
-    {"aws": "Bedrock Guardrails", "azure": "Azure AI Content Safety", "gcp": "Vertex AI Safety Filters", "category": "AI/ML", "confidence": 0.80, "notes": "Content filtering and responsible AI guardrails for LLM applications"},
-    {"aws": "PartyRock", "azure": "Azure AI Foundry (low-code)", "gcp": "Vertex AI Studio", "category": "AI/ML", "confidence": 0.75, "notes": "Low-code generative AI app builder"},
-    {"aws": "CodeGuru", "azure": "GitHub Advanced Security", "gcp": "Gemini Code Assist", "category": "AI/ML", "confidence": 0.75, "notes": "AI-powered code review and security analysis"},
+    {"aws": "Bedrock Agents", "azure": "Azure AI Agent Service", "gcp": "Vertex AI Agents", "category": "AI/ML", "confidence": 0.80, "notes": "Autonomous AI agents with tool-use — rapidly evolving across all providers", "last_reviewed": "2026-05-03"},
+    {"aws": "Bedrock Knowledge Bases", "azure": "Azure AI Search (RAG)", "gcp": "Vertex AI Search", "category": "AI/ML", "confidence": 0.80, "notes": "Retrieval-Augmented Generation with managed vector stores", "last_reviewed": "2026-05-03"},
+    {"aws": "Q Business", "azure": "Microsoft 365 Copilot / AI Foundry", "gcp": "Gemini for Workspace", "category": "AI/ML", "confidence": 0.75, "notes": "Enterprise AI assistant grounded in organizational data", "last_reviewed": "2026-05-03"},
+    {"aws": "SageMaker Canvas", "azure": "Azure ML AutoML", "gcp": "Vertex AI AutoML", "category": "AI/ML", "confidence": 0.85, "notes": "No-code / low-code ML model building", "last_reviewed": "2026-05-03"},
+    {"aws": "Bedrock Guardrails", "azure": "Azure AI Content Safety", "gcp": "Vertex AI Safety Filters", "category": "AI/ML", "confidence": 0.80, "notes": "Content filtering and responsible AI guardrails for LLM applications", "last_reviewed": "2026-05-03"},
+    {"aws": "PartyRock", "azure": "Azure AI Foundry (low-code)", "gcp": "Vertex AI Studio", "category": "AI/ML", "confidence": 0.75, "notes": "Low-code generative AI app builder", "last_reviewed": "2026-05-03"},
+    {"aws": "CodeGuru", "azure": "GitHub Advanced Security", "gcp": "Gemini Code Assist", "category": "AI/ML", "confidence": 0.75, "notes": "AI-powered code review and security analysis", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # EDGE COMPUTING & DISTRIBUTED CLOUD  (#62)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Wavelength", "azure": "Azure Edge Zones", "gcp": "Distributed Cloud Edge", "category": "Edge", "confidence": 0.80, "notes": "Ultra-low-latency compute at 5G / telco edge"},
-    {"aws": "Local Zones", "azure": "Azure Extended Zones", "gcp": "Distributed Cloud Edge", "category": "Edge", "confidence": 0.80, "notes": "Cloud infrastructure closer to metro areas for latency-sensitive apps"},
-    {"aws": "Lambda@Edge", "azure": "Azure Front Door Rules Engine", "gcp": "Cloud CDN (edge functions)", "category": "Edge", "confidence": 0.80, "notes": "Serverless logic at CDN edge locations"},
-    {"aws": "CloudFront Functions", "azure": "Azure CDN Rules Engine", "gcp": "Cloud CDN Policies", "category": "Edge", "confidence": 0.80, "notes": "Lightweight edge compute for request/response manipulation"},
-    {"aws": "Elastic Disaster Recovery", "azure": "Azure Site Recovery", "gcp": "Backup and DR (Actifio)", "category": "Edge", "confidence": 0.85, "notes": "Cloud-native disaster recovery with continuous replication"},
+    {"aws": "Wavelength", "azure": "Azure Edge Zones", "gcp": "Distributed Cloud Edge", "category": "Edge", "confidence": 0.80, "notes": "Ultra-low-latency compute at 5G / telco edge", "last_reviewed": "2026-05-03"},
+    {"aws": "Local Zones", "azure": "Azure Extended Zones", "gcp": "Distributed Cloud Edge", "category": "Edge", "confidence": 0.80, "notes": "Cloud infrastructure closer to metro areas for latency-sensitive apps", "last_reviewed": "2026-05-03"},
+    {"aws": "Lambda@Edge", "azure": "Azure Front Door Rules Engine", "gcp": "Cloud CDN (edge functions)", "category": "Edge", "confidence": 0.80, "notes": "Serverless logic at CDN edge locations", "last_reviewed": "2026-05-03"},
+    {"aws": "CloudFront Functions", "azure": "Azure CDN Rules Engine", "gcp": "Cloud CDN Policies", "category": "Edge", "confidence": 0.80, "notes": "Lightweight edge compute for request/response manipulation", "last_reviewed": "2026-05-03"},
+    {"aws": "Elastic Disaster Recovery", "azure": "Azure Site Recovery", "gcp": "Backup and DR (Actifio)", "category": "Edge", "confidence": 0.85, "notes": "Cloud-native disaster recovery with continuous replication", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # MANAGED OBSERVABILITY  (#63)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Managed Grafana", "azure": "Azure Managed Grafana", "gcp": "Grafana (marketplace)", "category": "Observability", "confidence": 0.90, "notes": "Fully managed Grafana dashboards — first-party on AWS/Azure, marketplace on GCP"},
-    {"aws": "Managed Prometheus", "azure": "Azure Monitor (Prometheus)", "gcp": "Managed Service for Prometheus", "category": "Observability", "confidence": 0.90, "notes": "Managed Prometheus-compatible metrics collection"},
-    {"aws": "Distro for OpenTelemetry", "azure": "Azure Monitor (OpenTelemetry)", "gcp": "Cloud Trace (OpenTelemetry)", "category": "Observability", "confidence": 0.85, "notes": "OpenTelemetry distribution for vendor-neutral telemetry collection"},
-    {"aws": "CloudWatch Container Insights", "azure": "Container Insights (Azure Monitor)", "gcp": "GKE Monitoring", "category": "Observability", "confidence": 0.85, "notes": "Container and Kubernetes-specific monitoring and logging"},
+    {"aws": "Managed Grafana", "azure": "Azure Managed Grafana", "gcp": "Grafana (marketplace)", "category": "Observability", "confidence": 0.90, "notes": "Fully managed Grafana dashboards — first-party on AWS/Azure, marketplace on GCP", "last_reviewed": "2026-05-03"},
+    {"aws": "Managed Prometheus", "azure": "Azure Monitor (Prometheus)", "gcp": "Managed Service for Prometheus", "category": "Observability", "confidence": 0.90, "notes": "Managed Prometheus-compatible metrics collection", "last_reviewed": "2026-05-03"},
+    {"aws": "Distro for OpenTelemetry", "azure": "Azure Monitor (OpenTelemetry)", "gcp": "Cloud Trace (OpenTelemetry)", "category": "Observability", "confidence": 0.85, "notes": "OpenTelemetry distribution for vendor-neutral telemetry collection", "last_reviewed": "2026-05-03"},
+    {"aws": "CloudWatch Container Insights", "azure": "Container Insights (Azure Monitor)", "gcp": "GKE Monitoring", "category": "Observability", "confidence": 0.85, "notes": "Container and Kubernetes-specific monitoring and logging", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # DATA GOVERNANCE & DATA MESH  (#64)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "DataZone", "azure": "Microsoft Purview (Data Governance)", "gcp": "Dataplex", "category": "Data Governance", "confidence": 0.85, "notes": "Data catalog, governance, and domain-based data mesh management"},
-    {"aws": "Clean Rooms", "azure": "Azure Confidential Clean Rooms", "gcp": "BigQuery Clean Rooms", "category": "Data Governance", "confidence": 0.80, "notes": "Privacy-safe collaborative analytics across organizations"},
-    {"aws": "AppFlow", "azure": "Azure Logic Apps (SaaS connectors)", "gcp": "Application Integration", "category": "Data Governance", "confidence": 0.80, "notes": "No-code SaaS data integration (Salesforce, SAP, etc.)"},
-    {"aws": "Audit Manager", "azure": "Microsoft Purview Compliance Manager", "gcp": "Assured Workloads", "category": "Data Governance", "confidence": 0.80, "notes": "Continuous audit and compliance evidence collection"},
-    {"aws": "Glue DataBrew", "azure": "Azure Data Factory (data wrangling)", "gcp": "Dataprep by Trifacta", "category": "Data Governance", "confidence": 0.85, "notes": "Visual data preparation and cleansing tool"},
+    {"aws": "DataZone", "azure": "Microsoft Purview (Data Governance)", "gcp": "Dataplex", "category": "Data Governance", "confidence": 0.85, "notes": "Data catalog, governance, and domain-based data mesh management", "last_reviewed": "2026-05-03"},
+    {"aws": "Clean Rooms", "azure": "Azure Confidential Clean Rooms", "gcp": "BigQuery Clean Rooms", "category": "Data Governance", "confidence": 0.80, "notes": "Privacy-safe collaborative analytics across organizations", "last_reviewed": "2026-05-03"},
+    {"aws": "AppFlow", "azure": "Azure Logic Apps (SaaS connectors)", "gcp": "Application Integration", "category": "Data Governance", "confidence": 0.80, "notes": "No-code SaaS data integration (Salesforce, SAP, etc.)", "last_reviewed": "2026-05-03"},
+    {"aws": "Audit Manager", "azure": "Microsoft Purview Compliance Manager", "gcp": "Assured Workloads", "category": "Data Governance", "confidence": 0.80, "notes": "Continuous audit and compliance evidence collection", "last_reviewed": "2026-05-03"},
+    {"aws": "Glue DataBrew", "azure": "Azure Data Factory (data wrangling)", "gcp": "Dataprep by Trifacta", "category": "Data Governance", "confidence": 0.85, "notes": "Visual data preparation and cleansing tool", "last_reviewed": "2026-05-03"},
 
     # ═══════════════════════════════════════════════════════════
     # ZERO TRUST & SASE SECURITY  (#67)
     # ═══════════════════════════════════════════════════════════
-    {"aws": "Verified Access", "azure": "Entra Private Access", "gcp": "BeyondCorp Enterprise", "category": "Zero Trust", "confidence": 0.85, "notes": "Zero-trust network access — identity-based app access without VPN"},
-    {"aws": "Security Lake", "azure": "Microsoft Sentinel (data lake)", "gcp": "Chronicle SIEM", "category": "Zero Trust", "confidence": 0.80, "notes": "Centralized security data lake with OCSF / normalized schema"},
-    {"aws": "Detective", "azure": "Microsoft Sentinel (investigation)", "gcp": "Chronicle Investigation", "category": "Zero Trust", "confidence": 0.85, "notes": "Security investigation and root-cause analysis"},
-    {"aws": "Firewall Manager", "azure": "Azure Firewall Manager", "gcp": "Cloud Firewall Policies", "category": "Zero Trust", "confidence": 0.90, "notes": "Centralized firewall policy management across accounts/subscriptions"},
-    {"aws": "Network Firewall (IDPS)", "azure": "Azure Firewall Premium (IDPS)", "gcp": "Cloud IDS", "category": "Zero Trust", "confidence": 0.85, "notes": "Intrusion detection and prevention integrated with network firewall"},
-    {"aws": "VPC Lattice", "azure": "Azure Private Link (service networking)", "gcp": "Private Service Connect", "category": "Zero Trust", "confidence": 0.80, "notes": "Application-layer service-to-service networking with built-in auth"},
+    {"aws": "Verified Access", "azure": "Entra Private Access", "gcp": "BeyondCorp Enterprise", "category": "Zero Trust", "confidence": 0.85, "notes": "Zero-trust network access — identity-based app access without VPN", "last_reviewed": "2026-05-03"},
+    {"aws": "Security Lake", "azure": "Microsoft Sentinel (data lake)", "gcp": "Chronicle SIEM", "category": "Zero Trust", "confidence": 0.80, "notes": "Centralized security data lake with OCSF / normalized schema", "last_reviewed": "2026-05-03"},
+    {"aws": "Detective", "azure": "Microsoft Sentinel (investigation)", "gcp": "Chronicle Investigation", "category": "Zero Trust", "confidence": 0.85, "notes": "Security investigation and root-cause analysis", "last_reviewed": "2026-05-03"},
+    {"aws": "Firewall Manager", "azure": "Azure Firewall Manager", "gcp": "Cloud Firewall Policies", "category": "Zero Trust", "confidence": 0.90, "notes": "Centralized firewall policy management across accounts/subscriptions", "last_reviewed": "2026-05-03"},
+    {"aws": "Network Firewall (IDPS)", "azure": "Azure Firewall Premium (IDPS)", "gcp": "Cloud IDS", "category": "Zero Trust", "confidence": 0.85, "notes": "Intrusion detection and prevention integrated with network firewall", "last_reviewed": "2026-05-03"},
+    {"aws": "VPC Lattice", "azure": "Azure Private Link (service networking)", "gcp": "Private Service Connect", "category": "Zero Trust", "confidence": 0.80, "notes": "Application-layer service-to-service networking with built-in auth", "last_reviewed": "2026-05-03"},
 ]

--- a/backend/tests/test_mappings.py
+++ b/backend/tests/test_mappings.py
@@ -124,60 +124,31 @@ class TestLossyMappingsWidened:
 
 
 # ---------------------------------------------------------------------------
-# #590 — Freshness shape contract (sets up #594 quarterly-review CI lint)
+# #594 — Freshness shape contract
 # ---------------------------------------------------------------------------
 
 class TestMappingsFreshness:
-    """Every mapping touched by #590 must declare a `last_reviewed` ISO
-    date. #594 will turn this into a CI lint rule that all rows declare
-    `last_reviewed` and that none are older than 6 months."""
+    """Every mapping row must declare a `last_reviewed` ISO date."""
 
-    def test_touched_rows_carry_last_reviewed_iso_date(self):
-        """The five rows fixed/added by #590 MUST carry `last_reviewed`."""
-        touched_aws_keys = {
-            "Aurora PostgreSQL",
-            "Aurora MySQL",
-            "CloudFront",
-            "Cognito",
-            "GuardDuty",
-            "KMS",
-            "KMS (FIPS 140-3)",
-        }
+    def test_all_rows_carry_last_reviewed_iso_date(self):
         for row in CROSS_CLOUD_MAPPINGS:
-            if row["aws"] in touched_aws_keys:
-                assert "last_reviewed" in row, (
-                    f"Row {row['aws']!r} → {row['azure']!r} is in the "
-                    f"#590 touched-set but missing `last_reviewed` field. "
-                    f"All touched rows must carry the freshness stamp."
+            assert "last_reviewed" in row, (
+                f"Row {row['aws']!r} → {row['azure']!r} is missing "
+                "`last_reviewed`."
+            )
+            try:
+                parsed = date.fromisoformat(row["last_reviewed"])
+            except ValueError as exc:  # noqa: PERF203
+                pytest.fail(
+                    f"Row {row['aws']!r}: `last_reviewed` "
+                    f"{row['last_reviewed']!r} is not ISO YYYY-MM-DD: {exc}"
                 )
-                # Must parse as a YYYY-MM-DD ISO date.
-                try:
-                    parsed = date.fromisoformat(row["last_reviewed"])
-                except ValueError as exc:  # noqa: PERF203
-                    pytest.fail(
-                        f"Row {row['aws']!r}: `last_reviewed` "
-                        f"{row['last_reviewed']!r} is not ISO YYYY-MM-DD: {exc}"
-                    )
-                # Sanity: not in the future, not before the project existed.
-                assert parsed <= date.today(), (
-                    f"Row {row['aws']!r}: `last_reviewed` is in the future"
-                )
-                assert parsed >= date(2024, 1, 1), (
-                    f"Row {row['aws']!r}: `last_reviewed` predates the project"
-                )
-
-    def test_last_reviewed_is_optional_for_untouched_rows(self):
-        """Until #594 mandates the field globally, untouched rows may
-        omit it. This test documents that staged rollout."""
-        rows_with = [m for m in CROSS_CLOUD_MAPPINGS if "last_reviewed" in m]
-        rows_without = [m for m in CROSS_CLOUD_MAPPINGS if "last_reviewed" not in m]
-        # At least the #590-touched rows have it.
-        assert len(rows_with) >= 5
-        # Untouched rows are still allowed.
-        assert len(rows_without) > 0, (
-            "All rows now have last_reviewed — #594 should flip this test "
-            "to assert 100% coverage."
-        )
+            assert parsed <= date.today(), (
+                f"Row {row['aws']!r}: `last_reviewed` is in the future"
+            )
+            assert parsed >= date(2024, 1, 1), (
+                f"Row {row['aws']!r}: `last_reviewed` predates the project"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mappings_freshness_lint.py
+++ b/backend/tests/test_mappings_freshness_lint.py
@@ -1,0 +1,75 @@
+from datetime import date
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "lint_mappings_freshness.py"
+SPEC = spec_from_file_location("lint_mappings_freshness", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+lint_mappings_freshness = module_from_spec(SPEC)
+sys.modules[SPEC.name] = lint_mappings_freshness
+SPEC.loader.exec_module(lint_mappings_freshness)
+
+
+def test_low_confidence_missing_last_reviewed_is_error():
+    findings = lint_mappings_freshness.evaluate_rows(
+        [{"aws": "AppSync", "azure": "API Apps", "confidence": 0.75}],
+        today=date(2026, 5, 3),
+    )
+
+    assert [(f.level, f.message) for f in findings] == [("error", "missing last_reviewed")]
+
+
+def test_high_confidence_stale_row_is_warning():
+    findings = lint_mappings_freshness.evaluate_rows(
+        [
+            {
+                "aws": "EC2",
+                "azure": "Virtual Machines",
+                "confidence": 0.95,
+                "last_reviewed": "2025-01-01",
+            }
+        ],
+        today=date(2026, 5, 3),
+        max_age_days=180,
+    )
+
+    assert len(findings) == 1
+    assert findings[0].level == "warning"
+    assert "487 days old" in findings[0].message
+
+
+def test_low_confidence_stale_row_is_error():
+    findings = lint_mappings_freshness.evaluate_rows(
+        [
+            {
+                "aws": "QLDB",
+                "azure": "Confidential Ledger",
+                "confidence": 0.75,
+                "last_reviewed": "2025-01-01",
+            }
+        ],
+        today=date(2026, 5, 3),
+        max_age_days=180,
+    )
+
+    assert len(findings) == 1
+    assert findings[0].level == "error"
+    assert "487 days old" in findings[0].message
+
+
+def test_fresh_rows_pass():
+    findings = lint_mappings_freshness.evaluate_rows(
+        [
+            {
+                "aws": "CloudFront",
+                "azure": "Front Door",
+                "confidence": 0.9,
+                "last_reviewed": "2026-05-01",
+            }
+        ],
+        today=date(2026, 5, 3),
+    )
+
+    assert findings == []

--- a/docs/MAPPINGS_OWNERSHIP.md
+++ b/docs/MAPPINGS_OWNERSHIP.md
@@ -1,0 +1,17 @@
+# Mappings Ownership
+
+## Owner
+
+Cloud Master agent owns the cross-cloud service mapping table in `backend/services/mappings.py`. The human backup is idokatz86.
+
+## Review Cadence
+
+Every mapping row must include `last_reviewed` in `YYYY-MM-DD` format. Rows should be re-reviewed at least every 180 days, with low-confidence rows (`confidence < 0.8`) treated as blocking when stale or missing a review date.
+
+The quarterly GitHub Actions workflow opens a review issue on the first day of each quarter. The issue body contains the current freshness lint report so the owner can prioritize stale or low-confidence rows.
+
+## Update Process
+
+When a mapping changes, update the service names, confidence, notes, and `last_reviewed` date in the same PR. Prefer precise provider/product names over generic categories, and call out stale branding or engine-specific constraints in `notes` when that context protects customers from a wrong migration choice.
+
+CI runs `scripts/lint_mappings_freshness.py` in non-blocking mode during the one-sprint soak. After the soak, remove `continue-on-error: true` from the CI job to make stale low-confidence rows block merges.

--- a/scripts/lint_mappings_freshness.py
+++ b/scripts/lint_mappings_freshness.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Check service mapping rows for freshness review metadata."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "backend"
+DEFAULT_MAX_AGE_DAYS = int(os.getenv("MAPPINGS_FRESHNESS_MAX_AGE_DAYS", "180"))
+
+
+@dataclass(frozen=True)
+class Finding:
+    level: str
+    row_id: str
+    message: str
+
+
+def main() -> int:
+    args = _parse_args()
+    rows = _load_rows()
+    findings = evaluate_rows(
+        rows,
+        today=date.fromisoformat(args.today) if args.today else date.today(),
+        max_age_days=args.max_age_days,
+    )
+    _print_findings(findings, output_format=args.output)
+    return 1 if any(f.level == "error" for f in findings) else 0
+
+
+def evaluate_rows(
+    rows: list[dict[str, Any]],
+    *,
+    today: date,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for index, row in enumerate(rows, start=1):
+        row_id = _row_id(row, index)
+        confidence = float(row.get("confidence", 0))
+        last_reviewed = row.get("last_reviewed")
+
+        if not last_reviewed:
+            level = "error" if confidence < 0.8 else "warning"
+            findings.append(Finding(level, row_id, "missing last_reviewed"))
+            continue
+
+        try:
+            reviewed_on = date.fromisoformat(str(last_reviewed))
+        except ValueError:
+            findings.append(Finding("error", row_id, f"invalid last_reviewed={last_reviewed!r}"))
+            continue
+
+        if reviewed_on > today:
+            findings.append(Finding("error", row_id, f"last_reviewed {reviewed_on} is in the future"))
+            continue
+
+        age_days = (today - reviewed_on).days
+        if age_days > max_age_days:
+            level = "error" if confidence < 0.8 else "warning"
+            findings.append(
+                Finding(
+                    level,
+                    row_id,
+                    f"last_reviewed {reviewed_on} is {age_days} days old "
+                    f"(max {max_age_days})",
+                )
+            )
+
+    return findings
+
+
+def _load_rows() -> list[dict[str, Any]]:
+    sys.path.insert(0, str(BACKEND_ROOT))
+    from services.mappings import CROSS_CLOUD_MAPPINGS  # noqa: PLC0415
+
+    return list(CROSS_CLOUD_MAPPINGS)
+
+
+def _row_id(row: dict[str, Any], index: int) -> str:
+    source = row.get("aws") or row.get("source") or f"row {index}"
+    target = row.get("azure") or row.get("target") or "?"
+    return f"{source} -> {target}"
+
+
+def _print_findings(findings: list[Finding], *, output_format: str) -> None:
+    errors = [f for f in findings if f.level == "error"]
+    warnings = [f for f in findings if f.level == "warning"]
+
+    if output_format == "markdown":
+        print("# Mappings Freshness Review")
+        print()
+        print(f"Errors: {len(errors)}")
+        print(f"Warnings: {len(warnings)}")
+        print()
+        if not findings:
+            print("All mapping rows are fresh.")
+            return
+        print("| Level | Row | Message |")
+        print("| --- | --- | --- |")
+        for finding in findings:
+            print(f"| {finding.level} | {finding.row_id} | {finding.message} |")
+        return
+
+    if not findings:
+        print("Mappings freshness lint passed")
+        return
+
+    for finding in findings:
+        stream = sys.stderr if finding.level == "error" else sys.stdout
+        print(f"{finding.level.upper()}: {finding.row_id}: {finding.message}", file=stream)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=DEFAULT_MAX_AGE_DAYS,
+        help="Maximum acceptable age for last_reviewed dates.",
+    )
+    parser.add_argument(
+        "--today",
+        help="Override today's date as YYYY-MM-DD for tests or scheduled reports.",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "markdown"),
+        default="text",
+        help="Output format.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #594.

- Backfill `last_reviewed` metadata across all 156 cross-cloud mapping rows while preserving #590 review stamps.
- Add `scripts/lint_mappings_freshness.py` with configurable max-age checks, low-confidence error handling, and markdown report output.
- Add focused freshness lint tests and flip the mapping freshness shape contract to require all rows.
- Wire a non-blocking `mappings-freshness` CI job for the one-sprint soak.
- Add quarterly review workflow and ownership/process docs.

## Validation

- `backend/.venv/bin/python scripts/lint_mappings_freshness.py`
- `cd backend && .venv/bin/python -m pytest -q tests/test_mappings.py tests/test_mappings_freshness_lint.py`
- `cd backend && .venv/bin/python -m ruff check tests/test_mappings.py tests/test_mappings_freshness_lint.py ../scripts/lint_mappings_freshness.py`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/mappings-quarterly-review.yml`
- Confirmed `156/156` mapping rows have `last_reviewed`.