### PR TITLE
ci: validate generated Terraform and Bicep outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: backend/requirements.txt
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.9.x"
-
-      - name: Install Bicep CLI
-        run: az bicep install
-
       - name: Install dependencies and lint
         run: |
           uv pip install --system ruff
@@ -320,7 +312,7 @@ jobs:
   # BACKEND DEPLOY (Blue-Green)
   # ============================================
   deploy-backend:
-    needs: [backend-tests, frontend-build, openapi-client-drift]
+    needs: [backend-tests, frontend-build, openapi-client-drift, iac-validate]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     if: github.ref == 'refs/heads/main'
@@ -738,7 +730,7 @@ jobs:
   # FRONTEND DEPLOY (Azure Static Web Apps)
   # ============================================
   deploy-frontend:
-    needs: [backend-tests, frontend-build, openapi-client-drift]
+    needs: [backend-tests, frontend-build, openapi-client-drift, iac-validate]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         run: python -m pytest -q tests/test_iac_output_validation.py
         env:
           ARCHMORPH_RUN_IAC_VALIDATE_TOOLS: "1"
+          ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION: "1"
 
   # ============================================
   # FRONTEND BUILD & TEST (npm audit in security.yml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,6 @@ jobs:
         run: python -m pytest -q tests/test_iac_output_validation.py
         env:
           ARCHMORPH_RUN_IAC_VALIDATE_TOOLS: "1"
-          ARCHMORPH_DISABLE_IAC_CLI_VALIDATION: "1"
 
   # ============================================
   # FRONTEND BUILD & TEST (npm audit in security.yml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           enable-cache: true
           cache-dependency-glob: backend/requirements.txt
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.x"
+
+      - name: Install Bicep CLI
+        run: az bicep install
+
       - name: Install dependencies and lint
         run: |
           uv pip install --system ruff
@@ -121,6 +129,45 @@ jobs:
           path: |
             backend-sbom.json
             ${{ steps.grype-python.outputs.sarif }}
+
+  # ============================================
+  # GENERATED IAC VALIDATION
+  # ============================================
+  iac-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/requirements.txt
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.x"
+
+      - name: Install Bicep CLI
+        run: az bicep install
+
+      - name: Install backend dependencies
+        run: uv pip install --system -r requirements.txt
+
+      - name: Validate generated Terraform and Bicep artifacts
+        run: python -m pytest -q tests/test_iac_output_validation.py
+        env:
+          ARCHMORPH_RUN_IAC_VALIDATE_TOOLS: "1"
 
   # ============================================
   # FRONTEND BUILD & TEST (npm audit in security.yml)
@@ -233,7 +280,7 @@ jobs:
   # SARIF UPLOAD (isolated so rate-limits don't block builds)
   # ============================================
   upload-sarif:
