### PR TITLE
feat: emit architecture package artifact manifests

### DIFF
--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -9,8 +9,11 @@ customer-safe talking points.
 from __future__ import annotations
 
 import copy
+import hashlib
 import html
+import json
 import re
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from azure_landing_zone import generate_landing_zone_svg
@@ -27,7 +30,8 @@ def generate_architecture_package(
     *,
     format: PackageFormat = "html",
     diagram: DiagramVariant = "primary",
-) -> dict[str, str]:
+    analysis_id: str | None = None,
+) -> dict[str, Any]:
     """Generate the architecture package in HTML or SVG form."""
     if format not in ("html", "svg"):
         raise ValueError("format must be 'html' or 'svg'")
@@ -38,10 +42,19 @@ def generate_architecture_package(
 
     if format == "svg":
         result = generate_landing_zone_svg(_diagram_analysis(analysis, diagram), dr_variant=diagram)
+        filename = result["filename"].replace("landing-zone", "architecture-package")
+        manifest = _build_manifest(
+            analysis,
+            format=format,
+            diagram=diagram,
+            analysis_id=analysis_id,
+            artifact_filenames=[filename],
+        )
         return {
             "format": "architecture-package-svg",
-            "filename": result["filename"].replace("landing-zone", "architecture-package"),
-            "content": result["content"],
+            "filename": filename,
+            "content": _embed_svg_manifest(result["content"], manifest),
+            "manifest": manifest,
         }
 
     primary_svg = _namespace_svg_ids(
@@ -52,15 +65,31 @@ def generate_architecture_package(
         _strip_xml_declaration(generate_landing_zone_svg(_diagram_analysis(analysis, "dr"), dr_variant="dr")["content"]),
         "dr",
     )
-    content = _render_html_package(analysis, primary_svg, dr_svg)
+    filename = f"archmorph-{_safe_filename(analysis)}-architecture-package.html"
+    target_filename = f"archmorph-{_safe_filename(analysis)}-architecture-package-primary.svg"
+    dr_filename = f"archmorph-{_safe_filename(analysis)}-architecture-package-dr.svg"
+    manifest = _build_manifest(
+        analysis,
+        format=format,
+        diagram=diagram,
+        analysis_id=analysis_id,
+        artifact_filenames=[filename, target_filename, dr_filename],
+    )
+    content = _render_html_package(analysis, primary_svg, dr_svg, manifest)
     return {
         "format": "architecture-package-html",
-        "filename": f"archmorph-{_safe_filename(analysis)}-architecture-package.html",
+        "filename": filename,
         "content": content,
+        "manifest": manifest,
     }
 
 
-def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str) -> str:
+def _render_html_package(
+    analysis: dict[str, Any],
+    primary_svg: str,
+    dr_svg: str,
+    manifest: dict[str, Any],
+) -> str:
     package_name = _package_name(analysis)
     title = html.escape(f"Archmorph — {package_name} Architecture Package")
     display_name = html.escape(package_name)
@@ -86,6 +115,7 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
         for tier, names in _tier_summary(analysis)
     )
 
+    manifest_json = _manifest_json(manifest)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -159,6 +189,7 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
     <footer>Archmorph · {display_name} · {source} → Azure · generated from the customer-uploaded architecture diagram.</footer>
     </div>
   <script>
