### PR TITLE
fix(security): strengthen exportable session ids

### DIFF
--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -16,12 +16,11 @@ from pydantic import BaseModel
 from typing import Dict, Any, Optional
 import asyncio
 import base64
-import secrets
 import logging
 
 from routers.shared import (
     SESSION_STORE, IMAGE_STORE,
-    limiter, verify_api_key, MAX_UPLOAD_SIZE,
+    limiter, verify_api_key, MAX_UPLOAD_SIZE, generate_session_id,
 )
 from job_queue import job_manager
 from usage_metrics import record_event, record_funnel_step
@@ -177,7 +176,7 @@ async def upload_diagram(request: Request, project_id: str, file: UploadFile = F
     if file.content_type not in allowed_types and not is_visio and not is_drawio:
         raise ArchmorphException(400, f"File type {file.content_type} not supported. Accepted: PNG, JPG, JPEG, SVG, PDF, Draw.io, Visio.")
 
-    diagram_id = f"diag-{secrets.token_urlsafe(16)}"
+    diagram_id = generate_session_id("diag")
     # Read file in chunks with early size limit enforcement
     chunks = []
     total_size = 0

--- a/backend/routers/infra_import.py
+++ b/backend/routers/infra_import.py
@@ -8,10 +8,9 @@ Split from diagrams.py for maintainability (#284).
 from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel, Field
 import asyncio
-import uuid
 import logging
 
-from routers.shared import SESSION_STORE, limiter, verify_api_key
+from routers.shared import SESSION_STORE, limiter, verify_api_key, generate_session_id
 from usage_metrics import record_event, record_funnel_step
 from infra_import import parse_infrastructure, detect_format, InfraFormat
 
@@ -48,7 +47,7 @@ async def import_infrastructure(request: Request, body: InfraImportRequest, _aut
         except ValueError:
             raise ArchmorphException(400, f"Unsupported format: {body.format}")
 
-    diagram_id = f"import-{uuid.uuid4().hex[:8]}"
+    diagram_id = generate_session_id("import")
 
     try:
         analysis = await asyncio.to_thread(

--- a/backend/routers/samples.py
+++ b/backend/routers/samples.py
@@ -426,9 +426,9 @@ def build_sample_analysis(sample_id: str, diagram_id: str) -> dict:
     }
 
 
-import secrets as _secrets  # noqa: E402
 import re as _re  # noqa: E402
 from export_capabilities import attach_export_capability  # noqa: E402
+from routers.shared import generate_session_id  # noqa: E402
 
 
 def _sample_id_from_diagram_id(diagram_id: str) -> str | None:
@@ -478,7 +478,7 @@ async def analyze_sample_diagram(request: Request, sample_id: str):
     every downstream endpoint (questions, apply-answers, export, IaC,
     HLD, cost-estimate) works without special-casing.
     """
-    diagram_id = f"sample-{sample_id}-{_secrets.token_urlsafe(16)}"
+    diagram_id = generate_session_id(f"sample-{sample_id}")
     analysis = build_sample_analysis(sample_id, diagram_id)
     if analysis is None:
         raise ArchmorphException(404, f"Sample '{sample_id}' not found")

--- a/backend/routers/shared.py
+++ b/backend/routers/shared.py
@@ -114,6 +114,11 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
 MAX_UPLOAD_SIZE = int(os.getenv("MAX_UPLOAD_SIZE", str(10 * 1024 * 1024)))
 
 
+def generate_session_id(prefix: str) -> str:
+    """Return a URL-safe, high-entropy session identifier."""
+    return f"{prefix}-{secrets.token_urlsafe(16)}"
+
+
 # ─────────────────────────────────────────────────────────────
 # Per-session asyncio lock (#336) — prevents concurrent writes
 # from corrupting session data in the store.

--- a/backend/tests/test_session_id_entropy.py
+++ b/backend/tests/test_session_id_entropy.py
@@ -10,6 +10,10 @@ from routers.shared import generate_session_id
 
 
 URL_SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{22,}$")
+SHORT_UUID_HEX_SLICE_RE = re.compile(
+    r"uuid\s*\.\s*uuid4\s*\(\s*\)\s*\.\s*hex\s*\[\s*:\s*(\d+)\s*\]",
+)
+TOKEN_URLSAFE_RE = re.compile(r"token_urlsafe\s*\(\s*(\d+)\s*\)")
 
 
 def _assert_high_entropy_id(identifier: str, prefix: str) -> None:
@@ -79,12 +83,17 @@ def test_exportable_session_routes_do_not_use_truncated_uuid_ids():
         repo_root / "routers" / "samples.py",
         repo_root / "routers" / "infra_import.py",
     ]
-    forbidden = re.compile(r"uuid\.uuid4\(\)\.hex\[:8\]|token_urlsafe\([468]\)")
+    offenders: list[str] = []
+    for path in checked_files:
+        source = path.read_text(encoding="utf-8")
+        rel_path = str(path.relative_to(repo_root))
 
-    offenders = [
-        str(path.relative_to(repo_root))
-        for path in checked_files
-        if forbidden.search(path.read_text(encoding="utf-8"))
-    ]
+        for match in SHORT_UUID_HEX_SLICE_RE.finditer(source):
+            if int(match.group(1)) < 16:
+                offenders.append(f"{rel_path}: uuid4 hex slice {match.group(0)!r}")
+
+        for match in TOKEN_URLSAFE_RE.finditer(source):
+            if int(match.group(1)) < 16:
+                offenders.append(f"{rel_path}: token_urlsafe({match.group(1)})")
 
     assert not offenders, f"Weak exportable session ID generation in: {offenders}"

--- a/backend/tests/test_session_id_entropy.py
+++ b/backend/tests/test_session_id_entropy.py
@@ -1,0 +1,90 @@
+"""Regression tests for exportable session identifier entropy (#610)."""
+
+from __future__ import annotations
+
+import io
+import re
+from pathlib import Path
+
+from routers.shared import generate_session_id
+
+
+URL_SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{22,}$")
+
+
+def _assert_high_entropy_id(identifier: str, prefix: str) -> None:
+    assert identifier.startswith(f"{prefix}-")
+    token = identifier.removeprefix(f"{prefix}-")
+    assert URL_SAFE_TOKEN_RE.fullmatch(token), identifier
+    assert not re.fullmatch(r"[0-9a-f]{6,8}", token), identifier
+
+
+def test_generate_session_id_uses_url_safe_high_entropy_token():
+    identifier = generate_session_id("diag")
+    _assert_high_entropy_id(identifier, "diag")
+
+
+def test_upload_diagram_mints_high_entropy_diag_id(test_client):
+    response = test_client.post(
+        "/api/projects/proj-001/diagrams",
+        files={"file": ("test.png", io.BytesIO(b"\x89PNG\r\n\x1a\n" + b"0" * 50), "image/png")},
+    )
+
+    assert response.status_code == 200
+    _assert_high_entropy_id(response.json()["diagram_id"], "diag")
+
+
+def test_sample_analysis_mints_high_entropy_sample_id(test_client):
+    response = test_client.post("/api/samples/aws-iaas/analyze")
+
+    assert response.status_code == 200
+    _assert_high_entropy_id(response.json()["diagram_id"], "sample-aws-iaas")
+
+
+def test_infrastructure_import_mints_high_entropy_import_id(test_client, monkeypatch):
+    import routers.infra_import as infra_routes
+
+    def fake_parse_infrastructure(content, fmt, diagram_id):
+        return {
+            "diagram_id": diagram_id,
+            "source_format": fmt.value,
+            "services_detected": 0,
+            "source_provider": "aws",
+            "mappings": [],
+            "zones": [],
+            "service_connections": [],
+            "confidence_summary": {"high": 0, "medium": 0, "low": 0, "average": 0},
+            "architecture_patterns": [],
+        }
+
+    monkeypatch.setattr(infra_routes, "parse_infrastructure", fake_parse_infrastructure)
+
+    response = test_client.post(
+        "/api/import/infrastructure",
+        json={
+            "content": "resource \"aws_s3_bucket\" \"example\" {}",
+            "format": "terraform_hcl",
+            "filename": "main.tf",
+        },
+    )
+
+    assert response.status_code == 200
+    _assert_high_entropy_id(response.json()["diagram_id"], "import")
+
+
+def test_exportable_session_routes_do_not_use_truncated_uuid_ids():
+    repo_root = Path(__file__).resolve().parents[1]
+    checked_files = [
+        repo_root / "routers" / "diagrams.py",
+        repo_root / "routers" / "samples.py",
+        repo_root / "routers" / "infra_import.py",
+    ]
+    forbidden = re.compile(r"uuid\.uuid4\(\)\.hex\[:8\]|token_urlsafe\([468]\)")
+
+    offenders = [
+        str(path.relative_to(repo_root))
+        for path in checked_files
+        if forbidden.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert not offenders, f"Weak exportable session ID generation in: {offenders}"


### PR DESCRIPTION
## Summary
- add a shared high-entropy, URL-safe session ID helper
- use it for uploaded diagrams, sample analyses, and infrastructure imports
- add regression coverage that rejects old truncated-UUID token shapes for exportable session IDs

Closes #610.

## Verification
- `cd backend && .venv/bin/python -m pytest -q tests/test_session_id_entropy.py tests/test_sample_session_recreate.py tests/test_api.py tests/test_infra_import.py`
- `git diff --check -- backend/routers/shared.py backend/routers/diagrams.py backend/routers/samples.py backend/routers/infra_import.py backend/tests/test_session_id_entropy.py`

Note: focused pytest completed green; the run emits an existing shutdown logging warning from `usage_metrics._shutdown_flush` after tests finish.