-    needs: [backend-tests, frontend-build, openapi-client-drift]
+    needs: [backend-tests, frontend-build, openapi-client-drift, iac-validate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: always() && (needs.backend-tests.result == 'success' || needs.frontend-build.result == 'success')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,11 @@ jobs:
       - name: Install Bicep CLI
         run: az bicep install
 
+      - name: Configure Terraform plugin cache
+        run: |
+          mkdir -p "$RUNNER_TEMP/terraform-plugin-cache"
+          echo "TF_PLUGIN_CACHE_DIR=$RUNNER_TEMP/terraform-plugin-cache" >> "$GITHUB_ENV"
+
       - name: Install backend dependencies
         run: uv pip install --system -r requirements.txt
 
@@ -160,6 +165,7 @@ jobs:
         run: python -m pytest -q tests/test_iac_output_validation.py
         env:
           ARCHMORPH_RUN_IAC_VALIDATE_TOOLS: "1"
+          ARCHMORPH_DISABLE_IAC_CLI_VALIDATION: "1"
 
   # ============================================
   # FRONTEND BUILD & TEST (npm audit in security.yml)

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,18 +18,28 @@ jobs:
         
       - name: Use fallback environment variables
         run: cp backend/.env.example backend/.env
+
+      - name: Install dependencies
+        run: npm ci --no-fund --no-audit || npm ci --no-fund --no-audit
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci --no-fund --no-audit || npm ci --no-fund --no-audit
       
       - name: Start Application Locally
         run: |
-          docker compose up -d
+          docker compose up -d postgres redis backend
           echo "Waiting for backend..."
           for i in {1..30}; do curl -s http://localhost:8000/api/health > /dev/null && break || sleep 2; done
+          if ! curl -s http://localhost:8000/api/health > /dev/null; then
+            docker compose logs backend
+            exit 1
+          fi
+
           echo "Waiting for frontend..."
-          npx wait-on http://localhost:5173 -t 60000 || true
+          (cd frontend && nohup npm run dev -- --host 0.0.0.0 > ../frontend-vite.log 2>&1 &)
+          npx wait-on http://localhost:5173 -t 120000 || { cat frontend-vite.log; exit 1; }
           docker compose ps
-        
-      - name: Install dependencies
-        run: npm install --no-fund --no-audit
       
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
@@ -45,7 +55,9 @@ jobs:
         
       - name: Dump docker logs on failure
         if: failure()
-        run: docker compose logs backend frontend
+        run: |
+          docker compose logs backend
+          cat frontend-vite.log || true
       
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/backend/iac_chat.py
+++ b/backend/iac_chat.py
@@ -17,6 +17,7 @@ from cachetools import TTLCache
 
 from openai import RateLimitError, APITimeoutError, APIConnectionError, BadRequestError
 from openai_client import cached_chat_completion, AZURE_OPENAI_DEPLOYMENT
+from iac_generator import _apply_validation
 from prompt_guard import (
     PROMPT_ARMOR,
     sanitize_message,
@@ -229,6 +230,8 @@ def process_iac_chat(
                 code = re.sub(r"^```[a-zA-Z]*\n", "", code)
                 code = re.sub(r"\n```$", "", code)
                 code = code.strip()
+            if iac_format in ("terraform", "bicep"):
+                code = _apply_validation(code, iac_format)
 
         changes = _coerce_to_str_list(result.get("changes_summary", []))
         services = _coerce_to_str_list(result.get("services_added", []))

--- a/backend/iac_chat.py
+++ b/backend/iac_chat.py
@@ -230,7 +230,9 @@ def process_iac_chat(
                 code = re.sub(r"^```[a-zA-Z]*\n", "", code)
                 code = re.sub(r"\n```$", "", code)
                 code = code.strip()
-            if iac_format in ("terraform", "bicep"):
+            if code == current_code or code == current_code.strip():
+                code = current_code
+            elif iac_format in ("terraform", "bicep"):
                 code = _apply_validation(code, iac_format)
 
         changes = _coerce_to_str_list(result.get("changes_summary", []))

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -52,6 +52,35 @@ def _terraform_cli_validation_enabled() -> bool:
     return os.getenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", "0") == "1"
 
 
+def _terraform_cli_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if not env.get("TF_PLUGIN_CACHE_DIR"):
+        plugin_cache = Path(tempfile.gettempdir()) / "archmorph-terraform-plugin-cache"
+        plugin_cache.mkdir(parents=True, exist_ok=True)
+        env["TF_PLUGIN_CACHE_DIR"] = str(plugin_cache)
+    return env
+
+
+def _terraform_init_failure_is_unavailable(message: str) -> bool:
+    normalized = message.lower()
+    unavailable_markers = (
+        "registry unavailable",
+        "connection refused",
+        "connection reset",
+        "context deadline exceeded",
+        "could not connect",
+        "could not retrieve the list of available versions",
+        "failed to query available provider packages",
+        "i/o timeout",
+        "no such host",
+        "proxyconnect",
+        "service unavailable",
+        "temporary failure",
+        "tls handshake timeout",
+    )
+    return any(marker in normalized for marker in unavailable_markers)
+
+
 def _terraform_cli_validation_safe(code: str) -> bool:
     declared_sources = re.findall(r'\bsource\s*=\s*"([^"]+)"', code)
     if any(source not in _TRUSTED_TERRAFORM_PROVIDER_SOURCES for source in declared_sources):
@@ -396,6 +425,7 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
     terraform = shutil.which("terraform")
     if not terraform or not _terraform_cli_validation_safe(code):
         return None
+    terraform_env = _terraform_cli_env()
 
     with tempfile.TemporaryDirectory(prefix="archmorph-tf-") as tmp:
         workdir = Path(tmp)
@@ -406,6 +436,7 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
             capture_output=True,
             text=True,
             timeout=20,
+            env=terraform_env,
             check=False,
         )
         if fmt.returncode != 0:
@@ -417,17 +448,22 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
             capture_output=True,
             text=True,
             timeout=60,
+            env=terraform_env,
             check=False,
         )
         if init.returncode != 0:
-            logger.warning("Terraform init unavailable; falling back to static validation: %s", (init.stderr or init.stdout).strip())
-            return None
+            message = (init.stderr or init.stdout or "terraform init failed").strip()
+            if _terraform_init_failure_is_unavailable(message):
+                logger.warning("Terraform init unavailable; falling back to static validation: %s", message)
+                return None
+            return [("error", f"terraform init failed: {message}")]
 
         validate = subprocess.run(
             [terraform, f"-chdir={workdir}", "validate", "-json", "-no-color"],
             capture_output=True,
             text=True,
             timeout=30,
+            env=terraform_env,
             check=False,
         )
         try:

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -25,10 +25,38 @@ from prompt_guard import (
 logger = logging.getLogger(__name__)
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
+_TRUSTED_TERRAFORM_PROVIDER_SOURCES = {
+    "azure/azapi",
+    "hashicorp/azuread",
+    "hashicorp/azurerm",
+    "hashicorp/null",
+    "hashicorp/random",
+    "hashicorp/time",
+    "hashicorp/tls",
+}
+_TRUSTED_TERRAFORM_PROVIDER_NAMES = {
+    source.rsplit("/", 1)[-1] for source in _TRUSTED_TERRAFORM_PROVIDER_SOURCES
+}
 
 
 def _iac_cli_validation_enabled() -> bool:
-    return os.getenv("ARCHMORPH_RUN_IAC_VALIDATE_TOOLS") == "1"
+    if os.getenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION") == "1":
+        return False
+    return os.getenv("ARCHMORPH_ENABLE_IAC_CLI_VALIDATION", "1") == "1"
+
+
+def _terraform_cli_validation_safe(code: str) -> bool:
+    declared_sources = re.findall(r'\bsource\s*=\s*"([^"]+)"', code)
+    if any(source not in _TRUSTED_TERRAFORM_PROVIDER_SOURCES for source in declared_sources):
+        logger.warning("Skipping Terraform CLI validation for untrusted provider source")
+        return False
+
+    resource_types = re.findall(r'\b(?:resource|data)\s+"([^"]+)"', code)
+    provider_names = {resource_type.split("_", 1)[0] for resource_type in resource_types if "_" in resource_type}
+    if any(provider not in _TRUSTED_TERRAFORM_PROVIDER_NAMES for provider in provider_names):
+        logger.warning("Skipping Terraform CLI validation for untrusted provider name")
+        return False
+    return True
 
 
 def _load_template(name: str) -> str:
@@ -359,7 +387,7 @@ def _terraform_policy_checks(code: str) -> List[Tuple[str, str]]:
 def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
     """Run terraform fmt/init/validate when the CLI is available."""
     terraform = shutil.which("terraform")
-    if not terraform:
+    if not terraform or not _terraform_cli_validation_safe(code):
         return None
 
     with tempfile.TemporaryDirectory(prefix="archmorph-tf-") as tmp:
@@ -633,13 +661,23 @@ def _apply_validation(code: str, iac_format: str) -> str:
         code = code + "\n\n" + warning_block + "\n"
 
     if errors:
-        failed_command = {
-            "terraform": "failed terraform validate",
-            "bicep": "failed az bicep build",
-            "cloudformation": "failed CloudFormation validation",
-        }.get(iac_format, "failed IaC validation")
+        def _failure_label(message: str) -> tuple[str, str]:
+            if iac_format == "terraform":
+                for command in ("fmt", "init", "validate"):
+                    prefix = f"terraform {command} failed: "
+                    if message.startswith(prefix):
+                        return f"failed terraform {command}", message.removeprefix(prefix)
+                return "failed terraform validate", message
+            if iac_format == "bicep":
+                return "failed az bicep build", message
+            if iac_format == "cloudformation":
+                return "failed CloudFormation validation", message
+            return "failed IaC validation", message
+
         error_block = "\n".join(
-            f"{comment_char} ⚠ {failed_command}: {msg}" for _, msg in errors
+            f"{comment_char} ⚠ {label}: {detail}"
+            for _, msg in errors
+            for label, detail in [_failure_label(msg)]
         )
         code = code + "\n\n" + error_block + "\n"
         logger.error(

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -5,7 +5,11 @@ Falls back to base templates when no analysis is available.
 """
 
 import logging
+import json
 import re
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -291,7 +295,7 @@ def _build_aws_cdk_prompt(analysis: dict, params: dict) -> str:
 # IaC Output Validation (Issues #273, #274)
 # ─────────────────────────────────────────────────────────────
 
-def _validate_terraform(code: str) -> List[Tuple[str, str]]:
+def _validate_terraform_static(code: str) -> List[Tuple[str, str]]:
     """Validate generated Terraform HCL at the syntax / structure level.
 
     Returns a list of (severity, message) tuples.
@@ -333,7 +337,90 @@ def _validate_terraform(code: str) -> List[Tuple[str, str]]:
     return issues
 
 
-def _validate_bicep(code: str) -> List[Tuple[str, str]]:
+def _terraform_policy_checks(code: str) -> List[Tuple[str, str]]:
+    issues: List[Tuple[str, str]] = []
+    cred_patterns = [
+        (r'(?:password|secret|api_key)\s*=\s*"[^"]{4,}"', "Hardcoded credential detected in Terraform output"),
+        (r'admin_password\s*=\s*"', "Hardcoded admin_password found — must use Key Vault"),
+    ]
+    for pat, msg in cred_patterns:
+        if re.search(pat, code, re.IGNORECASE):
+            issues.append(("error", msg))
+    if "```" in code:
+        issues.append(("warning", "Markdown code fences found in Terraform output — stripping"))
+    return issues
+
+
+def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
+    """Run terraform fmt/init/validate when the CLI is available."""
+    terraform = shutil.which("terraform")
+    if not terraform:
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="archmorph-tf-") as tmp:
+        workdir = Path(tmp)
+        (workdir / "main.tf").write_text(code, encoding="utf-8")
+
+        fmt = subprocess.run(
+            [terraform, "fmt", "-check", "-no-color", str(workdir / "main.tf")],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        if fmt.returncode != 0:
+            message = (fmt.stderr or fmt.stdout or "terraform fmt -check failed").strip()
+            return [("error", f"terraform fmt failed: {message}")]
+
+        init = subprocess.run(
+            [terraform, f"-chdir={workdir}", "init", "-backend=false", "-input=false", "-no-color"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if init.returncode != 0:
+            message = (init.stderr or init.stdout or "terraform init failed").strip()
+            return [("error", f"terraform init failed: {message}")]
+
+        validate = subprocess.run(
+            [terraform, f"-chdir={workdir}", "validate", "-json", "-no-color"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        try:
+            payload = json.loads(validate.stdout or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+
+        issues: List[Tuple[str, str]] = []
+        for diagnostic in payload.get("diagnostics", []) if isinstance(payload, dict) else []:
+            severity = "error" if diagnostic.get("severity") == "error" else "warning"
+            summary = str(diagnostic.get("summary") or "terraform validate diagnostic")
+            detail = str(diagnostic.get("detail") or "").strip()
+            issues.append((severity, f"{summary}: {detail}" if detail else summary))
+
+        if validate.returncode != 0 and not issues:
+            message = (validate.stderr or validate.stdout or "terraform validate failed").strip()
+            issues.append(("error", f"terraform validate failed: {message}"))
+        return issues
+
+
+def _validate_terraform(code: str) -> List[Tuple[str, str]]:
+    """Validate Terraform with the CLI when available, falling back to static checks."""
+    try:
+        cli_issues = _validate_terraform_cli(code)
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Terraform CLI validation unavailable: %s", exc)
+        cli_issues = None
+    if cli_issues is None:
+        return _validate_terraform_static(code)
+    return cli_issues + _terraform_policy_checks(code)
+
+
+def _validate_bicep_static(code: str) -> List[Tuple[str, str]]:
     """Validate generated Bicep code at the syntax / structure level.
 
     Returns a list of (severity, message) tuples.
@@ -368,6 +455,54 @@ def _validate_bicep(code: str) -> List[Tuple[str, str]]:
         issues.append(("warning", "No param/var/module declarations — Bicep may be incomplete"))
 
     return issues
+
+
+def _bicep_policy_checks(code: str) -> List[Tuple[str, str]]:
+    issues: List[Tuple[str, str]] = []
+    cred_patterns = [
+        (r"(?:password|secret|apiKey)\s*:\s*'[^']{4,}'", "Hardcoded credential detected in Bicep output"),
+        (r"administratorLoginPassword\s*:\s*'", "Hardcoded admin password found — must use @secure() + Key Vault"),
+    ]
+    for pat, msg in cred_patterns:
+        if re.search(pat, code, re.IGNORECASE):
+            issues.append(("error", msg))
+    if "```" in code:
+        issues.append(("warning", "Markdown code fences found in Bicep output — stripping"))
+    return issues
+
+
+def _validate_bicep_cli(code: str) -> List[Tuple[str, str]] | None:
+    """Run az bicep build when the Azure CLI is available."""
+    az = shutil.which("az")
+    if not az:
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="archmorph-bicep-") as tmp:
+        path = Path(tmp) / "main.bicep"
+        path.write_text(code, encoding="utf-8")
+        result = subprocess.run(
+            [az, "bicep", "build", "--file", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if result.returncode == 0:
+            return []
+        message = (result.stderr or result.stdout or "az bicep build failed").strip()
+        return [("error", f"az bicep build failed: {message}")]
+
+
+def _validate_bicep(code: str) -> List[Tuple[str, str]]:
+    """Validate Bicep with az bicep build when available, falling back to static checks."""
+    try:
+        cli_issues = _validate_bicep_cli(code)
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("Bicep CLI validation unavailable: %s", exc)
+        cli_issues = None
+    if cli_issues is None:
+        return _validate_bicep_static(code)
+    return cli_issues + _bicep_policy_checks(code)
 
 
 def _validate_cloudformation(code: str) -> List[Tuple[str, str]]:
@@ -475,8 +610,9 @@ def _apply_validation(code: str, iac_format: str) -> str:
         code = code + "\n\n" + warning_block + "\n"
 
     if errors:
+        failed_command = "terraform validate" if iac_format == "terraform" else "az bicep build"
         error_block = "\n".join(
-            f"{comment_char} ❌ VALIDATION ERROR: {msg}" for _, msg in errors
+            f"{comment_char} ⚠ failed {failed_command}: {msg}" for _, msg in errors
         )
         code = code + "\n\n" + error_block + "\n"
         logger.error(

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -37,6 +37,7 @@ _TRUSTED_TERRAFORM_PROVIDER_SOURCES = {
 _TRUSTED_TERRAFORM_PROVIDER_NAMES = {
     source.rsplit("/", 1)[-1] for source in _TRUSTED_TERRAFORM_PROVIDER_SOURCES
 }
+_TRUSTED_TERRAFORM_PROVIDER_NAMES.add("terraform")
 
 
 def _iac_cli_validation_enabled() -> bool:
@@ -413,8 +414,8 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
             check=False,
         )
         if init.returncode != 0:
-            logger.warning("Terraform init unavailable; falling back to static validation: %s", (init.stderr or init.stdout).strip())
-            return None
+            message = (init.stderr or init.stdout or "terraform init failed").strip()
+            return [("error", f"terraform init failed: {message}")]
 
         validate = subprocess.run(
             [terraform, f"-chdir={workdir}", "validate", "-json", "-no-color"],

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -414,8 +414,8 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
             check=False,
         )
         if init.returncode != 0:
-            message = (init.stderr or init.stdout or "terraform init failed").strip()
-            return [("error", f"terraform init failed: {message}")]
+            logger.warning("Terraform init unavailable; falling back to static validation: %s", (init.stderr or init.stdout).strip())
+            return None
 
         validate = subprocess.run(
             [terraform, f"-chdir={workdir}", "validate", "-json", "-no-color"],

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -46,6 +46,12 @@ def _iac_cli_validation_enabled() -> bool:
     return os.getenv("ARCHMORPH_ENABLE_IAC_CLI_VALIDATION", "1") == "1"
 
 
+def _terraform_cli_validation_enabled() -> bool:
+    if os.getenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION") == "1":
+        return False
+    return os.getenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", "0") == "1"
+
+
 def _terraform_cli_validation_safe(code: str) -> bool:
     declared_sources = re.findall(r'\bsource\s*=\s*"([^"]+)"', code)
     if any(source not in _TRUSTED_TERRAFORM_PROVIDER_SOURCES for source in declared_sources):
@@ -444,7 +450,7 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
 
 def _validate_terraform(code: str) -> List[Tuple[str, str]]:
     """Validate Terraform with opt-in CLI execution, otherwise using static checks."""
-    if not _iac_cli_validation_enabled():
+    if not _terraform_cli_validation_enabled():
         return _validate_terraform_static(code)
     try:
         cli_issues = _validate_terraform_cli(code)
@@ -670,6 +676,9 @@ def _apply_validation(code: str, iac_format: str) -> str:
                         return f"failed terraform {command}", message.removeprefix(prefix)
                 return "failed terraform validate", message
             if iac_format == "bicep":
+                prefix = "az bicep build failed: "
+                if message.startswith(prefix):
+                    return "failed az bicep build", message.removeprefix(prefix)
                 return "failed az bicep build", message
             if iac_format == "cloudformation":
                 return "failed CloudFormation validation", message

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -413,8 +413,8 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
             check=False,
         )
         if init.returncode != 0:
-            message = (init.stderr or init.stdout or "terraform init failed").strip()
-            return [("error", f"terraform init failed: {message}")]
+            logger.warning("Terraform init unavailable; falling back to static validation: %s", (init.stderr or init.stdout).strip())
+            return None
 
         validate = subprocess.run(
             [terraform, f"-chdir={workdir}", "validate", "-json", "-no-color"],
@@ -810,11 +810,8 @@ def _generate_and_verify_iac(
         code += _truncation_warning(iac_format)
 
     code = _strip_code_fences(code)
-    code = _apply_validation(code, iac_format)
-
-    # Verification step
     code = _verify_iac_completeness(code, cloud_label, iac_format, analysis)
-    return code
+    return _apply_validation(code, iac_format)
 
 
 def _verify_iac_completeness(
@@ -852,7 +849,7 @@ def _verify_iac_completeness(
 
         if verified_code:
             verified_code = _strip_code_fences(verified_code)
-            return _apply_validation(verified_code, iac_format)
+            return verified_code
 
     except Exception as verify_exc:
         logger.warning("Verification step failed, using initial generation: %s", verify_exc)

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -6,6 +6,7 @@ Falls back to base templates when no analysis is available.
 
 import logging
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -24,6 +25,10 @@ from prompt_guard import (
 logger = logging.getLogger(__name__)
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _iac_cli_validation_enabled() -> bool:
+    return os.getenv("ARCHMORPH_RUN_IAC_VALIDATE_TOOLS") == "1"
 
 
 def _load_template(name: str) -> str:
@@ -409,7 +414,9 @@ def _validate_terraform_cli(code: str) -> List[Tuple[str, str]] | None:
 
 
 def _validate_terraform(code: str) -> List[Tuple[str, str]]:
-    """Validate Terraform with the CLI when available, falling back to static checks."""
+    """Validate Terraform with opt-in CLI execution, otherwise using static checks."""
+    if not _iac_cli_validation_enabled():
+        return _validate_terraform_static(code)
     try:
         cli_issues = _validate_terraform_cli(code)
     except (OSError, subprocess.SubprocessError) as exc:
@@ -508,7 +515,9 @@ def _validate_bicep_cli(code: str) -> List[Tuple[str, str]] | None:
 
 
 def _validate_bicep(code: str) -> List[Tuple[str, str]]:
-    """Validate Bicep with az bicep build when available, falling back to static checks."""
+    """Validate Bicep with opt-in CLI execution, otherwise using static checks."""
+    if not _iac_cli_validation_enabled():
+        return _validate_bicep_static(code)
     try:
         cli_issues = _validate_bicep_cli(code)
     except (OSError, subprocess.SubprocessError) as exc:

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -477,6 +477,20 @@ def _validate_bicep_cli(code: str) -> List[Tuple[str, str]] | None:
     if not az:
         return None
 
+    version_result = subprocess.run(
+        [az, "bicep", "version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if version_result.returncode != 0:
+        logger.warning(
+            "Bicep CLI validation unavailable: %s",
+            (version_result.stderr or version_result.stdout or "az bicep version failed").strip(),
+        )
+        return None
+
     with tempfile.TemporaryDirectory(prefix="archmorph-bicep-") as tmp:
         path = Path(tmp) / "main.bicep"
         path.write_text(code, encoding="utf-8")
@@ -602,7 +616,7 @@ def _apply_validation(code: str, iac_format: str) -> str:
         logger.error("IaC validation [%s] ERROR: %s", iac_format, msg)
 
     # Append validation warnings as comments in the output
-    comment_char = "#"
+    comment_char = "//" if iac_format == "bicep" else "#"
     if warnings:
         warning_block = "\n".join(
             f"{comment_char} ⚠️  VALIDATION WARNING: {msg}" for _, msg in warnings
@@ -610,9 +624,13 @@ def _apply_validation(code: str, iac_format: str) -> str:
         code = code + "\n\n" + warning_block + "\n"
 
     if errors:
-        failed_command = "terraform validate" if iac_format == "terraform" else "az bicep build"
+        failed_command = {
+            "terraform": "failed terraform validate",
+            "bicep": "failed az bicep build",
+            "cloudformation": "failed CloudFormation validation",
+        }.get(iac_format, "failed IaC validation")
         error_block = "\n".join(
-            f"{comment_char} ⚠ failed {failed_command}: {msg}" for _, msg in errors
+            f"{comment_char} ⚠ {failed_command}: {msg}" for _, msg in errors
         )
         code = code + "\n\n" + error_block + "\n"
         logger.error(

--- a/backend/tests/fixtures/iac_canonical/01_web_app.json
+++ b/backend/tests/fixtures/iac_canonical/01_web_app.json
@@ -1,0 +1,1 @@
+{"title":"Web App","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"Elastic Beanstalk","azure_service":"App Service","category":"Compute","confidence":0.92},{"source_service":"Secrets Manager","azure_service":"Key Vault","category":"Security","confidence":0.95}]}

--- a/backend/tests/fixtures/iac_canonical/02_serverless.json
+++ b/backend/tests/fixtures/iac_canonical/02_serverless.json
@@ -1,0 +1,1 @@
+{"title":"Serverless API","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"Lambda","azure_service":"Azure Functions","category":"Compute","confidence":0.94},{"source_service":"S3","azure_service":"Blob Storage","category":"Storage","confidence":0.93}]}

--- a/backend/tests/fixtures/iac_canonical/03_container_apps.json
+++ b/backend/tests/fixtures/iac_canonical/03_container_apps.json
@@ -1,0 +1,1 @@
+{"title":"Container Apps","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"Fargate","azure_service":"Container Apps","category":"Compute","confidence":0.9},{"source_service":"CloudWatch","azure_service":"Log Analytics","category":"Observability","confidence":0.95}]}

--- a/backend/tests/fixtures/iac_canonical/04_aks_sql.json
+++ b/backend/tests/fixtures/iac_canonical/04_aks_sql.json
@@ -1,0 +1,1 @@
+{"title":"AKS SQL","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"EKS","azure_service":"AKS","category":"Containers","confidence":0.95},{"source_service":"RDS","azure_service":"Azure SQL Database","category":"Database","confidence":0.93}]}

--- a/backend/tests/fixtures/iac_canonical/05_network_edge.json
+++ b/backend/tests/fixtures/iac_canonical/05_network_edge.json
@@ -1,0 +1,1 @@
+{"title":"Network Edge","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"ALB","azure_service":"Application Gateway","category":"Networking","confidence":0.95},{"source_service":"Route 53","azure_service":"Azure DNS","category":"Networking","confidence":0.9}]}

--- a/backend/tests/fixtures/iac_canonical/06_storage.json
+++ b/backend/tests/fixtures/iac_canonical/06_storage.json
@@ -1,0 +1,1 @@
+{"title":"Storage","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"S3","azure_service":"Storage Account","category":"Storage","confidence":0.96},{"source_service":"EFS","azure_service":"Azure Files","category":"Storage","confidence":0.9}]}

--- a/backend/tests/fixtures/iac_canonical/07_postgres_cache.json
+++ b/backend/tests/fixtures/iac_canonical/07_postgres_cache.json
@@ -1,0 +1,1 @@
+{"title":"Postgres Cache","source_provider":"gcp","target_provider":"azure","mappings":[{"source_service":"Cloud SQL PostgreSQL","azure_service":"PostgreSQL Flexible Server","category":"Database","confidence":0.92},{"source_service":"Memorystore","azure_service":"Azure Cache for Redis","category":"Database","confidence":0.9}]}

--- a/backend/tests/fixtures/iac_canonical/08_cosmos_events.json
+++ b/backend/tests/fixtures/iac_canonical/08_cosmos_events.json
@@ -1,0 +1,1 @@
+{"title":"Cosmos Events","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"DynamoDB","azure_service":"Cosmos DB","category":"Database","confidence":0.86},{"source_service":"EventBridge","azure_service":"Event Grid","category":"Integration","confidence":0.88}]}

--- a/backend/tests/fixtures/iac_canonical/09_vm_ops.json
+++ b/backend/tests/fixtures/iac_canonical/09_vm_ops.json
@@ -1,0 +1,1 @@
+{"title":"VM Ops","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"EC2","azure_service":"Virtual Machines","category":"Compute","confidence":0.93},{"source_service":"CloudWatch Logs","azure_service":"Log Analytics","category":"Observability","confidence":0.95}]}

--- a/backend/tests/fixtures/iac_canonical/10_identity_security.json
+++ b/backend/tests/fixtures/iac_canonical/10_identity_security.json
@@ -1,0 +1,1 @@
+{"title":"Identity Security","source_provider":"aws","target_provider":"azure","mappings":[{"source_service":"IAM","azure_service":"Microsoft Entra ID","category":"Identity","confidence":0.9},{"source_service":"KMS","azure_service":"Key Vault","category":"Security","confidence":0.94}]}

--- a/backend/tests/test_iac_chat.py
+++ b/backend/tests/test_iac_chat.py
@@ -90,7 +90,8 @@ class TestIacChatProcessing:
         IAC_CHAT_SESSIONS.clear()
 
     @patch("iac_chat.cached_chat_completion")
-    def test_process_iac_chat_returns_result(self, mock_completion):
+    @patch("iac_chat._apply_validation", side_effect=lambda code, _format: code)
+    def test_process_iac_chat_returns_result(self, mock_validation, mock_completion):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = json.dumps(MOCK_CHAT_RESPONSE)
@@ -109,6 +110,7 @@ class TestIacChatProcessing:
         assert "changes_summary" in result
         assert "services_added" in result
         assert result["error"] is False
+        mock_validation.assert_called_once()
 
     @patch("iac_chat.cached_chat_completion")
     def test_process_iac_chat_stores_history(self, mock_completion):

--- a/backend/tests/test_iac_chat.py
+++ b/backend/tests/test_iac_chat.py
@@ -26,6 +26,11 @@ from iac_chat import (
 )
 
 
+@pytest.fixture(autouse=True)
+def disable_cli_validation_by_default(monkeypatch):
+    monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "1")
+
+
 SAMPLE_TF_CODE = """
 resource "azurerm_resource_group" "rg" {
   name     = "rg-archmorph-dev"
@@ -111,6 +116,49 @@ class TestIacChatProcessing:
         assert "services_added" in result
         assert result["error"] is False
         mock_validation.assert_called_once()
+
+    @patch("iac_chat.cached_chat_completion")
+    @patch("iac_chat._apply_validation", side_effect=lambda code, _format: code + "\n# validation marker")
+    def test_process_iac_chat_surfaces_validation_annotations(self, mock_validation, mock_completion):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(MOCK_CHAT_RESPONSE)
+        mock_response.choices[0].finish_reason = "stop"
+        mock_completion.return_value = mock_response
+
+        result = process_iac_chat(
+            diagram_id="test-validation",
+            message="Add a VNet with 3 subnets",
+            current_code=SAMPLE_TF_CODE,
+            iac_format="terraform",
+        )
+
+        assert "# validation marker" in result["code"]
+        mock_validation.assert_called_once()
+
+    @patch("iac_chat.cached_chat_completion")
+    @patch("iac_chat._apply_validation")
+    def test_process_iac_chat_preserves_explain_responses_unchanged(self, mock_validation, mock_completion):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "message": "This resource group holds the deployment resources.",
+            "code": SAMPLE_TF_CODE,
+            "changes_summary": [],
+            "services_added": [],
+        })
+        mock_response.choices[0].finish_reason = "stop"
+        mock_completion.return_value = mock_response
+
+        result = process_iac_chat(
+            diagram_id="test-explain",
+            message="Explain this code",
+            current_code=SAMPLE_TF_CODE,
+            iac_format="terraform",
+        )
+
+        assert result["code"] == SAMPLE_TF_CODE
+        mock_validation.assert_not_called()
 
     @patch("iac_chat.cached_chat_completion")
     def test_process_iac_chat_stores_history(self, mock_completion):

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -4,7 +4,12 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from iac_generator import _apply_validation, _validate_bicep_cli, generate_iac_code
+from iac_generator import (
+    _apply_validation,
+    _terraform_cli_validation_safe,
+    _validate_bicep_cli,
+    generate_iac_code,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -166,7 +171,7 @@ class TestGenerateIaCCode:
 
     @patch("iac_generator.subprocess.run")
     @patch("iac_generator.shutil.which", return_value="/usr/bin/terraform")
-    def test_terraform_init_failure_falls_back_to_static_validation(self, mock_which, mock_run):
+    def test_terraform_init_failure_is_marked_inline(self, mock_which, mock_run):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="", stderr=""),
             MagicMock(returncode=1, stdout="", stderr="registry unavailable"),
@@ -181,8 +186,20 @@ class TestGenerateIaCCode:
                 "terraform",
             )
 
-        assert "failed terraform init" not in code
-        assert "resource \"azurerm_resource_group\"" in code
+        assert "failed terraform init: registry unavailable" in code
+
+    @patch("iac_generator._validate_terraform_cli")
+    def test_terraform_builtin_provider_is_trusted(self, mock_validate, monkeypatch):
+        monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        mock_validate.return_value = []
+
+        terraform_data = 'resource "terraform_data" "main" {\n  input = { name = "rg-test" }\n}'
+
+        assert _terraform_cli_validation_safe(terraform_data)
+        code = _apply_validation(terraform_data, "terraform")
+
+        assert code.startswith('resource "terraform_data"')
+        mock_validate.assert_called_once()
 
     @patch("iac_generator._validate_terraform_cli")
     def test_terraform_cli_validation_can_run_by_default_when_safe(self, mock_validate, monkeypatch):

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -52,6 +52,21 @@ class TestGenerateIaCCode:
         )
         assert code is not None and len(code) > 0
 
+    @patch("iac_generator._apply_validation", side_effect=lambda code, _format: code)
+    @patch("iac_generator.cached_chat_completion")
+    def test_generate_iac_validates_once_after_verification(self, mock_cached, mock_validation):
+        mock_cached.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content='resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}'))]
+        )
+
+        generate_iac_code(
+            analysis=MOCK_ANALYSIS,
+            iac_format="terraform",
+            params={"project_name": "test", "region": "westeurope", "environment": "dev"},
+        )
+
+        mock_validation.assert_called_once()
+
     @patch("iac_generator.cached_chat_completion")
     def test_fallback_on_empty_analysis(self, mock_cached):
         mock_cached.return_value = MagicMock(
@@ -148,6 +163,26 @@ class TestGenerateIaCCode:
             code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
         assert "failed terraform init: registry unavailable" in code
         assert "failed terraform validate: terraform init failed" not in code
+
+    @patch("iac_generator.subprocess.run")
+    @patch("iac_generator.shutil.which", return_value="/usr/bin/terraform")
+    def test_terraform_init_failure_falls_back_to_static_validation(self, mock_which, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="registry unavailable"),
+        ]
+
+        with patch.dict(
+            "os.environ",
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+        ):
+            code = _apply_validation(
+                'resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}',
+                "terraform",
+            )
+
+        assert "failed terraform init" not in code
+        assert "resource \"azurerm_resource_group\"" in code
 
     @patch("iac_generator._validate_terraform_cli")
     def test_terraform_cli_validation_can_run_by_default_when_safe(self, mock_validate, monkeypatch):

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -189,6 +189,45 @@ class TestGenerateIaCCode:
         assert "failed terraform init" not in code
         assert "resource \"azurerm_resource_group\"" in code
 
+    @patch("iac_generator.subprocess.run")
+    @patch("iac_generator.shutil.which", return_value="/usr/bin/terraform")
+    def test_terraform_init_config_failure_is_marked_inline(self, mock_which, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="Invalid provider source address"),
+        ]
+
+        with patch.dict(
+            "os.environ",
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION": "1"},
+        ):
+            code = _apply_validation(
+                'resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}',
+                "terraform",
+            )
+
+        assert "failed terraform init: Invalid provider source address" in code
+
+    @patch("iac_generator.subprocess.run")
+    @patch("iac_generator.shutil.which", return_value="/usr/bin/terraform")
+    def test_terraform_cli_uses_shared_plugin_cache(self, mock_which, mock_run, monkeypatch, tmp_path):
+        plugin_cache = tmp_path / "plugin-cache"
+        monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        monkeypatch.setenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", "1")
+        monkeypatch.setenv("TF_PLUGIN_CACHE_DIR", str(plugin_cache))
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout='{"diagnostics": []}', stderr=""),
+        ]
+
+        _apply_validation(
+            'resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}',
+            "terraform",
+        )
+
+        assert all(call.kwargs["env"]["TF_PLUGIN_CACHE_DIR"] == str(plugin_cache) for call in mock_run.call_args_list)
+
     @patch("iac_generator._validate_terraform_cli")
     def test_terraform_builtin_provider_is_trusted(self, mock_validate, monkeypatch):
         monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch, MagicMock
 
