### PR TITLE
feat: add regulated workload audit-evidence blocker

### DIFF
--- a/backend/architecture_review/__init__.py
+++ b/backend/architecture_review/__init__.py
@@ -1,0 +1,12 @@
+"""Architecture review enrichments for regulated workloads and audit evidence."""
+
+from .audit_pipeline import build_audit_pipeline_issue, detect_audit_evidence_pipeline
+from .regulated_classifier import Domain, RegulatedWorkloadClassification, classify_regulated_workload
+
+__all__ = [
+    "Domain",
+    "RegulatedWorkloadClassification",
+    "build_audit_pipeline_issue",
+    "classify_regulated_workload",
+    "detect_audit_evidence_pipeline",
+]

--- a/backend/architecture_review/audit_pipeline.py
+++ b/backend/architecture_review/audit_pipeline.py
@@ -1,0 +1,217 @@
+"""Audit-evidence pipeline detector for regulated workloads (#627)."""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from architecture_rules.models import ArchitectureIssue, Severity
+from .regulated_classifier import RegulatedWorkloadClassification, collect_text_corpus
+
+
+@dataclass(frozen=True)
+class AuditEvidenceDetection:
+    has_worm_store: bool
+    has_cross_account_or_region_copy: bool
+    has_kms_cmk: bool
+    has_retention_period: bool
+    retention_years: int | None
+    evidence: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def missing(self) -> list[str]:
+        missing: list[str] = []
+        if not self.has_worm_store:
+            missing.append("worm_store")
+        if not self.has_cross_account_or_region_copy:
+            missing.append("independent_copy")
+        if not self.has_kms_cmk:
+            missing.append("kms_cmk")
+        if not self.has_retention_period:
+            missing.append("retention_period")
+        return missing
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "has_worm_store": self.has_worm_store,
+            "has_cross_account_or_region_copy": self.has_cross_account_or_region_copy,
+            "has_kms_cmk": self.has_kms_cmk,
+            "has_retention_period": self.has_retention_period,
+            "retention_years": self.retention_years,
+            "evidence": {key: list(values) for key, values in self.evidence.items()},
+            "missing": self.missing,
+        }
+
+
+_CONTROL_PATH = Path(__file__).resolve().parent.parent / "data" / "compliance_controls.yaml"
+
+_WORM_PATTERNS = (
+    r"s3 object lock",
+    r"object lock\s*\(?compliance",
+    r"azure immutable blob",
+    r"immutability policy",
+    r"locked retention policy",
+    r"gcs bucket lock",
+    r"\bworm\b",
+    r"write once read many",
+)
+_COPY_PATTERNS = (
+    r"cross[- ]account",
+    r"cross[- ]region",
+    r"separate audit account",
+    r"replication to (?:a )?separate",
+    r"geo[- ]replication",
+)
+_KMS_PATTERNS = (
+    r"\bcmk\b",
+    r"customer[- ]managed key",
+    r"kms cmk",
+    r"azure key vault key",
+    r"cloud kms key",
+)
+_MONITORING_ONLY_PATTERNS = (
+    r"elasticsearch",
+    r"opensearch",
+    r"log analytics",
+    r"cloudwatch",
+    r"siem",
+)
+_NEGATED_EVIDENCE = re.compile(
+    r"\b(?:no|not|without|missing|lacks?|absent)\s+(?:\w+\s+){0,4}"
+    r"(?:object lock|immutable|immutability|worm|cross[- ]account|cross[- ]region|cmk|customer[- ]managed key|retention)",
+    re.IGNORECASE,
+)
+
+
+@lru_cache(maxsize=4)
+def _load_compliance_controls_cached(control_path: str) -> dict[str, Any]:
+    try:
+        with Path(control_path).open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (FileNotFoundError, OSError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_compliance_controls(path: Path | None = None) -> dict[str, Any]:
+    control_path = str(path or _CONTROL_PATH)
+    return _load_compliance_controls_cached(control_path)
+
+
+def _matches(text: str, patterns: tuple[str, ...]) -> list[str]:
+    hits: list[str] = []
+    for pattern in patterns:
+        for match in re.finditer(pattern, text, re.IGNORECASE):
+            start = max(0, match.start() - 45)
+            end = min(len(text), match.end() + 45)
+            context = text[start:end].strip()
+            if _NEGATED_EVIDENCE.search(context):
+                continue
+            hits.append(context)
+    return hits[:8]
+
+
+def _retention_years(text: str) -> int | None:
+    years: list[int] = []
+    for match in re.finditer(r"(\d{1,2})\s*(?:year|yr)s?\s*(?:retention|archive|audit)?", text, re.IGNORECASE):
+        years.append(int(match.group(1)))
+    for match in re.finditer(r"retention\s*(?:period|policy)?\D{0,20}(\d{1,2})\s*(?:year|yr)s?", text, re.IGNORECASE):
+        years.append(int(match.group(1)))
+    return max(years) if years else None
+
+
+def _required_retention_years(classification: RegulatedWorkloadClassification, controls: dict[str, Any]) -> int:
+    domains = controls.get("domains", {}) if isinstance(controls, dict) else {}
+    required = 0
+    for domain in classification.domains:
+        domain_controls = domains.get(domain.value, {}) if isinstance(domains, dict) else {}
+        for control in domain_controls.get("audit_controls", []) or []:
+            if isinstance(control, dict):
+                required = max(required, int(control.get("retention_years") or 0))
+    return required or 7
+
+
+def detect_audit_evidence_pipeline(analysis: dict[str, Any], *, required_retention_years: int = 7) -> AuditEvidenceDetection:
+    text = "\n".join(collect_text_corpus(analysis))
+    retention_years = _retention_years(text)
+    evidence = {
+        "worm_store": _matches(text, _WORM_PATTERNS),
+        "independent_copy": _matches(text, _COPY_PATTERNS),
+        "kms_cmk": _matches(text, _KMS_PATTERNS),
+        "monitoring_only": _matches(text, _MONITORING_ONLY_PATTERNS),
+    }
+    if retention_years is not None:
+        evidence["retention_period"] = [f"{retention_years} year retention"]
+    return AuditEvidenceDetection(
+        has_worm_store=bool(evidence["worm_store"]),
+        has_cross_account_or_region_copy=bool(evidence["independent_copy"]),
+        has_kms_cmk=bool(evidence["kms_cmk"]),
+        has_retention_period=retention_years is not None and retention_years >= required_retention_years,
+        retention_years=retention_years,
+        evidence={key: value for key, value in evidence.items() if value},
+    )
+
+
+def _required_by(classification: RegulatedWorkloadClassification, controls: dict[str, Any]) -> list[str]:
+    domains = controls.get("domains", {}) if isinstance(controls, dict) else {}
+    required: list[str] = []
+    for domain in classification.domains:
+        domain_controls = domains.get(domain.value, {}) if isinstance(domains, dict) else {}
+        required.extend(str(item) for item in domain_controls.get("frameworks", []) or [])
+    return list(dict.fromkeys(required))
+
+
+def build_audit_pipeline_issue(
+    analysis: dict[str, Any],
+    classification: RegulatedWorkloadClassification,
+    *,
+    controls: dict[str, Any] | None = None,
+) -> ArchitectureIssue | None:
+    if not classification.domains:
+        return None
+    controls = controls or load_compliance_controls()
+    required_retention = _required_retention_years(classification, controls)
+    detection = detect_audit_evidence_pipeline(analysis, required_retention_years=required_retention)
+    if not detection.missing:
+        return None
+
+    domain_names = [domain.value for domain in classification.domains]
+    required_by = _required_by(classification, controls)
+    missing_titles = {
+        "worm_store": "immutable/WORM evidence store",
+        "independent_copy": "cross-account or cross-region audit copy",
+        "kms_cmk": "customer-managed key protection",
+        "retention_period": f"documented retention period >= {required_retention} years",
+    }
+    missing_text = ", ".join(missing_titles[key] for key in detection.missing)
+
+    return ArchitectureIssue(
+        rule_id="regulated-workload-audit-evidence-pipeline-missing",
+        severity=Severity.BLOCKER,
+        category="compliance-audit",
+        title="Regulated-workload audit-evidence pipeline missing",
+        message=(
+            "Regulated workload signals were detected, but the architecture does not show "
+            f"all required audit-evidence controls: {missing_text}."
+        ),
+        remediation=(
+            "Add an immutable audit pipeline with WORM storage, independent replication, "
+            "customer-managed keys, and a documented retention period aligned to the detected regimes."
+        ),
+        docs_url="https://learn.microsoft.com/azure/storage/blobs/immutable-storage-overview",
+        affected_services=[],
+        source="curated",
+        evidence={
+            "display_severity": "critical",
+            "domains": domain_names,
+            "confidence": classification.confidence,
+            "required_by": required_by,
+            "required_retention_years": required_retention,
+            "pipeline": detection.to_dict(),
+        },
+    )

--- a/backend/architecture_review/regulated_classifier.py
+++ b/backend/architecture_review/regulated_classifier.py
@@ -1,0 +1,190 @@
+"""Regulated-workload classifier for architecture review (#627)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable
+
+
+class Domain(str, Enum):
+    FINANCIAL_CRIME = "financial_crime"
+    PCI = "pci"
+    HIPAA = "hipaa"
+    GDPR = "gdpr"
+    FEDRAMP = "fedramp"
+    BANKING_MODEL_RISK = "banking_model_risk"
+
+
+@dataclass(frozen=True)
+class RegulatedWorkloadClassification:
+    domains: list[Domain]
+    confidence: dict[str, float]
+    evidence: dict[str, list[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "is_regulated": bool(self.domains),
+            "domains": [domain.value for domain in self.domains],
+            "confidence": dict(self.confidence),
+            "evidence": {key: list(values) for key, values in self.evidence.items()},
+        }
+
+
+_DOMAIN_SIGNALS: dict[Domain, tuple[tuple[str, float], ...]] = {
+    Domain.FINANCIAL_CRIME: (
+        (r"\baml\b", 0.55),
+        (r"\bsar\b", 0.45),
+        (r"\bkyc\b", 0.45),
+        (r"transaction monitoring", 0.45),
+        (r"financial crime|fincrime", 0.45),
+        (r"actimize", 0.4),
+        (r"case investigation|case management", 0.25),
+        (r"fraud", 0.2),
+    ),
+    Domain.PCI: (
+        (r"\bpci(?:[- ]?dss)?\b", 0.55),
+        (r"cardholder", 0.5),
+        (r"\bpan\b", 0.45),
+        (r"card token|tokenized card|payment token", 0.4),
+        (r"payment processor|checkout", 0.3),
+        (r"payment", 0.15),
+    ),
+    Domain.HIPAA: (
+        (r"\bhipaa\b", 0.6),
+        (r"\bphi\b", 0.5),
+        (r"\behr\b|\bemr\b", 0.4),
+        (r"patient", 0.3),
+        (r"healthcare|medical|claims", 0.25),
+        (r"\bfhir\b|\bhl7\b", 0.3),
+    ),
+    Domain.GDPR: (
+        (r"\bgdpr\b", 0.6),
+        (r"\bdsar\b|subject access", 0.45),
+        (r"personal data|personally identifiable|\bpii\b", 0.4),
+        (r"data subject", 0.35),
+        (r"eu user|european user|consent", 0.2),
+    ),
+    Domain.FEDRAMP: (
+        (r"\bfedramp\b", 0.65),
+        (r"\bil[245]\b", 0.45),
+        (r"govcloud|azure government", 0.45),
+        (r"\bcjis\b|\bfisma\b", 0.4),
+        (r"\.gov\b|government agency", 0.25),
+    ),
+    Domain.BANKING_MODEL_RISK: (
+        (r"sr[- ]?11[- ]?7", 0.65),
+        (r"model risk", 0.5),
+        (r"credit scoring", 0.4),
+        (r"regulatory reporting", 0.35),
+        (r"model validation|challenger model", 0.35),
+    ),
+}
+
+_NEGATED_CONTEXT = re.compile(
+    r"\b(?:not|non|no|without|excludes?)\s+(?:\w+\s+){0,3}"
+    r"(?:pci|hipaa|phi|aml|sar|kyc|gdpr|fedramp|pan|cardholder)\b",
+    re.IGNORECASE,
+)
+
+
+def _flatten(value: Any) -> Iterable[str]:
+    if value is None:
+        return
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            yield stripped
+        return
+    if isinstance(value, (int, float, bool)):
+        yield str(value)
+        return
+    if isinstance(value, dict):
+        for key, inner in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from _flatten(inner)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from _flatten(item)
+
+
+def collect_text_corpus(analysis: dict[str, Any]) -> list[str]:
+    if not isinstance(analysis, dict):
+        return []
+
+    preferred_keys = (
+        "description",
+        "summary",
+        "diagram_text",
+        "ocr_text",
+        "raw_text",
+        "filename",
+        "source_file",
+        "identified_services",
+        "mappings",
+        "service_connections",
+        "service_to_resource_mapping",
+        "iac",
+        "iac_code",
+        "metadata",
+    )
+    corpus: list[str] = []
+    for key in preferred_keys:
+        if key in analysis:
+            corpus.extend(_flatten(analysis.get(key)) or [])
+    corpus.extend(_flatten({k: v for k, v in analysis.items() if k not in preferred_keys}) or [])
+    return list(dict.fromkeys(corpus))
+
+
+def _score_domain(text: str, domain: Domain) -> tuple[float, list[str]]:
+    evidence: list[str] = []
+    score = 0.0
+    for pattern, weight in _DOMAIN_SIGNALS[domain]:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if not match:
+            continue
+        start = max(0, match.start() - 45)
+        end = min(len(text), match.end() + 45)
+        context = text[start:end].strip()
+        if _NEGATED_CONTEXT.search(context):
+            continue
+        score += weight
+        evidence.append(context)
+
+    if domain == Domain.FINANCIAL_CRIME:
+        if re.search(r"\bsar\b", text, re.IGNORECASE) and not re.search(
+            r"aml|kyc|fraud|transaction|case|regulatory|filing", text, re.IGNORECASE
+        ):
+            score = min(score, 0.35)
+    if domain == Domain.PCI and re.search(r"payment", text, re.IGNORECASE) and not re.search(
+        r"pci|pan|cardholder|card token|tokenized card|processor|checkout", text, re.IGNORECASE
+    ):
+        score = min(score, 0.35)
+    if domain == Domain.FEDRAMP and re.search(r"government", text, re.IGNORECASE) and not re.search(
+        r"fedramp|govcloud|azure government|\bil[245]\b|cjis|fisma|\.gov", text, re.IGNORECASE
+    ):
+        score = min(score, 0.35)
+    if domain == Domain.BANKING_MODEL_RISK and re.search(r"\bmodel\b", text, re.IGNORECASE) and not re.search(
+        r"model risk|credit scoring|regulatory reporting|validation|sr[- ]?11[- ]?7", text, re.IGNORECASE
+    ):
+        score = min(score, 0.35)
+
+    return min(round(score, 2), 1.0), evidence[:6]
+
+
+def classify_regulated_workload(analysis: dict[str, Any], *, threshold: float = 0.6) -> RegulatedWorkloadClassification:
+    text = "\n".join(collect_text_corpus(analysis))
+    domains: list[Domain] = []
+    confidence: dict[str, float] = {}
+    evidence: dict[str, list[str]] = {}
+    for domain in Domain:
+        score, domain_evidence = _score_domain(text, domain)
+        if score >= threshold:
+            domains.append(domain)
+            confidence[domain.value] = score
+            evidence[domain.value] = domain_evidence
+    domains.sort(key=lambda domain: confidence.get(domain.value, 0), reverse=True)
+    return RegulatedWorkloadClassification(domains=domains, confidence=confidence, evidence=evidence)

--- a/backend/data/compliance_controls.yaml
+++ b/backend/data/compliance_controls.yaml
@@ -1,0 +1,59 @@
+domains:
+  financial_crime:
+    frameworks:
+      - BSA/AML
+      - SOX 404
+      - NYDFS-500 §500.06
+      - GDPR Art. 30
+    audit_controls:
+      - framework: BSA/AML
+        control: Suspicious activity and transaction-monitoring audit retention
+        retention_years: 7
+      - framework: SOX 404
+        control: Internal-control evidence integrity
+        retention_years: 7
+      - framework: NYDFS-500
+        control: §500.06 audit trail
+        retention_years: 7
+  pci:
+    frameworks:
+      - PCI-DSS 10
+    audit_controls:
+      - framework: PCI-DSS
+        control: Audit logs for cardholder data access and security events
+        retention_years: 1
+  hipaa:
+    frameworks:
+      - HIPAA §164.312(b)
+      - HIPAA §164.316(b)(2)(i)
+    audit_controls:
+      - framework: HIPAA
+        control: PHI audit controls and documentation retention
+        retention_years: 10
+  gdpr:
+    frameworks:
+      - GDPR Art. 30
+      - GDPR Art. 32
+      - GDPR Art. 33
+    audit_controls:
+      - framework: GDPR
+        control: Records of processing and breach-investigation evidence
+        retention_years: 7
+  fedramp:
+    frameworks:
+      - FedRAMP AU-2
+      - FedRAMP AU-9
+      - FedRAMP AU-11
+      - FedRAMP SC-13
+    audit_controls:
+      - framework: FedRAMP
+        control: Protected audit records and retention
+        retention_years: 7
+  banking_model_risk:
+    frameworks:
+      - SR-11-7
+      - SOX 404
+    audit_controls:
+      - framework: SR-11-7
+        control: Model validation, approval, and monitoring evidence
+        retention_years: 7

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -34,6 +34,7 @@ from error_envelope import ArchmorphException
 from sku_translator import get_sku_translator
 from confidence_provenance import build_provenance
 from architecture_rules import evaluate as evaluate_architecture_rules
+from architecture_review import build_audit_pipeline_issue, classify_regulated_workload
 from source_provider import normalize_source_provider
 
 logger = logging.getLogger(__name__)
@@ -98,6 +99,11 @@ def _enrich_with_architecture_issues(result: dict) -> dict:
     """
     try:
         issues = evaluate_architecture_rules(result)
+        classification = classify_regulated_workload(result)
+        result["regulated_workload"] = classification.to_dict()
+        audit_issue = build_audit_pipeline_issue(result, classification)
+        if audit_issue is not None:
+            issues.append(audit_issue)
         issue_dicts = [i.to_dict() for i in issues]
         summary = {"blocker": 0, "warning": 0, "info": 0, "total": len(issue_dicts)}
         for d in issue_dicts:

--- a/backend/tests/fixtures/actone_xse_regulated.json
+++ b/backend/tests/fixtures/actone_xse_regulated.json
@@ -1,0 +1,20 @@
+{
+  "description": "ActOne XSE case investigation platform for AML, SAR filing, KYC review, fraud triage, transaction monitoring, and GDPR personal data handling.",
+  "identified_services": [
+    {"name": "Case Management API", "category": "Application"},
+    {"name": "Transaction Monitoring Engine", "category": "Application"},
+    {"name": "Self-managed ElasticSearch audit logs", "category": "Monitoring"},
+    {"name": "PostgreSQL customer records", "category": "Database"}
+  ],
+  "mappings": [
+    {"source_service": "Self-managed ElasticSearch", "azure_service": "Azure Monitor", "category": "Monitoring"},
+    {"source_service": "PostgreSQL customer records", "azure_service": "Azure Database for PostgreSQL", "category": "Database"}
+  ],
+  "service_connections": [
+    {"from": "Case Management API", "to": "Self-managed ElasticSearch audit logs", "type": "log stream"}
+  ],
+  "metadata": {
+    "file_name": "actone-xse-aml-gdpr.drawio",
+    "notes": "The diagram shows operational monitoring only; it does not show a compliant durable audit-evidence pipeline."
+  }
+}

--- a/backend/tests/test_regulated_workload.py
+++ b/backend/tests/test_regulated_workload.py
@@ -1,0 +1,132 @@
+"""Tests for regulated workload detection and audit-evidence review (#627)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from architecture_review.audit_pipeline import (  # noqa: E402
+    build_audit_pipeline_issue,
+    detect_audit_evidence_pipeline,
+    load_compliance_controls,
+)
+from architecture_review.regulated_classifier import (  # noqa: E402
+    Domain,
+    classify_regulated_workload,
+)
+from routers.diagrams import _normalize_analysis  # noqa: E402
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_actone_xse_detects_financial_crime_and_gdpr():
+    result = classify_regulated_workload(_fixture("actone_xse_regulated.json"))
+
+    assert Domain.FINANCIAL_CRIME in result.domains
+    assert Domain.GDPR in result.domains
+    assert result.confidence[Domain.FINANCIAL_CRIME.value] >= 0.8
+    assert result.evidence[Domain.FINANCIAL_CRIME.value]
+
+
+def test_generic_saas_does_not_overfire_on_payment_word_alone():
+    analysis = {
+        "description": "SaaS settings page with payment preferences and generic app logs.",
+        "identified_services": ["Web App", "PostgreSQL", "Log Analytics"],
+    }
+
+    result = classify_regulated_workload(analysis)
+
+    assert result.domains == []
+    assert result.to_dict()["is_regulated"] is False
+
+
+def test_audit_pipeline_missing_controls_emits_blocker_critical_issue():
+    analysis = _fixture("actone_xse_regulated.json")
+    classification = classify_regulated_workload(analysis)
+
+    issue = build_audit_pipeline_issue(analysis, classification)
+
+    assert issue is not None
+    assert issue.rule_id == "regulated-workload-audit-evidence-pipeline-missing"
+    assert issue.severity.value == "blocker"
+    assert issue.evidence["display_severity"] == "critical"
+    assert issue.evidence["pipeline"]["missing"] == [
+        "worm_store",
+        "independent_copy",
+        "kms_cmk",
+        "retention_period",
+    ]
+    assert issue.affected_services == []
+
+
+def test_compliance_controls_fail_open_when_file_missing(tmp_path):
+    missing_path = tmp_path / "missing-controls.yaml"
+
+    assert load_compliance_controls(missing_path) == {}
+
+
+def test_worm_matching_does_not_match_substrings():
+    analysis = {
+        "description": (
+            "AML audit telemetry mentions a tapeworm incident in an unrelated note, "
+            "with 7 year retention, cross-account copy, and KMS CMK."
+        )
+    }
+
+    detection = detect_audit_evidence_pipeline(analysis, required_retention_years=7)
+
+    assert "worm_store" in detection.missing
+
+
+def test_complete_aml_pipeline_suppresses_blocker():
+    analysis = {
+        "description": (
+            "AML and SAR transaction monitoring writes audit events to S3 Object Lock "
+            "compliance mode with 7 year retention, cross-account replication to a "
+            "separate audit account, and KMS CMK customer-managed key protection."
+        ),
+        "identified_services": ["Kinesis Firehose", "S3 Object Lock", "AWS KMS CMK"],
+    }
+    classification = classify_regulated_workload(analysis)
+    detection = detect_audit_evidence_pipeline(analysis, required_retention_years=7)
+
+    assert Domain.FINANCIAL_CRIME in classification.domains
+    assert detection.missing == []
+    assert build_audit_pipeline_issue(analysis, classification) is None
+
+
+def test_hipaa_requires_ten_year_retention():
+    analysis = {
+        "description": (
+            "HIPAA PHI patient audit events go to Azure immutable Blob with cross-region "
+            "replication, customer-managed key in Azure Key Vault, and 7 year retention."
+        )
+    }
+    classification = classify_regulated_workload(analysis)
+
+    issue = build_audit_pipeline_issue(analysis, classification)
+
+    assert Domain.HIPAA in classification.domains
+    assert issue is not None
+    assert issue.evidence["required_retention_years"] == 10
+    assert "retention_period" in issue.evidence["pipeline"]["missing"]
+
+
+def test_diagram_normalization_adds_regulated_contract_and_blocker_summary():
+    result = _normalize_analysis(_fixture("actone_xse_regulated.json"))
+
+    assert result["regulated_workload"]["is_regulated"] is True
+    assert "financial_crime" in result["regulated_workload"]["domains"]
+    issue_ids = {issue["rule_id"] for issue in result["architecture_issues"]}
+    assert "regulated-workload-audit-evidence-pipeline-missing" in issue_ids
+    assert result["architecture_issues_summary"]["blocker"] >= 1


### PR DESCRIPTION
## Summary
- Adds a regulated-workload classifier for financial crime, PCI, HIPAA, GDPR, FedRAMP, and banking/model-risk signals.
- Adds an audit-evidence pipeline detector for immutable/WORM storage, independent copy, customer-managed keys, and retention period coverage.
- Integrates the detector into diagram normalization so missing regulated audit controls emit an existing `severity=blocker` architecture issue with `evidence.display_severity=critical`, allowing the existing IaC blocker gate to work unchanged.
- Adds compliance-control reference data and regression fixtures for the ActOne XSE-style regulated workload.

Closes #627.

## Validation
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check architecture_review routers/diagrams.py tests/test_regulated_workload.py`
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_regulated_workload.py tests/test_iac_blocker_gate.py`
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_architecture_rules.py tests/test_regulated_workload.py tests/test_iac_blocker_gate.py`