### PR TITLE
fix: render service-level export edges

### DIFF
--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -451,8 +451,23 @@ text {{ font-family: {FONT_STACK}; }}
 <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
   <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_RED}"/>
 </marker>
-<marker id="aflow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke"/>
+<marker id="aflow-default" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_INK_2}"/>
+</marker>
+<marker id="aflow-db" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_DB}"/>
+</marker>
+<marker id="aflow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_PURPLE}"/>
+</marker>
+<marker id="aflow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_RED}"/>
+</marker>
+<marker id="aflow-primary" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_PRIMARY}"/>
+</marker>
+<marker id="aflow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_GREEN}"/>
 </marker>
 </defs>"""
 
@@ -1047,23 +1062,27 @@ def _service_connection_flow(analysis: dict[str, Any]) -> str:
         ex, ey = end[0], end[1] + offset
         mid_x = (sx + ex) / 2
         control_y = min(sy, ey) - 44 if abs(sy - ey) < 140 else (sy + ey) / 2
-        color = {
-            "database": COLOR_DB,
-            "auth": COLOR_PURPLE,
-            "security": COLOR_RED,
-            "inspection": COLOR_RED,
-            "storage": COLOR_PRIMARY,
-            "metrics": COLOR_GREEN,
-        }.get(str(conn.get("type") or "traffic").lower(), COLOR_INK_2)
+        color, marker_id = _flow_color_and_marker(str(conn.get("type") or "traffic").lower())
         out.append(
             f'<path class="service-flow-edge" d="M {sx:.1f} {sy:.1f} Q {mid_x:.1f} {control_y:.1f} {ex:.1f} {ey:.1f}" '
-            f'stroke="{color}" stroke-width="2.2" fill="none" stroke-opacity="0.82" marker-end="url(#aflow)"/>'
+            f'stroke="{color}" stroke-width="2.2" fill="none" stroke-opacity="0.82" marker-end="url(#{marker_id})"/>'
         )
         out.append(_tx(mid_x, control_y - 6, _truncate(label, 26), "t-flow", anchor="middle"))
         rendered += 1
 
     out.append('</g>')
     return "\n".join(out) if rendered else ""
+
+
+def _flow_color_and_marker(conn_type: str) -> tuple[str, str]:
+    return {
+        "database": (COLOR_DB, "aflow-db"),
+        "auth": (COLOR_PURPLE, "aflow-purple"),
+        "security": (COLOR_RED, "aflow-red"),
+        "inspection": (COLOR_RED, "aflow-red"),
+        "storage": (COLOR_PRIMARY, "aflow-primary"),
+        "metrics": (COLOR_GREEN, "aflow-green"),
+    }.get(conn_type, (COLOR_INK_2, "aflow-default"))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -32,6 +32,12 @@ from azure_landing_zone_schema import (
     infer_replication,
     infer_tiers_from_mappings,
 )
+from service_connection_utils import (
+    connection_endpoint,
+    connection_label,
+    mapping_aliases,
+    service_key,
+)
 from source_provider import (
     SUPPORTED_SOURCE_PROVIDERS as _SUPPORTED_SOURCE_PROVIDERS,
     normalize_source_provider,
@@ -444,6 +450,9 @@ text {{ font-family: {FONT_STACK}; }}
 </marker>
 <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
   <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_RED}"/>
+</marker>
+<marker id="aflow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke"/>
 </marker>
 </defs>"""
 
@@ -994,41 +1003,8 @@ def _data_band(tiers: dict[str, list[dict[str, Any]]]) -> str:
     return "\n".join(out)
 
 
-def _service_key(value: Any) -> str:
-    text = str(value or "").lower().strip()
-    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
-    return re.sub(r"[^a-z0-9]+", "", text)
-
-
-def _connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:
-    return str(conn.get(primary) or conn.get(secondary) or "")
-
-
-def _connection_label(conn: dict[str, Any]) -> str:
-    protocol = str(conn.get("protocol") or "").strip()
-    conn_type = str(conn.get("type") or "").strip()
-    bits = [bit for bit in (protocol, conn_type) if bit]
-    return " · ".join(bits)
-
-
-def _mapping_aliases(analysis: dict[str, Any]) -> dict[str, str]:
-    aliases: dict[str, str] = {}
-    for mapping in analysis.get("mappings") or []:
-        if not isinstance(mapping, dict):
-            continue
-        azure = str(mapping.get("azure_service") or mapping.get("target") or "").strip()
-        if not azure:
-            continue
-        for field in ("source_service", "aws_service", "gcp_service", "source", "azure_service", "target"):
-            value = mapping.get(field)
-            if value:
-                aliases[_service_key(value)] = azure
-        aliases[_service_key(azure)] = azure
-    return aliases
-
-
 def _flow_anchor(service_name: str) -> tuple[float, float] | None:
