### PR TITLE
feat: make post-upload questions optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **FastAPI query-parameter test guard** — CI now fails when tests send `json=` bodies to query-only FastAPI routes, and the E2E step helper converts `has_X=False` detail flags into failed steps.
 - **Mappings freshness guard** — cross-cloud service mappings now carry `last_reviewed` metadata, with non-blocking CI freshness lint and a quarterly review issue workflow.
+- **Adaptive post-upload questions** — translated architecture drafts now open immediately after analysis, while inferred defaults are shown as reviewable assumptions and only high-impact or low-confidence gaps become focused follow-up questions.
 
 #### Architecture Package quality recovery
 

--- a/backend/guided_questions.py
+++ b/backend/guided_questions.py
@@ -336,6 +336,91 @@ def generate_questions(detected_services: list[str]) -> list[dict]:
     return selected
 
 
+def build_adaptive_question_set(
+    questions: list[dict],
+    analysis_result: dict,
+    inferred_answers: dict[str, Any] | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """Split generated questions into focused follow-ups and visible assumptions.
+
+    The default post-upload path should not ask broad questions that can be
+    represented as assumptions. Service-specific questions stay visible when
+    they affect high-impact choices or low-confidence mappings.
+    """
+    inferred_answers = inferred_answers or {}
+    low_confidence_services = _low_confidence_source_services(analysis_result)
+    has_low_confidence = bool(low_confidence_services)
+    focused: list[dict] = []
+    assumptions: list[dict] = []
+
+    for question in questions:
+        question_id = question.get("id")
+        assumed_answer = inferred_answers.get(question_id, question.get("default"))
+        condition = question.get("condition") or []
+        high_impact = _is_high_impact_question(question)
+        touches_low_confidence = any(
+            _normalise_service(service) in low_confidence_services
+            for service in condition
+        )
+
+        include_as_question = bool(condition) and (high_impact or touches_low_confidence)
+        include_as_question = include_as_question or (
+            has_low_confidence and high_impact and question_id not in inferred_answers
+        )
+
+        enriched = {
+            **question,
+            "assumed_answer": assumed_answer,
+            "impact_level": "high" if high_impact else "medium",
+            "reason": _question_reason(question, touches_low_confidence, inferred_answers),
+        }
+
+        if include_as_question and question_id not in inferred_answers:
+            focused.append(enriched)
+        else:
+            assumptions.append({
+                "id": question_id,
+                "question": question.get("question", ""),
+                "assumed_answer": assumed_answer,
+                "category": question.get("category", "General"),
+                "impact": question.get("impact", ""),
+                "source": "inferred" if question_id in inferred_answers else "default",
+                "needs_review": high_impact or touches_low_confidence,
+            })
+
+    return focused, assumptions
+
+
+def _low_confidence_source_services(analysis_result: dict) -> set[str]:
+    services: set[str] = set()
+    for mapping in analysis_result.get("mappings", []):
+        if mapping.get("confidence", 1.0) >= 0.8:
+            continue
+        source = mapping.get("source_service", "")
+        services.add(_normalise_service(source))
+    return services
+
+
+def _is_high_impact_question(question: dict) -> bool:
+    text = f"{question.get('id', '')} {question.get('question', '')} {question.get('impact', '')}".lower()
+    high_impact_terms = (
+        "compliance", "residency", "private", "air-gapped", "customer-managed",
+        "hsm", "high-availability", "availability", "multi-region", "disaster",
+        "rto", "sla", "region", "encryption", "network isolation", "kafka",
+        "throughput", "api", "premium", "enterprise",
+    )
+    return any(term in text for term in high_impact_terms)
+
+
+def _question_reason(question: dict, touches_low_confidence: bool, inferred_answers: dict[str, Any]) -> str:
+    question_id = question.get("id")
+    if question_id in inferred_answers:
+        return "Already inferred from the diagram or user context."
+    if touches_low_confidence:
+        return "Low-confidence mapping; this answer can materially change the target architecture."
+    return "High-impact architecture choice; reviewing it can change generated Azure resources."
+
+
 def apply_answers(analysis_result: dict, answers: dict) -> dict:
     """Apply user answers to refine an Azure architecture analysis.
 

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -13,7 +13,7 @@ import logging
 from routers.shared import SESSION_STORE, limiter, verify_api_key
 from routers.samples import get_or_recreate_session
 from usage_metrics import record_event, record_funnel_step
-from guided_questions import generate_questions, apply_answers, get_question_constraints
+from guided_questions import generate_questions, apply_answers, get_question_constraints, build_adaptive_question_set
 from mcp_diagram_generator import mcp_client
 from service_builder import deduplicate_questions, get_smart_defaults_from_analysis, add_services_from_text
 from architecture_package import generate_architecture_package
@@ -49,24 +49,33 @@ async def get_guided_questions(request: Request, diagram_id: str, smart_dedup: b
         m["source_service"]["name"] if isinstance(m["source_service"], dict) else m["source_service"]
         for m in analysis.get("mappings", [])
     ]
-    questions = generate_questions(detected)
+    all_questions = generate_questions(detected)
+    questions = all_questions
 
     # Apply smart deduplication if enabled
     inferred_answers = {}
     if smart_dedup:
         user_context = analysis.get("user_context", {})
-        questions, inferred_answers = deduplicate_questions(questions, analysis, user_context)
+        _, inferred_answers = deduplicate_questions(all_questions, analysis, user_context)
         smart_defaults = get_smart_defaults_from_analysis(analysis)
         inferred_answers = {**smart_defaults, **inferred_answers}
 
-    record_event("questions_generated", {"diagram_id": diagram_id, "count": len(questions)})
+    adaptive_questions, assumptions = build_adaptive_question_set(questions, analysis, inferred_answers)
+
+    record_event("questions_generated", {
+        "diagram_id": diagram_id,
+        "count": len(adaptive_questions),
+        "assumptions": len(assumptions),
+    })
     record_funnel_step(diagram_id, "questions")
     return {
         "diagram_id": diagram_id,
-        "questions": questions,
-        "total": len(questions),
+        "questions": adaptive_questions,
+        "all_questions": all_questions,
+        "assumptions": assumptions,
+        "total": len(adaptive_questions),
         "inferred_answers": inferred_answers,
-        "questions_skipped": len(inferred_answers),
+        "questions_skipped": len(all_questions) - len(adaptive_questions),
         **get_question_constraints(),
     }
 

--- a/backend/tests/test_guided_questions_rules.py
+++ b/backend/tests/test_guided_questions_rules.py
@@ -24,6 +24,7 @@ from guided_questions import (
     _apply_encryption,
     _apply_monitoring,
     generate_questions,
+    build_adaptive_question_set,
     apply_answers,
     QUESTION_BANK,
 )
@@ -311,6 +312,49 @@ class TestGenerateQuestions:
             assert "question" in q
             assert "options" in q
             assert "default" in q
+
+
+# ====================================================================
+# build_adaptive_question_set()
+# ====================================================================
+
+class TestAdaptiveQuestionSet:
+    def test_broad_defaults_become_visible_assumptions(self, sample_analysis):
+        questions = generate_questions(["EC2", "S3"])
+        focused, assumptions = build_adaptive_question_set(questions, sample_analysis, {})
+
+        focused_ids = {q["id"] for q in focused}
+        assumption_ids = {a["id"] for a in assumptions}
+
+        assert "env_target" not in focused_ids
+        assert "env_target" in assumption_ids
+        assert any(a["assumed_answer"] == "Production" for a in assumptions if a["id"] == "env_target")
+
+    def test_low_confidence_service_question_stays_focused(self):
+        analysis = {
+            "mappings": [
+                {"source_service": "Amazon Kinesis", "azure_service": "Event Hubs", "confidence": 0.72},
+            ],
+        }
+        questions = generate_questions(["Kinesis"])
+        focused, assumptions = build_adaptive_question_set(questions, analysis, {})
+
+        assert any(q["id"] == "data_streaming_engine" for q in focused)
+        assert not any(a["id"] == "data_streaming_engine" for a in assumptions)
+
+    def test_inferred_answer_is_not_reasked(self, sample_analysis):
+        questions = generate_questions(["EC2"])
+        focused, assumptions = build_adaptive_question_set(
+            questions,
+            sample_analysis,
+            {"arch_deploy_region": "East US"},
+        )
+
+        assert not any(q["id"] == "arch_deploy_region" for q in focused)
+        assert any(
+            a["id"] == "arch_deploy_region" and a["assumed_answer"] == "East US" and a["source"] == "inferred"
+            for a in assumptions
+        )
 
 
 # ====================================================================

--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -221,6 +221,7 @@ export default function AnalysisResults({
   copyFeedback, genProgress, notifyEmail, onNotifyEmail,
   onSetStep, onGenerateIac, onExportDiagram, onCopyWithFeedback,
   diagramId, exportCapability, onExportCapability,
+  assumptions = [], questionsCount = 0, onReviewAssumptions,
 }) {
   const [resultsView, setResultsView] = useState('card');
 
@@ -282,6 +283,34 @@ export default function AnalysisResults({
           </>
         )}
       </Card>
+
+      {assumptions.length > 0 && (
+        <Card className="p-4 border-info/20 bg-info/5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 mb-2">
+                <HelpCircle className="w-4 h-4 text-info shrink-0" />
+                <h3 className="text-sm font-semibold text-text-primary">Architecture Assumptions</h3>
+                <Badge variant="outline">{questionsCount} follow-up{questionsCount === 1 ? '' : 's'}</Badge>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                {assumptions.slice(0, 4).map(a => (
+                  <div key={a.id} className="rounded-lg border border-border/50 bg-surface/60 px-3 py-2">
+                    <p className="text-xs font-medium text-text-primary truncate" title={a.question}>{a.question}</p>
+                    <p className="text-xs text-text-muted mt-0.5 truncate" title={String(a.assumed_answer ?? '')}>{String(a.assumed_answer ?? 'Not specified')}</p>
+                  </div>
+                ))}
+              </div>
+              {assumptions.length > 4 && (
+                <p className="text-xs text-text-muted mt-2">{assumptions.length - 4} more assumption{assumptions.length - 4 === 1 ? '' : 's'} available for review.</p>
+              )}
+            </div>
+            <Button onClick={onReviewAssumptions || (() => onSetStep('questions'))} variant="secondary" icon={HelpCircle}>
+              Review assumptions
+            </Button>
+          </div>
+        </Card>
+      )}
 
       {/* Results Table / Matrix / Map toggle */}
       {analysis.mappings?.length > 0 && (

--- a/frontend/src/components/DiagramTranslator/GuidedQuestions.jsx
+++ b/frontend/src/components/DiagramTranslator/GuidedQuestions.jsx
@@ -49,16 +49,19 @@ function OptionCard({ selected, onClick, label, description, multi }) {
 }
 
 export default function GuidedQuestions({
-  analysis, questions, answers, loading,
+  analysis, questions, allQuestions = [], assumptions = [], answers, loading,
   onUpdateAnswer, onApplyAnswers, onSkip,
   constraints = [], regionGroups = {},
 }) {
+  const [showAllQuestions, setShowAllQuestions] = useState(false);
+  const displayedQuestions = showAllQuestions && allQuestions.length > 0 ? allQuestions : questions;
+
   /* ── Apply inter-question constraints ── */
   const constrainedQuestions = useMemo(() => {
-    if (!constraints.length) return questions;
+    if (!constraints.length) return displayedQuestions;
 
     // Deep-copy questions so we don't mutate the original
-    const result = questions.map(q => ({ ...q, options: [...(q.options || [])], constraintReasons: [] }));
+    const result = displayedQuestions.map(q => ({ ...q, options: [...(q.options || [])], constraintReasons: [] }));
 
     for (const rule of constraints) {
       const sourceAnswer = answers[rule.source];
@@ -92,7 +95,7 @@ export default function GuidedQuestions({
       target.constraintReasons.push(rule.reason);
     }
     return result;
-  }, [questions, answers, constraints, regionGroups]);
+  }, [displayedQuestions, answers, constraints, regionGroups]);
 
   /* ── Auto-clear answers that are no longer valid after constraint filtering ── */
   useEffect(() => {
@@ -194,17 +197,46 @@ export default function GuidedQuestions({
             </div>
           </div>
           {/* Expert / Guided toggle */}
-          <button
-            type="button"
-            onClick={toggleExpertMode}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 hover:border-cta/30 bg-secondary/10 hover:bg-secondary/20 transition-all cursor-pointer text-sm font-medium"
-          >
-            {expertMode ? <LayoutGrid className="w-4 h-4 text-cta" /> : <List className="w-4 h-4 text-text-muted" />}
-            <span className={expertMode ? 'text-cta' : 'text-text-secondary'}>
-              {expertMode ? 'Expert View' : 'Guided View'}
-            </span>
-          </button>
+          <div className="flex items-center gap-2">
+            {allQuestions.length > questions.length && (
+              <button
+                type="button"
+                onClick={() => setShowAllQuestions(prev => !prev)}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 hover:border-cta/30 bg-secondary/10 hover:bg-secondary/20 transition-all cursor-pointer text-sm font-medium text-text-secondary"
+              >
+                {showAllQuestions ? <List className="w-4 h-4 text-cta" /> : <LayoutGrid className="w-4 h-4 text-text-muted" />}
+                <span>{showAllQuestions ? 'Focused Questions' : 'All Questions'}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={toggleExpertMode}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 hover:border-cta/30 bg-secondary/10 hover:bg-secondary/20 transition-all cursor-pointer text-sm font-medium"
+            >
+              {expertMode ? <LayoutGrid className="w-4 h-4 text-cta" /> : <List className="w-4 h-4 text-text-muted" />}
+              <span className={expertMode ? 'text-cta' : 'text-text-secondary'}>
+                {expertMode ? 'Expert View' : 'Guided View'}
+              </span>
+            </button>
+          </div>
         </div>
+
+        {assumptions.length > 0 && (
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <div className="rounded-lg border border-border/50 bg-secondary/10 px-3 py-2">
+              <p className="text-xs text-text-muted">Assumptions</p>
+              <p className="text-sm font-semibold text-text-primary">{assumptions.length}</p>
+            </div>
+            <div className="rounded-lg border border-border/50 bg-secondary/10 px-3 py-2">
+              <p className="text-xs text-text-muted">Focused follow-ups</p>
+              <p className="text-sm font-semibold text-text-primary">{questions.length}</p>
+            </div>
+            <div className="rounded-lg border border-border/50 bg-secondary/10 px-3 py-2">
+              <p className="text-xs text-text-muted">Review mode</p>
+              <p className="text-sm font-semibold text-text-primary">{showAllQuestions ? 'All' : 'Focused'}</p>
+            </div>
+          </div>
+        )}
 
         {/* Overall progress */}
         <div className="mt-4">

--- a/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
@@ -47,6 +47,7 @@ describe('AnalysisResults', () => {
     onSetHldIncludeDiagrams: vi.fn(),
     onHldExport: vi.fn(),
     onCopyWithFeedback: vi.fn(),
+    onReviewAssumptions: vi.fn(),
   }
 
   it('renders diagram type title', () => {
@@ -112,6 +113,20 @@ describe('AnalysisResults', () => {
   it('renders export panel', () => {
     render(<AnalysisResults {...defaultProps} />)
     expect(screen.getByTestId('export-panel')).toBeInTheDocument()
+  })
+
+  it('shows assumptions and review action when available', async () => {
+    const user = userEvent.setup()
+    const assumptions = [
+      { id: 'env_target', question: 'What environment is this architecture for?', assumed_answer: 'Production' },
+    ]
+
+    render(<AnalysisResults {...defaultProps} assumptions={assumptions} questionsCount={2} />)
+
+    expect(screen.getByText('Architecture Assumptions')).toBeInTheDocument()
+    expect(screen.getByText('Production')).toBeInTheDocument()
+    await user.click(screen.getByText('Review assumptions'))
+    expect(defaultProps.onReviewAssumptions).toHaveBeenCalledTimes(1)
   })
 
   // Regression: GPT vision prompt tells the model to emit warnings as

--- a/frontend/src/components/DiagramTranslator/__tests__/GuidedQuestions.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/GuidedQuestions.test.jsx
@@ -126,6 +126,22 @@ describe('GuidedQuestions', () => {
     expect(defaultProps.onSkip).toHaveBeenCalledTimes(1)
   })
 
+  it('can expand from focused questions to all questions', async () => {
+    const user = userEvent.setup()
+    render(
+      <GuidedQuestions
+        {...defaultProps}
+        questions={[mockQuestions[0]]}
+        allQuestions={mockQuestions}
+        assumptions={[{ id: 'q2', question: 'Enable monitoring?', assumed_answer: 'yes' }]}
+      />
+    )
+
+    expect(screen.queryByText('Select features')).not.toBeInTheDocument()
+    await user.click(screen.getByText('All Questions'))
+    expect(screen.getByText('Select features')).toBeInTheDocument()
+  })
+
   it('calls onApplyAnswers when apply button clicked on last tab', async () => {
     const user = userEvent.setup()
     render(<GuidedQuestions {...defaultProps} />)

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -46,6 +46,31 @@ const DELIVERABLE_TABS = [
   { id: 'deploy', label: 'Deploy', icon: Rocket, feature: 'deployEngine' },
 ].filter(tab => !tab.feature || isFeatureEnabled(tab.feature));
 
+function buildQuestionState(qData = {}) {
+  const questions = qData.questions || [];
+  const allQuestions = qData.all_questions || questions;
+  const assumptions = qData.assumptions || [];
+  const answers = {};
+
+  allQuestions.forEach(q => {
+    if (q.assumed_answer !== undefined) answers[q.id] = q.assumed_answer;
+    else if (q.default !== undefined) answers[q.id] = q.default;
+  });
+  assumptions.forEach(a => {
+    if (a.assumed_answer !== undefined) answers[a.id] = a.assumed_answer;
+  });
+  Object.assign(answers, qData.inferred_answers || {});
+
+  return {
+    questions,
+    allQuestions,
+    questionAssumptions: assumptions,
+    answers,
+    questionConstraints: qData.constraints || [],
+    regionGroups: qData.region_groups || {},
+  };
+}
+
 export default function DiagramTranslator() {
   const {
     state, set, addProgress, addChatMessage,
@@ -116,6 +141,8 @@ export default function DiagramTranslator() {
         diagramId: cached.diagramId,
         analysis: cached.analysis,
         questions: cached.questions || [],
+        allQuestions: cached.allQuestions || cached.questions || [],
+        questionAssumptions: cached.questionAssumptions || [],
         answers: cached.answers || {},
         iacCode: cached.iacCode || null,
         iacFormat: cached.iacFormat || 'terraform',
@@ -142,6 +169,8 @@ export default function DiagramTranslator() {
             diagramId: data.diagram_id,
             analysis: data.analysis || null,
             questions: data.questions || [],
+            allQuestions: data.all_questions || data.questions || [],
+            questionAssumptions: data.question_assumptions || [],
             answers: data.answers || {},
             iacCode: data.iac_code || null,
             iacFormat: data.iac_format || 'terraform',
@@ -387,11 +416,13 @@ export default function DiagramTranslator() {
 
         set({ analysis: result, exportCapability: result.export_capability || state.exportCapability || null });
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
-        const questions = qData.questions || [];
-        const defaults = {};
-        questions.forEach(q => { defaults[q.id] = q.default; });
-        saveSession(diagram_id, result, questions, defaults, { exportCapability: result.export_capability || uploadData.export_capability || null });
-        set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
+        const questionState = buildQuestionState(qData);
+        saveSession(diagram_id, result, questionState.questions, questionState.answers, {
+          exportCapability: result.export_capability || uploadData.export_capability || null,
+          allQuestions: questionState.allQuestions,
+          questionAssumptions: questionState.questionAssumptions,
+        });
+        set({ ...questionState, step: 'results' });
       } else {
         // ── Fallback: sync endpoint with simulated progress ──
         addProgress('Analyzing architecture with GPT-4o Vision...');
@@ -442,11 +473,13 @@ export default function DiagramTranslator() {
 
         set({ analysis: result, exportCapability: result.export_capability || uploadData.export_capability || null });
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
-        const questions = qData.questions || [];
-        const defaults = {};
-        questions.forEach(q => { defaults[q.id] = q.default; });
-        saveSession(diagram_id, result, questions, defaults, { exportCapability: result.export_capability || uploadData.export_capability || null });
-        set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
+        const questionState = buildQuestionState(qData);
+        saveSession(diagram_id, result, questionState.questions, questionState.answers, {
+          exportCapability: result.export_capability || uploadData.export_capability || null,
+          allQuestions: questionState.allQuestions,
+          questionAssumptions: questionState.questionAssumptions,
+        });
+        set({ ...questionState, step: 'results' });
       }
     } catch (err) {
       // Handle not_architecture_diagram errors from apiClient
@@ -479,11 +512,13 @@ export default function DiagramTranslator() {
       addProgress('Sample loaded successfully \u2713');
       await new Promise(r => setTimeout(r, 600));
       const qData = await api.post(`/diagrams/${result.diagram_id}/questions`);
-      const questions = qData.questions || [];
-      const defaults = {};
-      questions.forEach(q => { defaults[q.id] = q.default; });
-      saveSession(result.diagram_id, result, questions, defaults, { exportCapability: result.export_capability || null });
-      set({ questions, answers: defaults, step: 'questions', questionConstraints: qData.constraints || [], regionGroups: qData.region_groups || {} });
+      const questionState = buildQuestionState(qData);
+      saveSession(result.diagram_id, result, questionState.questions, questionState.answers, {
+        exportCapability: result.export_capability || null,
+        allQuestions: questionState.allQuestions,
+        questionAssumptions: questionState.questionAssumptions,
+      });
+      set({ ...questionState, step: 'results' });
     } catch (err) {
       set({ error: 'Failed to load sample: ' + err.message, step: 'upload' });
     }
@@ -931,6 +966,8 @@ export default function DiagramTranslator() {
         <GuidedQuestions
           analysis={state.analysis}
           questions={state.questions}
+          allQuestions={state.allQuestions}
+          assumptions={state.questionAssumptions}
           answers={state.answers}
           loading={state.loading}
           onUpdateAnswer={updateAnswer}
@@ -953,6 +990,7 @@ export default function DiagramTranslator() {
           exportLoading={state.exportLoading}
           copyFeedback={state.copyFeedback}
           onSetStep={(step) => set({ step })}
+          onReviewAssumptions={() => set({ step: 'questions' })}
           onGenerateIac={handleGenerateAll}
           genProgress={state.genProgress}
           notifyEmail={state.notifyEmail}
@@ -961,6 +999,8 @@ export default function DiagramTranslator() {
           onCopyWithFeedback={copyWithFeedback}
           diagramId={state.diagramId}
           exportCapability={state.exportCapability}
+          assumptions={state.questionAssumptions}
+          questionsCount={(state.questions || []).length}
           onExportCapability={(token) => {
             set({ exportCapability: token });
             updateSessionCache({ exportCapability: token });

--- a/frontend/src/components/DiagramTranslator/useWorkflow.js
+++ b/frontend/src/components/DiagramTranslator/useWorkflow.js
@@ -13,6 +13,8 @@ const initialState = {
   jobId: null,
   analysis: null,
   questions: [],
+  allQuestions: [],
+  questionAssumptions: [],
   answers: {},
   iacCode: null,
   iacFormat: 'terraform',

--- a/frontend/src/services/__tests__/sessionCache.test.js
+++ b/frontend/src/services/__tests__/sessionCache.test.js
@@ -83,6 +83,19 @@ describe('sessionCache', () => {
     expect(result.answers).toEqual(answers)
   })
 
+  it('preserves adaptive question assumptions', () => {
+    const assumptions = [
+      { id: 'env_target', question: 'Environment?', assumed_answer: 'Production' },
+    ]
+    const allQuestions = [{ id: 'env_target' }, { id: 'arch_ha' }]
+
+    saveSession('d1', { zones: [] }, [], {}, { allQuestions, questionAssumptions: assumptions })
+    const result = loadSession()
+
+    expect(result.allQuestions).toEqual(allQuestions)
+    expect(result.questionAssumptions).toEqual(assumptions)
+  })
+
   it('stores timestamp for TTL checks', () => {
     const before = Date.now()
     saveSession('d1', {}, [], {})

--- a/frontend/src/services/sessionCache.js
+++ b/frontend/src/services/sessionCache.js
@@ -38,6 +38,8 @@ export function saveSession(diagramId, analysis, questions = [], answers = {}, e
   try {
     const payload = JSON.stringify({
       diagramId, analysis, questions, answers,
+      allQuestions: extra.allQuestions || [],
+      questionAssumptions: extra.questionAssumptions || [],
       iacCode: extra.iacCode || null,
       iacFormat: extra.iacFormat || null,
       hldData: extra.hldData || null,


### PR DESCRIPTION
## Summary

Closes #681.

- Route upload/sample analysis completion directly to the translated architecture draft instead of the broad questions step.
- Split generated questions into focused follow-ups and visible assumptions using confidence and impact heuristics.
- Return `all_questions` and `assumptions` from the guided-questions endpoint so deeper guided/expert refinement remains available.
- Add a results-page `Review assumptions` path and an all-questions toggle in the guided questions screen.
- Persist adaptive question metadata in session storage.

## Validation

- `cd backend && .venv/bin/python -m pytest -q tests/test_guided_questions_rules.py`
- `cd backend && .venv/bin/python -m ruff check guided_questions.py routers/analysis.py tests/test_guided_questions_rules.py`
- `cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/GuidedQuestions.test.jsx src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx src/services/__tests__/sessionCache.test.js`
- `cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/index.test.jsx`
- `cd frontend && npm run lint -- --quiet`
- `cd frontend && npm run build`
- VS Code diagnostics clean for changed backend/frontend source files.