+        window.__ARCHMORPH_ARTIFACT_MANIFEST__ = {manifest_json};
     document.querySelectorAll('button.tab').forEach((button) => {{
       button.addEventListener('click', () => {{
         document.querySelectorAll('button.tab').forEach((tab) => tab.setAttribute('aria-selected', 'false'));
@@ -168,8 +199,121 @@ def _render_html_package(analysis: dict[str, Any], primary_svg: str, dr_svg: str
       }});
     }});
   </script>
+  <script type="application/json" id="archmorph-artifact-manifest">{html.escape(manifest_json)}</script>
 </body>
 </html>"""
+
+
+def _build_manifest(
+    analysis: dict[str, Any],
+    *,
+    format: PackageFormat,
+    diagram: DiagramVariant,
+    analysis_id: str | None,
+    artifact_filenames: list[str],
+) -> dict[str, Any]:
+    profile = _profile_from_analysis(analysis)
+    limitations = _limitations(analysis, profile)
+    source_provider = _source_label(analysis)
+    raw_warnings = [str(w) for w in analysis.get("warnings", []) if w]
+    unsupported = analysis.get("unsupported_assumptions") or analysis.get("unsupported") or []
+    if not isinstance(unsupported, list):
+        unsupported = [unsupported]
+
+    manifest = {
+        "schema_version": "architecture-package-manifest/v1",
+        "analysis_id": str(analysis_id or analysis.get("analysis_id") or analysis.get("diagram_id") or "unknown"),
+        "source_provider": source_provider,
+        "target_provider": "Azure",
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "export": {"format": format, "diagram": diagram},
+        "renderer": {"name": "architecture_package", "version": "1"},
+        "customer_intent_profile_hash": hashlib.sha256(
+            json.dumps(profile, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+        "artifact_filenames": artifact_filenames,
+        "artifacts": [
+            {"filename": name, "role": role, "format": artifact_format}
+            for name, role, artifact_format in _manifest_artifacts(artifact_filenames, format)
+        ],
+        "mapping_references": _mapping_references(analysis),
+        "warnings": raw_warnings[:10],
+        "limitations": [
+            {"title": title, "detail": detail}
+            for title, detail in limitations
+        ],
+        "unsupported_assumptions": [str(item) for item in unsupported if item][:10],
+    }
+    return _sanitize_manifest(manifest)
+
+
+def _manifest_artifacts(
+    filenames: list[str],
+    format: PackageFormat,
+) -> list[tuple[str, str, str]]:
+    if format == "svg":
+        return [(filenames[0], "selected-topology", "svg")]
+    roles = ["architecture-package-html", "target-topology-svg", "dr-topology-svg"]
+    formats = ["html", "svg", "svg"]
+    return list(zip(filenames, roles, formats))
+
+
+def _mapping_references(analysis: dict[str, Any]) -> list[dict[str, Any]]:
+    references: list[dict[str, Any]] = []
+    for mapping in analysis.get("mappings", []):
+        if not isinstance(mapping, dict):
+            continue
+        source = mapping.get("source_service") or mapping.get("source") or mapping.get("aws_service") or mapping.get("gcp_service")
+        target = mapping.get("azure_service") or mapping.get("target")
+        if not source or not target:
+            continue
+        ref: dict[str, Any] = {
+            "source_service": str(source),
+            "azure_service": str(target),
+        }
+        if mapping.get("source_provider"):
+            ref["source_provider"] = str(mapping["source_provider"])
+        if mapping.get("category"):
+            ref["category"] = str(mapping["category"])
+        if mapping.get("confidence") is not None:
+            ref["confidence"] = mapping["confidence"]
+        references.append(ref)
+    return references[:200]
+
+
+def _manifest_json(manifest: dict[str, Any]) -> str:
+    return (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+def _embed_svg_manifest(svg: str, manifest: dict[str, Any]) -> str:
+    manifest_json = _manifest_json(manifest)
+    metadata = (
+        '<metadata id="archmorph-artifact-manifest" '
+        'type="application/json">'
+        f'{html.escape(manifest_json)}'
+        '</metadata>'
+    )
+    return re.sub(r"(<svg\b[^>]*>)", lambda match: f"{match.group(1)}{metadata}", svg, count=1)
+
+
+def _sanitize_manifest(value: Any, key: str = "") -> Any:
+    secret_words = ("secret", "password", "token", "credential", "connection_string", "apikey", "api_key")
+    if any(word in key.lower() for word in secret_words):
+        return "[redacted]"
+    if isinstance(value, dict):
+        return {str(k): _sanitize_manifest(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_manifest(item, key) for item in value]
+    if isinstance(value, str):
+        lower = value.lower()
+        if any(f"{word}=" in lower or f"{word}:" in lower for word in secret_words):
+            return "[redacted]"
+    return value
 
 
 def _profile_from_analysis(analysis: dict[str, Any]) -> dict[str, str]:
@@ -282,7 +426,7 @@ def _source_label(analysis: dict[str, Any]) -> str:
 
 
 def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[tuple[str, str]]:
-    warnings = [str(w) for w in analysis.get("warnings", []) if w]
+    warnings = [str(_sanitize_manifest(str(w))) for w in analysis.get("warnings", []) if w]
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
     low_conf = [m for m in mappings if float(m.get("confidence") or 0) < 0.8]
     limits = [("Review warning", warning) for warning in warnings[:5]]

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -278,6 +278,7 @@ async def export_architecture_package(
             analysis,
             format=format,  # type: ignore[arg-type]
             diagram=diagram,  # type: ignore[arg-type]
+            analysis_id=diagram_id,
         )
     except ValueError as exc:
         raise ArchmorphException(400, str(exc))

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -76,6 +76,72 @@ def test_svg_package_is_parseable_xml():
     assert result["filename"].endswith(".svg")
     root = ET.fromstring(result["content"])
     assert root.tag.endswith("svg")
+    metadata = root.find("{http://www.w3.org/2000/svg}metadata")
+    assert metadata is not None
+    assert metadata.attrib["id"] == "archmorph-artifact-manifest"
+
+
+def test_architecture_package_html_manifest_contains_traceability_fields():
+    result = generate_architecture_package(
+        SAMPLE_ANALYSIS,
+        format="html",
+        analysis_id="analysis-676",
+    )
+    manifest = result["manifest"]
+
+    assert manifest["schema_version"] == "architecture-package-manifest/v1"
+    assert manifest["analysis_id"] == "analysis-676"
+    assert manifest["source_provider"] == "AWS"
+    assert manifest["target_provider"] == "Azure"
+    assert manifest["export"] == {"format": "html", "diagram": "primary"}
+    assert manifest["renderer"] == {"name": "architecture_package", "version": "1"}
+    assert len(manifest["customer_intent_profile_hash"]) == 64
+    assert result["filename"] in manifest["artifact_filenames"]
+    assert {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96} in manifest["mapping_references"]
+    assert "archmorph-artifact-manifest" in result["content"]
+
+
+def test_architecture_package_svg_manifest_tracks_selected_diagram():
+    result = generate_architecture_package(
+        SAMPLE_ANALYSIS,
+        format="svg",
+        diagram="dr",
+        analysis_id="svg-analysis-676",
+    )
+    manifest = result["manifest"]
+
+    assert manifest["analysis_id"] == "svg-analysis-676"
+    assert manifest["export"] == {"format": "svg", "diagram": "dr"}
+    assert manifest["artifact_filenames"] == [result["filename"]]
+    assert manifest["artifacts"] == [
+        {"filename": result["filename"], "role": "selected-topology", "format": "svg"}
+    ]
+    assert "archmorph-artifact-manifest" in result["content"]
+
+
+def test_architecture_package_manifest_redacts_secret_like_values():
+    analysis = {
+        **SAMPLE_ANALYSIS,
+        "warnings": ["password=hunter2", "review customer RTO"],
+        "unsupported_assumptions": ["token: abc123"],
+        "mappings": [
+            {
+                "source_service": "Legacy API",
+                "azure_service": "Container Apps",
+                "category": "Compute",
+                "confidence": 0.74,
+                "credential_note": "super-secret",
+            }
+        ],
+    }
+
+    result = generate_architecture_package(analysis, format="html", analysis_id="privacy-test")
+    manifest_text = json.dumps(result["manifest"])
+
+    assert "hunter2" not in manifest_text
+    assert "abc123" not in manifest_text
+    assert "super-secret" not in manifest_text
+    assert "hunter2" not in result["content"]
 
 
 def test_html_package_contains_tabs_and_namespaced_svg_ids():
@@ -163,6 +229,7 @@ def test_export_architecture_package_endpoint_returns_html(test_client):
     assert data["format"] == "architecture-package-html"
     assert data["filename"].endswith(".html")
     assert "A — Target Azure Topology" in data["content"]
+    assert data["manifest"]["analysis_id"] == diagram_id
 
 
 def test_export_architecture_package_endpoint_returns_dr_svg(test_client):
@@ -177,4 +244,5 @@ def test_export_architecture_package_endpoint_returns_dr_svg(test_client):
     data = response.json()
     assert data["format"] == "architecture-package-svg"
     assert data["filename"].endswith("-dr.svg")
+    assert data["manifest"]["analysis_id"] == diagram_id
     ET.fromstring(data["content"])

--- a/docs/DIAGRAM_EXPORT_SPEC.md
+++ b/docs/DIAGRAM_EXPORT_SPEC.md
@@ -765,6 +765,36 @@ def generate_diagram(
             "filename": str,      # architecture-package-*.html or architecture-package-*.svg
             "content": str,       # HTML or SVG
             "content_type": str,  # text/html or image/svg+xml
+            "manifest": dict,     # machine-readable artifact manifest, schema below
           }
         """
       ```
+
+      Architecture Package manifest contract:
+
+      ```json
+      {
+        "schema_version": "architecture-package-manifest/v1",
+        "analysis_id": "diagram-session-or-analysis-id",
+        "source_provider": "AWS",
+        "target_provider": "Azure",
+        "generated_at": "2026-05-03T18:00:00Z",
+        "export": { "format": "html", "diagram": "primary" },
+        "renderer": { "name": "architecture_package", "version": "1" },
+        "customer_intent_profile_hash": "sha256-of-normalized-profile",
+        "artifact_filenames": ["archmorph-workload-architecture-package.html"],
+        "artifacts": [
+          { "filename": "archmorph-workload-architecture-package.html", "role": "architecture-package-html", "format": "html" }
+        ],
+        "mapping_references": [
+          { "source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96 }
+        ],
+        "warnings": ["review warning text"],
+        "limitations": [
+          { "title": "Validate low-confidence mappings", "detail": "Owner validation is required." }
+        ],
+        "unsupported_assumptions": ["unsupported assumption text"]
+      }
+      ```
+
+      The manifest is emitted for both `format=html` and `format=svg` package exports. It is returned as the response `manifest` field and embedded into the artifact bytes as `archmorph-artifact-manifest` metadata. Manifest values are sanitized before emission; secret-like keys or values such as passwords, tokens, credentials, API keys, and connection strings are redacted. Raw `guided_answers` are intentionally excluded; reviewers should use `customer_intent_profile_hash` for profile traceability without exposing the source answer payload.


### PR DESCRIPTION
## Summary
- add a sanitized `architecture-package-manifest/v1` manifest to Architecture Package HTML/SVG export responses
- embed the manifest into downloaded HTML/SVG artifacts with `archmorph-artifact-manifest` metadata
- include analysis ID, provider context, generated timestamp, renderer version, profile hash, artifact filenames, mapping references, warnings, limitations, and unsupported assumptions
- document the manifest contract and add privacy/route/visual regression coverage

## Validation
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check architecture_package.py routers/analysis.py tests/test_architecture_package.py`
- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_architecture_package.py tests/test_architecture_package_visual_snapshots.py`

Closes #676