-    key = _service_key(service_name)
+    key = service_key(service_name)
     checks: list[tuple[tuple[str, ...], tuple[float, float]]] = [
         (("enduser", "user", "client", "partnerapi", "internaladmin"), (100, 142)),
         (("frontdoor", "cloudfront"), (1010, 264)),
@@ -1053,19 +1029,19 @@ def _service_connection_flow(analysis: dict[str, Any]) -> str:
     if not connections:
         return ""
 
-    aliases = _mapping_aliases(analysis)
+    aliases = mapping_aliases(analysis.get("mappings") or [])
     out = ['<g id="service-flow" data-source="service_connections">']
     rendered = 0
-    for conn in connections[:40]:
-        source = _connection_endpoint(conn, "from", "source")
-        target = _connection_endpoint(conn, "to", "target")
-        source_name = aliases.get(_service_key(source), source)
-        target_name = aliases.get(_service_key(target), target)
+    for conn in connections:
+        source = connection_endpoint(conn, "from", "source")
+        target = connection_endpoint(conn, "to", "target")
+        source_name = aliases.get(service_key(source), source)
+        target_name = aliases.get(service_key(target), target)
         start = _flow_anchor(source_name)
         end = _flow_anchor(target_name)
         if not start or not end or start == end:
             continue
-        label = _connection_label(conn) or "flow"
+        label = connection_label(conn) or "flow"
         offset = (rendered % 5 - 2) * 8
         sx, sy = start[0], start[1] + offset
         ex, ey = end[0], end[1] + offset
@@ -1081,7 +1057,7 @@ def _service_connection_flow(analysis: dict[str, Any]) -> str:
         }.get(str(conn.get("type") or "traffic").lower(), COLOR_INK_2)
         out.append(
             f'<path class="service-flow-edge" d="M {sx:.1f} {sy:.1f} Q {mid_x:.1f} {control_y:.1f} {ex:.1f} {ey:.1f}" '
-            f'stroke="{color}" stroke-width="2.2" fill="none" stroke-opacity="0.82" marker-end="url(#a)"/>'
+            f'stroke="{color}" stroke-width="2.2" fill="none" stroke-opacity="0.82" marker-end="url(#aflow)"/>'
         )
         out.append(_tx(mid_x, control_y - 6, _truncate(label, 26), "t-flow", anchor="middle"))
         rendered += 1

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -434,6 +434,7 @@ text {{ font-family: {FONT_STACK}; }}
 .t-actor-h   {{ font-size: 12px; font-weight: 700; fill: {COLOR_INK}; }}
 .t-traffic-g {{ font-size: 12px; font-weight: 700; fill: {COLOR_GREEN}; }}
 .t-traffic-r {{ font-size: 12px; font-weight: 700; fill: {COLOR_RED}; }}
+.t-flow      {{ font-size: 10px; font-weight: 700; fill: {COLOR_INK}; }}
 ]]></style>
 <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
   <path d="M 0 0 L 10 5 L 0 10 z" fill="{COLOR_INK_2}"/>
@@ -993,6 +994,102 @@ def _data_band(tiers: dict[str, list[dict[str, Any]]]) -> str:
     return "\n".join(out)
 
 
+def _service_key(value: Any) -> str:
+    text = str(value or "").lower().strip()
+    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
+    return re.sub(r"[^a-z0-9]+", "", text)
+
+
+def _connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:
+    return str(conn.get(primary) or conn.get(secondary) or "")
+
+
+def _connection_label(conn: dict[str, Any]) -> str:
+    protocol = str(conn.get("protocol") or "").strip()
+    conn_type = str(conn.get("type") or "").strip()
+    bits = [bit for bit in (protocol, conn_type) if bit]
+    return " · ".join(bits)
+
+
+def _mapping_aliases(analysis: dict[str, Any]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for mapping in analysis.get("mappings") or []:
+        if not isinstance(mapping, dict):
+            continue
+        azure = str(mapping.get("azure_service") or mapping.get("target") or "").strip()
+        if not azure:
+            continue
+        for field in ("source_service", "aws_service", "gcp_service", "source", "azure_service", "target"):
+            value = mapping.get(field)
+            if value:
+                aliases[_service_key(value)] = azure
+        aliases[_service_key(azure)] = azure
+    return aliases
+
+
+def _flow_anchor(service_name: str) -> tuple[float, float] | None:
+    key = _service_key(service_name)
+    checks: list[tuple[tuple[str, ...], tuple[float, float]]] = [
+        (("enduser", "user", "client", "partnerapi", "internaladmin"), (100, 142)),
+        (("frontdoor", "cloudfront"), (1010, 264)),
+        (("applicationgateway", "appgateway", "alb", "apimanagement"), (535, 416)),
+        (("aks", "kubernetesservice", "eks", "containerapps", "appservice", "azurefunctions", "functions"), (770, 610)),
+        (("azuresqldatabase", "azuresql", "sqldatabase", "sql", "cosmosdb", "azurecacheforredis", "cacheforredis", "redis"), (740, 995)),
+        (("blobstorage", "azurefiles", "manageddisks", "storage"), (240, 416)),
+        (("eventhubs", "servicebus", "servicebusqueues", "eventgrid", "logicapps"), (1040, 995)),
+        (("microsoftentraid", "entraid", "keyvault", "conditionalaccess"), (1580, 416)),
+        (("applicationinsights", "azuremonitor", "loganalytics", "activitylog"), (1090, 416)),
+        (("waf", "ddosprotection", "defenderforcloud"), (1620, 560)),
+    ]
+    for needles, point in checks:
+        if any(needle in key for needle in needles):
+            return point
+    return None
+
+
+def _service_connection_flow(analysis: dict[str, Any]) -> str:
+    """Overlay service-level flow paths from analysis service_connections."""
+    connections = [c for c in analysis.get("service_connections") or [] if isinstance(c, dict)]
+    if not connections:
+        return ""
+
+    aliases = _mapping_aliases(analysis)
+    out = ['<g id="service-flow" data-source="service_connections">']
+    rendered = 0
+    for conn in connections[:40]:
+        source = _connection_endpoint(conn, "from", "source")
+        target = _connection_endpoint(conn, "to", "target")
+        source_name = aliases.get(_service_key(source), source)
+        target_name = aliases.get(_service_key(target), target)
+        start = _flow_anchor(source_name)
+        end = _flow_anchor(target_name)
+        if not start or not end or start == end:
+            continue
+        label = _connection_label(conn) or "flow"
+        offset = (rendered % 5 - 2) * 8
+        sx, sy = start[0], start[1] + offset
+        ex, ey = end[0], end[1] + offset
+        mid_x = (sx + ex) / 2
+        control_y = min(sy, ey) - 44 if abs(sy - ey) < 140 else (sy + ey) / 2
+        color = {
+            "database": COLOR_DB,
+            "auth": COLOR_PURPLE,
+            "security": COLOR_RED,
+            "inspection": COLOR_RED,
+            "storage": COLOR_PRIMARY,
+            "metrics": COLOR_GREEN,
+        }.get(str(conn.get("type") or "traffic").lower(), COLOR_INK_2)
+        out.append(
+            f'<path class="service-flow-edge" d="M {sx:.1f} {sy:.1f} Q {mid_x:.1f} {control_y:.1f} {ex:.1f} {ey:.1f}" '
+            f'stroke="{color}" stroke-width="2.2" fill="none" stroke-opacity="0.82" marker-end="url(#a)"/>'
+        )
+        out.append(_tx(mid_x, control_y - 6, _truncate(label, 26), "t-flow", anchor="middle"))
+        rendered += 1
+
+    out.append('</g>')
+    return "\n".join(out) if rendered else ""
+
+
 # ---------------------------------------------------------------------------
 # Replication band (DR variant)
 # ---------------------------------------------------------------------------
@@ -1143,6 +1240,9 @@ def generate_landing_zone_svg(
                     status="primary",
                     role_text=primary_role_text,
                 ))