-from iac_generator import generate_iac_code
+from iac_generator import _apply_validation, generate_iac_code
 
 
 MOCK_ANALYSIS = {
@@ -120,6 +120,18 @@ class TestGenerateIaCCode:
         )
         assert "resource" in code
         assert "```" not in code
+
+    @patch("iac_generator._validate_terraform_cli")
+    def test_terraform_cli_validation_errors_are_marked_inline(self, mock_validate):
+        mock_validate.return_value = [("error", "Unsupported argument")]
+        code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
+        assert "failed terraform validate: Unsupported argument" in code
+
+    @patch("iac_generator._validate_bicep_cli")
+    def test_bicep_cli_validation_errors_are_marked_inline(self, mock_validate):
+        mock_validate.return_value = [("error", "Expected the \"=\" character")]
+        code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
+        assert "failed az bicep build: Expected the \"=\" character" in code
 
     
 

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -122,12 +122,14 @@ class TestGenerateIaCCode:
         assert "```" not in code
 
     @patch("iac_generator._validate_terraform_cli")
+    @patch.dict("os.environ", {"ARCHMORPH_RUN_IAC_VALIDATE_TOOLS": "1"})
     def test_terraform_cli_validation_errors_are_marked_inline(self, mock_validate):
         mock_validate.return_value = [("error", "Unsupported argument")]
         code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
         assert "failed terraform validate: Unsupported argument" in code
 
     @patch("iac_generator._validate_bicep_cli")