+                flow_overlay = _service_connection_flow(analysis)
+                if flow_overlay:
+                    parts.append(flow_overlay)
 
                 if dr_variant == "primary":
                     # Collapsed Region 2 banner if a second region is configured.

--- a/backend/diagram_export.py
+++ b/backend/diagram_export.py
@@ -94,6 +94,68 @@ def _service_source_name(service: Any) -> str:
     return str(service)
 
 
+def _service_key(value: Any) -> str:
+    """Stable fuzzy key for matching connection endpoints to rendered services."""
+    text = str(value or "").lower().strip()
+    text = re.sub(r"\[[^\]]+\]", "", text)
+    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
+    text = re.sub(r"[^a-z0-9]+", "", text)
+    return text
+
+
+def _connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:
+    return str(conn.get(primary) or conn.get(secondary) or "")
+
+
+def _connection_label(conn: dict[str, Any]) -> str:
+    protocol = str(conn.get("protocol") or "").strip()
+    conn_type = str(conn.get("type") or "").strip()
+    bits = [bit for bit in (protocol, conn_type) if bit]
+    return " · ".join(bits)
+
+
+def _mapping_aliases(mappings: list[dict[str, Any]]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for mapping in mappings:
+        azure = str(mapping.get("azure_service") or mapping.get("target") or "").strip()
+        if not azure:
+            continue
+        for field in ("source_service", "aws_service", "gcp_service", "source", "azure_service", "target"):
+            value = mapping.get(field)
+            if value:
+                aliases[_service_key(value)] = azure
+        aliases[_service_key(azure)] = azure
+    return aliases
+
+
+def _resolved_connection_endpoint(endpoint: str, aliases: dict[str, str]) -> str:
+    return aliases.get(_service_key(endpoint), endpoint)
+
+
+def _services_for_export_zones(zones: list[dict[str, Any]], mappings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure exports have service nodes even when analysis zones are metadata-only."""
+    if any(zone.get("services") for zone in zones if isinstance(zone, dict)):
+        return zones
+
+    if not mappings:
+        return zones
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for mapping in mappings:
+        category = str(mapping.get("category") or "Other").strip() or "Other"
+        grouped.setdefault(category, []).append(mapping)
+
+    synthesized: list[dict[str, Any]] = []
+    for idx, (category, category_mappings) in enumerate(grouped.items(), start=1):
+        synthesized.append({
+            "id": idx,
+            "number": idx,
+            "name": category,
+            "services": category_mappings,
+        })
+    return synthesized
+
+
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
@@ -948,8 +1010,9 @@ def _drawio_style(base: str = "rounded=1;whiteSpace=wrap;html=1;", **kw: str) ->
 
 
 def _generate_drawio(analysis: dict) -> dict:
-    zones = analysis.get("zones", [])
     mappings = analysis.get("mappings", [])
+    zones = _services_for_export_zones(analysis.get("zones", []), mappings)
+    connections = analysis.get("service_connections", [])
     title = analysis.get("title", "Azure Architecture Diagram")
 
     # Build mapping lookup
@@ -1016,6 +1079,7 @@ def _generate_drawio(analysis: dict) -> dict:
 
     zone_rects: list[dict] = []
     zone_ids: list[str] = []
+    service_ids: dict[str, str] = {}
 
     for idx, zone in enumerate(zones):
         services = zone.get("services", [])
@@ -1105,6 +1169,8 @@ def _generate_drawio(analysis: dict) -> dict:
                 vertex="1", parent=zid,
             )
             lbl_cell.append(_mx_geom(sx + 48, sy, sw - 48, sh))
+            for alias in (aws_name, azure_name, label):
+                service_ids[_service_key(alias)] = lbl_id
 
     # ── Cloud boundary geometry ──
     if zone_rects:
@@ -1116,24 +1182,63 @@ def _generate_drawio(analysis: dict) -> dict:
         bx, by, bw, bh = margin_x, margin_y, 800, 600
     cloud_cell.append(_mx_geom(bx, by, bw, bh))
 
-    # ── Arrows between consecutive zones ──
-    for i in range(len(zone_rects) - 1):
-        src = zone_rects[i]
-        dst = zone_rects[i + 1]
+    aliases = _mapping_aliases(mappings)
+    rendered_connections = 0
+    for conn in connections[:80]:
+        if not isinstance(conn, dict):
+            continue
+        from_endpoint = _connection_endpoint(conn, "from", "source")
+        to_endpoint = _connection_endpoint(conn, "to", "target")
+        from_service = _resolved_connection_endpoint(from_endpoint, aliases)
+        to_service = _resolved_connection_endpoint(to_endpoint, aliases)
+        source_id = service_ids.get(_service_key(from_service)) or service_ids.get(_service_key(from_endpoint))
+        target_id = service_ids.get(_service_key(to_service)) or service_ids.get(_service_key(to_endpoint))
+        if not source_id or not target_id or source_id == target_id:
+            continue
         eid = next_id()
+        label = _connection_label(conn)
+        conn_type = str(conn.get("type") or "traffic").lower()
+        color = {
+            "database": "#1A5DAB",
+            "auth": "#5C2D91",
+            "security": "#C73E1D",
+            "inspection": "#C73E1D",
+            "storage": "#0078D4",
+            "metrics": "#107C10",
+        }.get(conn_type, "#50E6FF")
         arrow_style = (
-            "edgeStyle=orthogonalEdgeStyle;rounded=1;strokeColor=#50E6FF;"
+            f"edgeStyle=orthogonalEdgeStyle;rounded=1;strokeColor={color};"
             "strokeWidth=2;fontSize=11;fontColor=#0078D4;"
         )
         edge = ET.SubElement(
             root_cell, "mxCell",
             id=eid,
-            value="data flow",
+            value=label,
             style=arrow_style,
             edge="1", parent="1",
-            source=src["id"], target=dst["id"],
+            source=source_id, target=target_id,
         )
         edge.append(_mx_geom(0, 0, 0, 0, relative=True))
+        rendered_connections += 1
+
+    if rendered_connections == 0:
+        for i in range(len(zone_rects) - 1):
+            src = zone_rects[i]
+            dst = zone_rects[i + 1]
+            eid = next_id()
+            arrow_style = (
+                "edgeStyle=orthogonalEdgeStyle;rounded=1;strokeColor=#50E6FF;"
+                "strokeWidth=2;fontSize=11;fontColor=#0078D4;"
+            )
+            edge = ET.SubElement(
+                root_cell, "mxCell",
+                id=eid,
+                value="data flow",
+                style=arrow_style,
+                edge="1", parent="1",
+                source=src["id"], target=dst["id"],
+            )
+            edge.append(_mx_geom(0, 0, 0, 0, relative=True))
 
     xml_str = ET.tostring(root, encoding="unicode", xml_declaration=True)
     return {
@@ -1164,8 +1269,9 @@ _VDX_NS = "http://schemas.microsoft.com/visio/2003/core"
 
 
 def _generate_vsdx(analysis: dict) -> dict:
-    zones = analysis.get("zones", [])
     mappings = analysis.get("mappings", [])
+    zones = _services_for_export_zones(analysis.get("zones", []), mappings)
+    connections = analysis.get("service_connections", [])
     title = analysis.get("title", "Azure Architecture Diagram")
 
     svc_map: dict[str, dict] = {}
@@ -1235,6 +1341,7 @@ def _generate_vsdx(analysis: dict) -> dict:
     margin_y_in = 2.0
 
     zone_shapes: list[dict] = []
+    service_shapes: dict[str, dict[str, Any]] = {}
 
     for idx, zone in enumerate(zones):
         services = zone.get("services", [])
@@ -1290,29 +1397,70 @@ def _generate_vsdx(analysis: dict) -> dict:
             _vdx_fill(svc_el, "#FFFFFF")
             _vdx_line(svc_el, _CONFIDENCE_COLORS.get(confidence, "#FF9800"))
             _vdx_text(svc_el, label)
+            absolute_x = zx + sx_local
+            absolute_y = zy + sy_local
+            for alias in (aws_name, azure_name, label):
+                service_shapes[_service_key(alias)] = {"id": ssid, "x": absolute_x, "y": absolute_y}
 
-    # ── Connectors between consecutive zones ──
     connects = ET.SubElement(page, f"{{{_VDX_NS}}}Connects")
-    for i in range(len(zone_shapes) - 1):
+    aliases = _mapping_aliases(mappings)
+    rendered_connections = 0
+    for idx, conn_data in enumerate(connections[:80]):
+        if not isinstance(conn_data, dict):
+            continue
+        from_endpoint = _connection_endpoint(conn_data, "from", "source")
+        to_endpoint = _connection_endpoint(conn_data, "to", "target")
+        from_service = _resolved_connection_endpoint(from_endpoint, aliases)
+        to_service = _resolved_connection_endpoint(to_endpoint, aliases)
+        src_shape = service_shapes.get(_service_key(from_service)) or service_shapes.get(_service_key(from_endpoint))
+        dst_shape = service_shapes.get(_service_key(to_service)) or service_shapes.get(_service_key(to_endpoint))
+        if not src_shape or not dst_shape or src_shape["id"] == dst_shape["id"]:
+            continue
         csid = next_shape_id()
         conn = ET.SubElement(shapes, f"{{{_VDX_NS}}}Shape", ID=csid, Type="Shape",
-                             NameU=f"Connector_{i}")
-        # XForm1D
+                             NameU=f"Connector_{idx}")
         xform1d = ET.SubElement(conn, f"{{{_VDX_NS}}}XForm1D")
-        src_z = zone_shapes[i]
-        dst_z = zone_shapes[i + 1]
-        ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginX").text = str(src_z["x"] + src_z["w"])
-        ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginY").text = str(src_z["y"] + src_z["h"] / 2)
-        ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndX").text = str(dst_z["x"])
-        ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndY").text = str(dst_z["y"] + dst_z["h"] / 2)
-        _vdx_line(conn, _AZURE_SECONDARY)
-        _vdx_text(conn, "data flow")
+        ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginX").text = str(round(float(src_shape["x"]), 4))
+        ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginY").text = str(round(float(src_shape["y"]), 4))
+        ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndX").text = str(round(float(dst_shape["x"]), 4))
+        ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndY").text = str(round(float(dst_shape["y"]), 4))
+        conn_type = str(conn_data.get("type") or "traffic").lower()
+        color = {
+            "database": "#1A5DAB",
+            "auth": "#5C2D91",
+            "security": "#C73E1D",
+            "inspection": "#C73E1D",
+            "storage": _AZURE_PRIMARY,
+            "metrics": "#107C10",
+        }.get(conn_type, _AZURE_SECONDARY)
+        _vdx_line(conn, color)
+        _vdx_text(conn, _connection_label(conn_data))
 
-        # Connect elements
         ET.SubElement(connects, f"{{{_VDX_NS}}}Connect", FromSheet=csid, FromCell="BeginX",
-                           ToSheet=src_z["id"])
+                           ToSheet=str(src_shape["id"]))
         ET.SubElement(connects, f"{{{_VDX_NS}}}Connect", FromSheet=csid, FromCell="EndX",
-                           ToSheet=dst_z["id"])
+                           ToSheet=str(dst_shape["id"]))
+        rendered_connections += 1
+
+    if rendered_connections == 0:
+        for i in range(len(zone_shapes) - 1):
+            csid = next_shape_id()
+            conn = ET.SubElement(shapes, f"{{{_VDX_NS}}}Shape", ID=csid, Type="Shape",
+                                 NameU=f"Connector_{i}")
+            xform1d = ET.SubElement(conn, f"{{{_VDX_NS}}}XForm1D")
+            src_z = zone_shapes[i]
+            dst_z = zone_shapes[i + 1]
+            ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginX").text = str(src_z["x"] + src_z["w"])
+            ET.SubElement(xform1d, f"{{{_VDX_NS}}}BeginY").text = str(src_z["y"] + src_z["h"] / 2)
+            ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndX").text = str(dst_z["x"])
+            ET.SubElement(xform1d, f"{{{_VDX_NS}}}EndY").text = str(dst_z["y"] + dst_z["h"] / 2)
+            _vdx_line(conn, _AZURE_SECONDARY)
+            _vdx_text(conn, "data flow")
+
+            ET.SubElement(connects, f"{{{_VDX_NS}}}Connect", FromSheet=csid, FromCell="BeginX",
+                               ToSheet=src_z["id"])
+            ET.SubElement(connects, f"{{{_VDX_NS}}}Connect", FromSheet=csid, FromCell="EndX",
+                               ToSheet=dst_z["id"])
 
     xml_str = ET.tostring(vdx, encoding="unicode", xml_declaration=True)
     return {

--- a/backend/diagram_export.py
+++ b/backend/diagram_export.py
@@ -21,6 +21,13 @@ from typing import Any
 import os
 import re
 
+from service_connection_utils import (
+    connection_endpoint,
+    connection_label,
+    mapping_aliases,
+    resolved_connection_endpoint,
+    service_key,
+)
 from source_provider import normalize_source_provider
 
 _data_file_AZURE_STENCILS = os.path.join(os.path.dirname(__file__), 'assets', 'diagram_stencils.json')
@@ -92,44 +99,6 @@ def _service_source_name(service: Any) -> str:
     if isinstance(service, dict):
         return str(service.get("source", service.get("aws", service.get("gcp", service.get("source_service", service.get("name", ""))))))
     return str(service)
-
-
-def _service_key(value: Any) -> str:
-    """Stable fuzzy key for matching connection endpoints to rendered services."""
-    text = str(value or "").lower().strip()
-    text = re.sub(r"\[[^\]]+\]", "", text)
-    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
-    text = re.sub(r"[^a-z0-9]+", "", text)
-    return text
-
-
-def _connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:
-    return str(conn.get(primary) or conn.get(secondary) or "")
-
-
-def _connection_label(conn: dict[str, Any]) -> str:
-    protocol = str(conn.get("protocol") or "").strip()
-    conn_type = str(conn.get("type") or "").strip()
-    bits = [bit for bit in (protocol, conn_type) if bit]
-    return " · ".join(bits)
-
-
-def _mapping_aliases(mappings: list[dict[str, Any]]) -> dict[str, str]:
-    aliases: dict[str, str] = {}
-    for mapping in mappings:
-        azure = str(mapping.get("azure_service") or mapping.get("target") or "").strip()
-        if not azure:
-            continue
-        for field in ("source_service", "aws_service", "gcp_service", "source", "azure_service", "target"):
-            value = mapping.get(field)
-            if value:
-                aliases[_service_key(value)] = azure
-        aliases[_service_key(azure)] = azure
-    return aliases
-
-
-def _resolved_connection_endpoint(endpoint: str, aliases: dict[str, str]) -> str:
-    return aliases.get(_service_key(endpoint), endpoint)
 
 
 def _services_for_export_zones(zones: list[dict[str, Any]], mappings: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1170,7 +1139,7 @@ def _generate_drawio(analysis: dict) -> dict:
             )
             lbl_cell.append(_mx_geom(sx + 48, sy, sw - 48, sh))
             for alias in (aws_name, azure_name, label):
-                service_ids[_service_key(alias)] = lbl_id
+                service_ids[service_key(alias)] = lbl_id
 
     # ── Cloud boundary geometry ──
     if zone_rects:
@@ -1182,21 +1151,21 @@ def _generate_drawio(analysis: dict) -> dict:
         bx, by, bw, bh = margin_x, margin_y, 800, 600
     cloud_cell.append(_mx_geom(bx, by, bw, bh))
 
-    aliases = _mapping_aliases(mappings)
+    aliases = mapping_aliases(mappings)
     rendered_connections = 0
-    for conn in connections[:80]:
+    for conn in connections:
         if not isinstance(conn, dict):
             continue
-        from_endpoint = _connection_endpoint(conn, "from", "source")
-        to_endpoint = _connection_endpoint(conn, "to", "target")
-        from_service = _resolved_connection_endpoint(from_endpoint, aliases)
-        to_service = _resolved_connection_endpoint(to_endpoint, aliases)
-        source_id = service_ids.get(_service_key(from_service)) or service_ids.get(_service_key(from_endpoint))
-        target_id = service_ids.get(_service_key(to_service)) or service_ids.get(_service_key(to_endpoint))
+        from_endpoint = connection_endpoint(conn, "from", "source")
+        to_endpoint = connection_endpoint(conn, "to", "target")
+        from_service = resolved_connection_endpoint(from_endpoint, aliases)
+        to_service = resolved_connection_endpoint(to_endpoint, aliases)
+        source_id = service_ids.get(service_key(from_service)) or service_ids.get(service_key(from_endpoint))
+        target_id = service_ids.get(service_key(to_service)) or service_ids.get(service_key(to_endpoint))
         if not source_id or not target_id or source_id == target_id:
             continue
         eid = next_id()
-        label = _connection_label(conn)
+        label = connection_label(conn)
         conn_type = str(conn.get("type") or "traffic").lower()
         color = {
             "database": "#1A5DAB",
@@ -1400,20 +1369,20 @@ def _generate_vsdx(analysis: dict) -> dict:
             absolute_x = zx + sx_local
             absolute_y = zy + sy_local
             for alias in (aws_name, azure_name, label):
-                service_shapes[_service_key(alias)] = {"id": ssid, "x": absolute_x, "y": absolute_y}
+                service_shapes[service_key(alias)] = {"id": ssid, "x": absolute_x, "y": absolute_y}
 
     connects = ET.SubElement(page, f"{{{_VDX_NS}}}Connects")
-    aliases = _mapping_aliases(mappings)
+    aliases = mapping_aliases(mappings)
     rendered_connections = 0
-    for idx, conn_data in enumerate(connections[:80]):
+    for idx, conn_data in enumerate(connections):
         if not isinstance(conn_data, dict):
             continue
-        from_endpoint = _connection_endpoint(conn_data, "from", "source")
-        to_endpoint = _connection_endpoint(conn_data, "to", "target")
-        from_service = _resolved_connection_endpoint(from_endpoint, aliases)
-        to_service = _resolved_connection_endpoint(to_endpoint, aliases)
-        src_shape = service_shapes.get(_service_key(from_service)) or service_shapes.get(_service_key(from_endpoint))
-        dst_shape = service_shapes.get(_service_key(to_service)) or service_shapes.get(_service_key(to_endpoint))
+        from_endpoint = connection_endpoint(conn_data, "from", "source")
+        to_endpoint = connection_endpoint(conn_data, "to", "target")
+        from_service = resolved_connection_endpoint(from_endpoint, aliases)
+        to_service = resolved_connection_endpoint(to_endpoint, aliases)
+        src_shape = service_shapes.get(service_key(from_service)) or service_shapes.get(service_key(from_endpoint))
+        dst_shape = service_shapes.get(service_key(to_service)) or service_shapes.get(service_key(to_endpoint))
         if not src_shape or not dst_shape or src_shape["id"] == dst_shape["id"]:
             continue
         csid = next_shape_id()
@@ -1434,7 +1403,7 @@ def _generate_vsdx(analysis: dict) -> dict:
             "metrics": "#107C10",
         }.get(conn_type, _AZURE_SECONDARY)
         _vdx_line(conn, color)
-        _vdx_text(conn, _connection_label(conn_data))
+        _vdx_text(conn, connection_label(conn_data))
 
         ET.SubElement(connects, f"{{{_VDX_NS}}}Connect", FromSheet=csid, FromCell="BeginX",
                            ToSheet=str(src_shape["id"]))

--- a/backend/service_connection_utils.py
+++ b/backend/service_connection_utils.py
@@ -47,7 +47,7 @@ def connection_label(conn: dict[str, Any]) -> str:
     protocol = str(conn.get("protocol") or "").strip()
     conn_type = str(conn.get("type") or "").strip()
     bits = [bit for bit in (protocol, conn_type) if bit]
-    return " · ".join(bits)
+    return " · ".join(bits) or "traffic"
 
 
 def mapping_aliases(mappings: list[dict[str, Any]]) -> dict[str, str]:

--- a/backend/service_connection_utils.py
+++ b/backend/service_connection_utils.py
@@ -1,0 +1,52 @@
+"""Shared helpers for rendering service-level connection edges."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def service_key(value: Any) -> str:
+    """Stable fuzzy key for matching connection endpoints to rendered services."""
+    text = str(value or "").lower().strip()
+    text = re.sub(r"\[[^\]]+\]", "", text)
+    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
+    return re.sub(r"[^a-z0-9]+", "", text)
+
+
+def connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:
+    return str(conn.get(primary) or conn.get(secondary) or "")
+
+
+def connection_label(conn: dict[str, Any]) -> str:
+    protocol = str(conn.get("protocol") or "").strip()
+    conn_type = str(conn.get("type") or "").strip()
+    bits = [bit for bit in (protocol, conn_type) if bit]
+    return " · ".join(bits)
+
+
+def mapping_aliases(mappings: list[dict[str, Any]]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for mapping in mappings:
+        if not isinstance(mapping, dict):
+            continue
+        azure = str(mapping.get("azure_service") or mapping.get("target") or "").strip()
+        if not azure:
+            continue
+        for field in (
+            "source_service",
+            "aws_service",
+            "gcp_service",
+            "source",
+            "azure_service",
+            "target",
+        ):
+            value = mapping.get(field)
+            if value:
+                aliases[service_key(value)] = azure
+        aliases[service_key(azure)] = azure
+    return aliases
+
+
+def resolved_connection_endpoint(endpoint: str, aliases: dict[str, str]) -> str:
+    return aliases.get(service_key(endpoint), endpoint)

--- a/backend/service_connection_utils.py
+++ b/backend/service_connection_utils.py
@@ -2,16 +2,41 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any
+
+
+_CLOUD_NOISE_WORDS = {"aws", "amazon", "azure", "gcp", "google", "microsoft"}
 
 
 def service_key(value: Any) -> str:
     """Stable fuzzy key for matching connection endpoints to rendered services."""
     text = str(value or "").lower().strip()
-    text = re.sub(r"\[[^\]]+\]", "", text)
-    text = re.sub(r"\b(?:aws|amazon|azure|gcp|google|microsoft)\b", "", text)
-    return re.sub(r"[^a-z0-9]+", "", text)
+    tokens: list[str] = []
+    current: list[str] = []
+    in_brackets = False
+
+    for char in text:
+        if char == "[":
+            if current:
+                tokens.append("".join(current))
+                current = []
+            in_brackets = True
+            continue
+        if char == "]":
+            in_brackets = False
+            continue
+        if in_brackets:
+            continue
+        if char.isalnum():
+            current.append(char)
+        elif current:
+            tokens.append("".join(current))
+            current = []
+
+    if current:
+        tokens.append("".join(current))
+
+    return "".join(token for token in tokens if token not in _CLOUD_NOISE_WORDS)
 
 
 def connection_endpoint(conn: dict[str, Any], primary: str, secondary: str) -> str:

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -350,6 +350,20 @@ class TestProductionReadyGuardrails:
             f"SVG size {size_bytes} bytes exceeds 300 KB cap on canonical fixture"
         )
 
+    def test_canonical_estate_renders_service_connection_flow_paths(self, canonical_aws_estate):
+        result = generate_landing_zone_svg(canonical_aws_estate, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        flow_paths = [
+            path for path in root.iter(f"{SVG_NS}path")
+            if path.get("class") == "service-flow-edge"
+        ]
+        texts = [text.text or "" for text in root.iter(f"{SVG_NS}text")]
+
+        expected = int(len(canonical_aws_estate["service_connections"]) * 0.8)
+        assert len(flow_paths) >= expected
+        assert "traffic" in texts
+        assert "database" in texts
+
     def test_dr_variant_renders_real_icons_too(self, canonical_aws_estate):
         """DR variant has 2x the canvas; must not lose icon resolution along the way."""
         result = generate_landing_zone_svg(canonical_aws_estate, dr_variant="dr")

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -363,7 +363,9 @@ class TestProductionReadyGuardrails:
         assert len(flow_paths) >= expected
         assert "traffic" in texts
         assert "database" in texts
-        assert all(path.get("marker-end") == "url(#aflow)" for path in flow_paths)
+        marker_ids = {path.get("marker-end") for path in flow_paths}
+        assert "url(#aflow-default)" in marker_ids
+        assert "url(#aflow-db)" in marker_ids
 
     def test_landing_zone_svg_does_not_truncate_service_connections_above_40(self):
         analysis = {

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -7,6 +7,7 @@ goes through the real XML parser, not substring/key existence checks.
 from __future__ import annotations
 
 import json
+import math
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -359,7 +360,7 @@ class TestProductionReadyGuardrails:
         ]
         texts = [text.text or "" for text in root.iter(f"{SVG_NS}text")]
 
-        expected = int(len(canonical_aws_estate["service_connections"]) * 0.8)
+        expected = math.ceil(len(canonical_aws_estate["service_connections"]) * 0.8)
         assert len(flow_paths) >= expected
         assert "traffic" in texts
         assert "database" in texts

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -363,6 +363,29 @@ class TestProductionReadyGuardrails:
         assert len(flow_paths) >= expected
         assert "traffic" in texts
         assert "database" in texts
+        assert all(path.get("marker-end") == "url(#aflow)" for path in flow_paths)
+
+    def test_landing_zone_svg_does_not_truncate_service_connections_above_40(self):
+        analysis = {
+            **SAMPLE_ANALYSIS,
+            "mappings": [
+                {"source_service": "CloudFront", "azure_service": "Azure Front Door", "category": "Edge"},
+                {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking"},
+            ],
+            "service_connections": [
+                {"source": "Azure Front Door", "target": "Application Gateway", "type": "traffic"}
+                for _ in range(45)
+            ],
+        }
+
+        result = generate_landing_zone_svg(analysis, dr_variant="primary")
+        root = ET.fromstring(result["content"])
+        flow_paths = [
+            path for path in root.iter(f"{SVG_NS}path")
+            if path.get("class") == "service-flow-edge"
+        ]
+
+        assert len(flow_paths) == len(analysis["service_connections"])
 
     def test_dr_variant_renders_real_icons_too(self, canonical_aws_estate):
         """DR variant has 2x the canvas; must not lose icon resolution along the way."""

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -7,6 +7,7 @@ valid — masking the broken Visio output (#569).
 """
 import json
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import pytest
 from diagram_export import generate_diagram, get_azure_stencil_id
@@ -40,6 +41,11 @@ SAMPLE_ANALYSIS = {
         },
     ],
 }
+
+
+CANONICAL_AWS_ESTATE_PATH = (
+    Path(__file__).parent / "fixtures" / "aws_canonical_estate.json"
+)
 
 
 MIXED_CLOUD_ANALYSIS = {
@@ -99,6 +105,32 @@ class TestGenerateDiagram:
         assert root.tag in ("mxfile", "mxGraphModel"), f"Unexpected root: {root.tag}"
         cells = root.findall(".//mxCell")
         assert len(cells) > 0, "Draw.io export had no mxCell elements"
+
+    def test_drawio_renders_service_connection_edges_from_canonical_fixture(self):
+        analysis = json.loads(CANONICAL_AWS_ESTATE_PATH.read_text(encoding="utf-8"))
+
+        result = generate_diagram(analysis, format="drawio")
+        root = ET.fromstring(result["content"])
+        edges = [cell for cell in root.findall(".//mxCell") if cell.get("edge") == "1"]
+
+        expected = int(len(analysis["service_connections"]) * 0.8)
+        assert len(edges) >= expected
+        assert all((edge.get("value") or "") != "data flow" for edge in edges)
+
+    def test_drawio_connection_edge_label_includes_protocol_and_type(self):
+        analysis = {
+            **SAMPLE_ANALYSIS,
+            "zones": [{"id": 1, "number": 1, "name": "app", "services": []}],
+            "service_connections": [
+                {"from": "EC2", "to": "S3", "protocol": "HTTPS", "type": "storage"},
+            ],
+        }
+
+        result = generate_diagram(analysis, format="drawio")
+        root = ET.fromstring(result["content"])
+        edge_values = [cell.get("value") or "" for cell in root.findall(".//mxCell") if cell.get("edge") == "1"]
+
+        assert "HTTPS · storage" in edge_values
 
     def test_mixed_cloud_drawio_handoff_labels_sources_and_uses_deterministic_fallback(self):
         result = generate_diagram(MIXED_CLOUD_ANALYSIS, format="drawio")
@@ -173,6 +205,27 @@ class TestGenerateDiagram:
         pages = root.find(f"{ns}Pages")
         assert pages is not None, "VDX missing <Pages> element"
         assert len(pages.findall(f"{ns}Page")) >= 1
+
+    def test_vsdx_renders_service_connection_connectors_from_canonical_fixture(self):
+        analysis = json.loads(CANONICAL_AWS_ESTATE_PATH.read_text(encoding="utf-8"))
+
+        result = generate_diagram(analysis, format="vsdx")
+        root = ET.fromstring(result["content"])
+        ns = "{http://schemas.microsoft.com/visio/2003/core}"
+        connectors = [
+            shape for shape in root.findall(f".//{ns}Shape")
+            if (shape.get("NameU") or "").startswith("Connector_")
+        ]
+        connector_texts = [
+            text.text or ""
+            for shape in connectors
+            for text in shape.findall(f"{ns}Text")
+        ]
+
+        expected = int(len(analysis["service_connections"]) * 0.8)
+        assert len(connectors) >= expected
+        assert "database" in connector_texts
+        assert "auth" in connector_texts
 
     def test_invalid_format_raises(self):
         with pytest.raises((ValueError, KeyError)):

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 from diagram_export import generate_diagram, get_azure_stencil_id
+from service_connection_utils import service_key
 
 
 SAMPLE_ANALYSIS = {
@@ -106,6 +107,16 @@ class TestGetAzureStencilId:
     def test_unknown_service_returns_fallback(self):
         stencil = get_azure_stencil_id("Nonexistent Service XYZ", target="drawio")
         assert isinstance(stencil, str)
+
+
+class TestServiceConnectionUtils:
+    def test_service_key_strips_provider_labels_without_regex_backtracking(self):
+        noisy = "[" * 5000 + "AWS] Azure Front Door"
+
+        assert service_key(noisy) == "frontdoor"
+
+    def test_service_key_normalizes_mixed_provider_labels(self):
+        assert service_key("[GCP] Pub/Sub → Azure Event Hubs") == "pubsubeventhubs"
 
 
 class TestGenerateDiagram:

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -48,6 +48,29 @@ CANONICAL_AWS_ESTATE_PATH = (
 )
 
 
+def _large_connection_analysis(count: int = 90) -> dict:
+    mappings = [
+        {
+            "source_service": f"Source {i}",
+            "azure_service": f"Service {i}",
+            "category": "Compute",
+            "confidence": 0.95,
+        }
+        for i in range(count + 1)
+    ]
+    return {
+        "title": "Large Connection Export",
+        "source_provider": "AWS",
+        "target_provider": "azure",
+        "zones": [{"id": 1, "number": 1, "name": "generated", "services": []}],
+        "mappings": mappings,
+        "service_connections": [
+            {"source": f"Service {i}", "target": f"Service {i + 1}", "type": "traffic"}
+            for i in range(count)
+        ],
+    }
+
+
 MIXED_CLOUD_ANALYSIS = {
     "source_provider": "aws",
     "source_providers": ["aws", "gcp"],
@@ -131,6 +154,15 @@ class TestGenerateDiagram:
         edge_values = [cell.get("value") or "" for cell in root.findall(".//mxCell") if cell.get("edge") == "1"]
 
         assert "HTTPS · storage" in edge_values
+
+    def test_drawio_does_not_truncate_service_connections_above_80(self):
+        analysis = _large_connection_analysis(count=90)
+
+        result = generate_diagram(analysis, format="drawio")
+        root = ET.fromstring(result["content"])
+        edges = [cell for cell in root.findall(".//mxCell") if cell.get("edge") == "1"]
+
+        assert len(edges) == len(analysis["service_connections"])
 
     def test_mixed_cloud_drawio_handoff_labels_sources_and_uses_deterministic_fallback(self):
         result = generate_diagram(MIXED_CLOUD_ANALYSIS, format="drawio")
@@ -226,6 +258,19 @@ class TestGenerateDiagram:
         assert len(connectors) >= expected
         assert "database" in connector_texts
         assert "auth" in connector_texts
+
+    def test_vsdx_does_not_truncate_service_connections_above_80(self):
+        analysis = _large_connection_analysis(count=90)
+
+        result = generate_diagram(analysis, format="vsdx")
+        root = ET.fromstring(result["content"])
+        ns = "{http://schemas.microsoft.com/visio/2003/core}"
+        connectors = [
+            shape for shape in root.findall(f".//{ns}Shape")
+            if (shape.get("NameU") or "").startswith("Connector_")
+        ]
+
+        assert len(connectors) == len(analysis["service_connections"])
 
     def test_invalid_format_raises(self):
         with pytest.raises((ValueError, KeyError)):

--- a/backend/tests/test_diagram_export.py
+++ b/backend/tests/test_diagram_export.py
@@ -6,12 +6,13 @@ previous coverage only checked that the result dict contained ``content`` or
 valid — masking the broken Visio output (#569).
 """
 import json
+import math
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
 from diagram_export import generate_diagram, get_azure_stencil_id
-from service_connection_utils import service_key
+from service_connection_utils import connection_label, service_key
 
 
 SAMPLE_ANALYSIS = {
@@ -118,6 +119,9 @@ class TestServiceConnectionUtils:
     def test_service_key_normalizes_mixed_provider_labels(self):
         assert service_key("[GCP] Pub/Sub → Azure Event Hubs") == "pubsubeventhubs"
 
+    def test_connection_label_defaults_to_traffic(self):
+        assert connection_label({}) == "traffic"
+
 
 class TestGenerateDiagram:
     def test_excalidraw_produces_valid_json_with_elements(self):
@@ -147,7 +151,7 @@ class TestGenerateDiagram:
         root = ET.fromstring(result["content"])
         edges = [cell for cell in root.findall(".//mxCell") if cell.get("edge") == "1"]
 
-        expected = int(len(analysis["service_connections"]) * 0.8)
+        expected = math.ceil(len(analysis["service_connections"]) * 0.8)
         assert len(edges) >= expected
         assert all((edge.get("value") or "") != "data flow" for edge in edges)
 
@@ -265,7 +269,7 @@ class TestGenerateDiagram:
             for text in shape.findall(f"{ns}Text")
         ]
 
-        expected = int(len(analysis["service_connections"]) * 0.8)
+        expected = math.ceil(len(analysis["service_connections"]) * 0.8)
         assert len(connectors) >= expected
         assert "database" in connector_texts
         assert "auth" in connector_texts


### PR DESCRIPTION
## Summary
- Render `service_connections` as service-level edges in single-page Draw.io exports.
- Render `service_connections` as VDX connectors between service shapes.
- Add a `service-flow` SVG overlay for landing-zone exports driven by `service_connections`.
- Add regression coverage for canonical fixture edge counts and protocol/type labels.

Closes #592

## Validation
- `cd backend && ./.venv/bin/python -m ruff check diagram_export.py azure_landing_zone.py tests/test_diagram_export.py tests/test_azure_landing_zone.py`
- `cd backend && ./.venv/bin/python -m pytest -q tests/test_diagram_export.py tests/test_azure_landing_zone.py`