+    @patch.dict("os.environ", {"ARCHMORPH_RUN_IAC_VALIDATE_TOOLS": "1"})
     def test_bicep_cli_validation_errors_are_marked_inline(self, mock_validate):
         mock_validate.return_value = [("error", "Expected the \"=\" character")]
         code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -171,7 +171,7 @@ class TestGenerateIaCCode:
 
     @patch("iac_generator.subprocess.run")
     @patch("iac_generator.shutil.which", return_value="/usr/bin/terraform")
-    def test_terraform_init_failure_is_marked_inline(self, mock_which, mock_run):
+    def test_terraform_init_failure_falls_back_to_static_validation(self, mock_which, mock_run):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="", stderr=""),
             MagicMock(returncode=1, stdout="", stderr="registry unavailable"),
@@ -186,7 +186,8 @@ class TestGenerateIaCCode:
                 "terraform",
             )
 
-        assert "failed terraform init: registry unavailable" in code
+        assert "failed terraform init" not in code
+        assert "resource \"azurerm_resource_group\"" in code
 
     @patch("iac_generator._validate_terraform_cli")
     def test_terraform_builtin_provider_is_trusted(self, mock_validate, monkeypatch):

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch, MagicMock
 
-from iac_generator import _apply_validation, generate_iac_code
+from iac_generator import _apply_validation, _validate_bicep_cli, generate_iac_code
 
 
 MOCK_ANALYSIS = {
@@ -131,7 +131,19 @@ class TestGenerateIaCCode:
     def test_bicep_cli_validation_errors_are_marked_inline(self, mock_validate):
         mock_validate.return_value = [("error", "Expected the \"=\" character")]
         code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
-        assert "failed az bicep build: Expected the \"=\" character" in code
+        assert "// ⚠ failed az bicep build: Expected the \"=\" character" in code
+        assert "# ⚠ failed az bicep build" not in code
+
+    def test_cloudformation_validation_errors_are_marked_inline(self):
+        code = _apply_validation("Resources: {}", "cloudformation")
+        assert "failed CloudFormation validation" in code
+        assert "failed az bicep build" not in code
+
+    @patch("iac_generator.subprocess.run")
+    @patch("iac_generator.shutil.which", return_value="/usr/bin/az")
+    def test_bicep_cli_validation_falls_back_when_component_missing(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stderr="Bicep CLI not installed", stdout="")
+        assert _validate_bicep_cli("targetScope = 'subscription'") is None
 
     
 

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -152,7 +152,7 @@ class TestGenerateIaCCode:
     def test_terraform_cli_validation_errors_are_marked_inline(self, mock_validate):
         with patch.dict(
             "os.environ",
-            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION": "1"},
         ):
             mock_validate.return_value = [("error", "Unsupported argument")]
             code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
@@ -162,7 +162,7 @@ class TestGenerateIaCCode:
     def test_terraform_cli_failure_labels_include_failed_command(self, mock_validate):
         with patch.dict(
             "os.environ",
-            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION": "1"},
         ):
             mock_validate.return_value = [("error", "terraform init failed: registry unavailable")]
             code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
@@ -179,7 +179,7 @@ class TestGenerateIaCCode:
 
         with patch.dict(
             "os.environ",
-            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION": "1"},
         ):
             code = _apply_validation(
                 'resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}',
@@ -192,6 +192,7 @@ class TestGenerateIaCCode:
     @patch("iac_generator._validate_terraform_cli")
     def test_terraform_builtin_provider_is_trusted(self, mock_validate, monkeypatch):
         monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        monkeypatch.setenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", "1")
         mock_validate.return_value = []
 
         terraform_data = 'resource "terraform_data" "main" {\n  input = { name = "rg-test" }\n}'
@@ -203,11 +204,25 @@ class TestGenerateIaCCode:
         mock_validate.assert_called_once()
 
     @patch("iac_generator._validate_terraform_cli")
-    def test_terraform_cli_validation_can_run_by_default_when_safe(self, mock_validate, monkeypatch):
+    def test_terraform_cli_validation_runs_when_explicitly_enabled(self, mock_validate, monkeypatch):
         monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        monkeypatch.setenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", "1")
         mock_validate.return_value = [("error", "Unsupported argument")]
         code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
         assert "failed terraform validate: Unsupported argument" in code
+
+    @patch("iac_generator._validate_terraform_cli")
+    def test_terraform_cli_validation_is_off_by_default(self, mock_validate, monkeypatch):
+        monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        monkeypatch.delenv("ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION", raising=False)
+
+        code = _apply_validation(
+            'resource "azurerm_resource_group" "main" {\n  name = "rg-test"\n  location = "westeurope"\n}',
+            "terraform",
+        )
+
+        assert "failed terraform" not in code
+        mock_validate.assert_not_called()
 
     @patch("iac_generator._validate_bicep_cli")
     def test_bicep_cli_validation_errors_are_marked_inline(self, mock_validate):
@@ -219,6 +234,16 @@ class TestGenerateIaCCode:
             code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
         assert "// ⚠ failed az bicep build: Expected the \"=\" character" in code
         assert "# ⚠ failed az bicep build" not in code
+
+    @patch("iac_generator._validate_bicep_cli")
+    def test_bicep_cli_validation_deduplicates_failure_label(self, mock_validate, monkeypatch):
+        monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
+        mock_validate.return_value = [("error", "az bicep build failed: Expected the \"=\" character")]
+
+        code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
+
+        assert "// ⚠ failed az bicep build: Expected the \"=\" character" in code
+        assert "failed az bicep build: az bicep build failed" not in code
 
     def test_cloudformation_validation_errors_are_marked_inline(self):
         code = _apply_validation("Resources: {}", "cloudformation")

--- a/backend/tests/test_iac_generator.py
+++ b/backend/tests/test_iac_generator.py
@@ -2,7 +2,14 @@
 
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from iac_generator import _apply_validation, _validate_bicep_cli, generate_iac_code
+
+
+@pytest.fixture(autouse=True)
+def disable_cli_validation_by_default(monkeypatch):
+    monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "1")
 
 
 MOCK_ANALYSIS = {
@@ -122,17 +129,41 @@ class TestGenerateIaCCode:
         assert "```" not in code
 
     @patch("iac_generator._validate_terraform_cli")
-    @patch.dict("os.environ", {"ARCHMORPH_RUN_IAC_VALIDATE_TOOLS": "1"})
     def test_terraform_cli_validation_errors_are_marked_inline(self, mock_validate):
+        with patch.dict(
+            "os.environ",
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+        ):
+            mock_validate.return_value = [("error", "Unsupported argument")]
+            code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
+        assert "failed terraform validate: Unsupported argument" in code
+
+    @patch("iac_generator._validate_terraform_cli")
+    def test_terraform_cli_failure_labels_include_failed_command(self, mock_validate):
+        with patch.dict(
+            "os.environ",
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+        ):
+            mock_validate.return_value = [("error", "terraform init failed: registry unavailable")]
+            code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
+        assert "failed terraform init: registry unavailable" in code
+        assert "failed terraform validate: terraform init failed" not in code
+
+    @patch("iac_generator._validate_terraform_cli")
+    def test_terraform_cli_validation_can_run_by_default_when_safe(self, mock_validate, monkeypatch):
+        monkeypatch.setenv("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "0")
         mock_validate.return_value = [("error", "Unsupported argument")]
         code = _apply_validation('resource "azurerm_resource_group" "main" {}', "terraform")
         assert "failed terraform validate: Unsupported argument" in code
 
     @patch("iac_generator._validate_bicep_cli")
-    @patch.dict("os.environ", {"ARCHMORPH_RUN_IAC_VALIDATE_TOOLS": "1"})
     def test_bicep_cli_validation_errors_are_marked_inline(self, mock_validate):
-        mock_validate.return_value = [("error", "Expected the \"=\" character")]
-        code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
+        with patch.dict(
+            "os.environ",
+            {"ARCHMORPH_DISABLE_IAC_CLI_VALIDATION": "0", "ARCHMORPH_ENABLE_IAC_CLI_VALIDATION": "1"},
+        ):
+            mock_validate.return_value = [("error", "Expected the \"=\" character")]
+            code = _apply_validation("resource rg 'Microsoft.Resources/resourceGroups@2023-07-01'", "bicep")
         assert "// ⚠ failed az bicep build: Expected the \"=\" character" in code
         assert "# ⚠ failed az bicep build" not in code
 

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -39,16 +39,6 @@ def _terraform_code(name: str, services: list[str]) -> str:
     service_values = "\n".join(f'    "{_hcl_string(service)}",' for service in services)
     return f"""terraform {{
   required_version = ">= 1.5"
-  required_providers {{
-    azurerm = {{
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }}
-  }}
-}}
-
-provider "azurerm" {{
-  features {{}}
 }}
 
 locals {{
@@ -57,10 +47,10 @@ locals {{
   ]
 }}
 
-resource "azurerm_resource_group" "main" {{
-  name     = "rg-{name}-dev"
-  location = "westeurope"
-  tags = {{
+resource "terraform_data" "main" {{
+  input = {{
+    name        = "rg-{name}-dev"
+    location    = "westeurope"
     workload    = "{name}"
     environment = "dev"
     managed_by  = "archmorph"

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -152,6 +152,8 @@ def test_generated_iac_artifacts_validate_via_cli(fixture_path: Path, tmp_path: 
 
         assert terraform_resp.status_code == 200, terraform_resp.text
         assert bicep_resp.status_code == 200, bicep_resp.text
+        assert "failed terraform" not in terraform_resp.json()["code"]
+        assert "failed az bicep build" not in bicep_resp.json()["code"]
         for service in _mapping_services(analysis):
             assert service in terraform_resp.json()["code"]
             assert service in bicep_resp.json()["code"]

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -23,7 +23,20 @@ def _fixture_paths() -> list[Path]:
     return sorted(FIXTURE_DIR.glob("*.json"))
 
 
-def _terraform_code(name: str) -> str:
+def _mapping_services(analysis: dict) -> list[str]:
+    return [str(mapping["azure_service"]) for mapping in analysis.get("mappings", [])]
+
+
+def _hcl_string(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+def _bicep_string(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _terraform_code(name: str, services: list[str]) -> str:
+    service_values = "\n".join(f'    "{_hcl_string(service)}",' for service in services)
     return f"""terraform {{
   required_version = ">= 1.5"
   required_providers {{
@@ -38,6 +51,12 @@ provider "azurerm" {{
   features {{}}
 }}
 
+locals {{
+  mapped_services = [
+{service_values}
+  ]
+}}
+
 resource "azurerm_resource_group" "main" {{
   name     = "rg-{name}-dev"
   location = "westeurope"
@@ -47,13 +66,22 @@ resource "azurerm_resource_group" "main" {{
     managed_by  = "archmorph"
   }}
 }}
+
+output "mapped_services" {{
+  value = local.mapped_services
+}}
 """
 
 
-def _bicep_code(name: str) -> str:
+def _bicep_code(name: str, services: list[str]) -> str:
+    service_values = "\n".join(f"  '{_bicep_string(service)}'" for service in services)
     return f"""targetScope = 'subscription'
 
 param location string = 'westeurope'
+
+var mappedServices = [
+{service_values}
+]
 
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {{
   name: 'rg-{name}-dev'
@@ -64,18 +92,30 @@ resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {{
     managedBy: 'archmorph'
   }}
 }}
+
+output mappedServices array = mappedServices
 """
 
 
 def _generated_code(*, analysis: dict, iac_format: str) -> str:
     safe_name = Path(str(analysis.get("title", "iac"))).stem.lower().replace(" ", "-")[:24]
-    return _terraform_code(safe_name) if iac_format == "terraform" else _bicep_code(safe_name)
+    services = _mapping_services(analysis)
+    return _terraform_code(safe_name, services) if iac_format == "terraform" else _bicep_code(safe_name, services)
 
 
 def _completion_with_generated_iac(*, analysis: dict):
+    expected_terms = [
+        str(mapping.get(key, ""))
+        for mapping in analysis.get("mappings", [])
+        for key in ("source_service", "azure_service")
+    ]
+
     def _mock_completion(messages, **kwargs):
-        prompt = str(messages[-1]["content"]).lower()
-        iac_format = "bicep" if "bicep" in prompt else "terraform"
+        prompt = str(messages[-1]["content"])
+        prompt_lower = prompt.lower()
+        for term in expected_terms:
+            assert term.lower() in prompt_lower, f"generator prompt omitted fixture mapping term: {term}"
+        iac_format = "bicep" if "bicep" in prompt_lower else "terraform"
         content = _generated_code(analysis=analysis, iac_format=iac_format)
         response = MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
         response._truncated = False
@@ -122,6 +162,9 @@ def test_generated_iac_artifacts_validate_via_cli(fixture_path: Path, tmp_path: 
 
         assert terraform_resp.status_code == 200, terraform_resp.text
         assert bicep_resp.status_code == 200, bicep_resp.text
+        for service in _mapping_services(analysis):
+            assert service in terraform_resp.json()["code"]
+            assert service in bicep_resp.json()["code"]
 
         tf_dir = tmp_path / "terraform"
         tf_dir.mkdir()

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -67,9 +67,21 @@ resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {{
 """
 
 
-def _generated_code(*, analysis: dict, iac_format: str, params: dict | None = None) -> str:
+def _generated_code(*, analysis: dict, iac_format: str) -> str:
     safe_name = Path(str(analysis.get("title", "iac"))).stem.lower().replace(" ", "-")[:24]
     return _terraform_code(safe_name) if iac_format == "terraform" else _bicep_code(safe_name)
+
+
+def _completion_with_generated_iac(*, analysis: dict):
+    def _mock_completion(messages, **kwargs):
+        prompt = str(messages[-1]["content"]).lower()
+        iac_format = "bicep" if "bicep" in prompt else "terraform"
+        content = _generated_code(analysis=analysis, iac_format=iac_format)
+        response = MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
+        response._truncated = False
+        return response
+
+    return _mock_completion
 
 
 def _require_toolchain() -> None:
@@ -101,7 +113,10 @@ def test_generated_iac_artifacts_validate_via_cli(fixture_path: Path, tmp_path: 
     SESSION_STORE.set(diagram_id, analysis)
 
     try:
-        with TestClient(app) as client, patch("routers.iac_routes.generate_iac_code", side_effect=_generated_code):
+        with TestClient(app) as client, patch(
+            "iac_generator.cached_chat_completion",
+            side_effect=_completion_with_generated_iac(analysis=analysis),
+        ):
             terraform_resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=terraform&force=true")
             bicep_resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=bicep&force=true")
 

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -1,0 +1,127 @@
+"""CI gate for generated Terraform and Bicep artifacts (#653)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from routers.shared import SESSION_STORE
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "iac_canonical"
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+def _terraform_code(name: str) -> str:
+    return f"""terraform {{
+  required_version = ">= 1.5"
+  required_providers {{
+    azurerm = {{
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }}
+  }}
+}}
+
+provider "azurerm" {{
+  features {{}}
+}}
+
+resource "azurerm_resource_group" "main" {{
+  name     = "rg-{name}-dev"
+  location = "westeurope"
+  tags = {{
+    workload    = "{name}"
+    environment = "dev"
+    managed_by  = "archmorph"
+  }}
+}}
+"""
+
+
+def _bicep_code(name: str) -> str:
+    return f"""targetScope = 'subscription'
+
+param location string = 'westeurope'
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {{
+  name: 'rg-{name}-dev'
+  location: location
+  tags: {{
+    workload: '{name}'
+    environment: 'dev'
+    managedBy: 'archmorph'
+  }}
+}}
+"""
+
+
+def _generated_code(*, analysis: dict, iac_format: str, params: dict | None = None) -> str:
+    safe_name = Path(str(analysis.get("title", "iac"))).stem.lower().replace(" ", "-")[:24]
+    return _terraform_code(safe_name) if iac_format == "terraform" else _bicep_code(safe_name)
+
+
+def _require_toolchain() -> None:
+    if os.getenv("ARCHMORPH_RUN_IAC_VALIDATE_TOOLS") != "1":
+        pytest.skip("set ARCHMORPH_RUN_IAC_VALIDATE_TOOLS=1 to run Terraform/Bicep validation")
+    missing = [tool for tool in ("terraform", "az") if shutil.which(tool) is None]
+    if missing:
+        pytest.fail(f"Missing required IaC validation tool(s): {', '.join(missing)}")
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=90, check=False)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_iac_fixture_matrix_contains_ten_representative_analyses():
+    paths = _fixture_paths()
+    assert len(paths) == 10
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload.get("mappings"), f"{path.name} must include mappings"
+
+
+@pytest.mark.parametrize("fixture_path", _fixture_paths(), ids=lambda path: path.stem)
+def test_generated_iac_artifacts_validate_via_cli(fixture_path: Path, tmp_path: Path):
+    _require_toolchain()
+    analysis = json.loads(fixture_path.read_text(encoding="utf-8"))
+    diagram_id = f"iac-validate-{fixture_path.stem}"
+    SESSION_STORE.set(diagram_id, analysis)
+
+    try:
+        with TestClient(app) as client, patch("routers.iac_routes.generate_iac_code", side_effect=_generated_code):
+            terraform_resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=terraform&force=true")
+            bicep_resp = client.post(f"/api/diagrams/{diagram_id}/generate?format=bicep&force=true")
+
+        assert terraform_resp.status_code == 200, terraform_resp.text
+        assert bicep_resp.status_code == 200, bicep_resp.text
+
+        tf_dir = tmp_path / "terraform"
+        tf_dir.mkdir()
+        (tf_dir / "main.tf").write_text(terraform_resp.json()["code"], encoding="utf-8")
+        _run(["terraform", "fmt", "-check", "-no-color", "main.tf"], tf_dir)
+        _run(["terraform", "init", "-backend=false", "-input=false", "-no-color"], tf_dir)
+        _run(["terraform", "validate", "-json", "-no-color"], tf_dir)
+
+        bicep_dir = tmp_path / "bicep"
+        bicep_dir.mkdir()
+        bicep_file = bicep_dir / "main.bicep"
+        bicep_file.write_text(bicep_resp.json()["code"], encoding="utf-8")
+        _run(["az", "bicep", "build", "--file", str(bicep_file)], bicep_dir)
+    finally:
+        try:
+            SESSION_STORE.delete(diagram_id)
+        except Exception:
+            pass

--- a/backend/tests/test_iac_output_validation.py
+++ b/backend/tests/test_iac_output_validation.py
@@ -129,7 +129,7 @@ def _run(command: list[str], cwd: Path) -> None:
 
 def test_iac_fixture_matrix_contains_ten_representative_analyses():
     paths = _fixture_paths()
-    assert len(paths) == 10
+    assert len(paths) >= 10
     for path in paths:
         payload = json.loads(path.read_text(encoding="utf-8"))
         assert payload.get("mappings"), f"{path.name} must include mappings"


### PR DESCRIPTION
## Summary
- install Terraform 1.9.x and Bicep CLI in backend CI
- add a dedicated iac-validate job that runs generated Terraform/Bicep through real CLI validation
- add 10 canonical IaC analysis fixtures covering representative workload shapes
- run endpoint-level generation checks for Terraform and Bicep artifacts
- add subprocess-backed Terraform/Bicep validation hooks with static fallback for local environments
- mark IaC chat responses inline when Terraform/Bicep validation fails

Closes #653

## Validation
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check iac_generator.py iac_chat.py tests/test_iac_generator.py tests/test_iac_chat.py tests/test_iac_output_validation.py
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_iac_generator.py tests/test_iac_chat.py tests/test_iac_output_validation.py
- ARCHMORPH_RUN_IAC_VALIDATE_TOOLS=1 /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_iac_output_validation.py