### PR TITLE
feat: add DR readiness rubric to architecture package

### DIFF
--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -112,6 +112,20 @@ def _render_html_package(
         f"<div class=\"insight-row\"><div class=\"insight-h\">{html.escape(item[0])}</div><div class=\"insight-b\">{html.escape(item[1])}</div></div>"
         for item in _limitations(analysis, profile)
     )
+    dr_readiness = manifest.get("dr_readiness")
+    if not isinstance(dr_readiness, dict):
+        dr_readiness = _build_dr_readiness_rubric(analysis, profile)
+    dr_score = html.escape(str(dr_readiness["score"]))
+    dr_rating = html.escape(str(dr_readiness["rating"]))
+    dr_summary = html.escape(str(dr_readiness["summary"]))
+    dr_rows = "\n".join(
+        _render_dr_rubric_row(item)
+        for item in dr_readiness["dimensions"]
+    )
+    dr_limitations = "\n".join(
+        f"<li>{html.escape(item)}</li>"
+        for item in dr_readiness["limitations"]
+    )
     tier_summary = "\n".join(
         f"<li><strong>{html.escape(tier.title())}</strong><span>{html.escape(', '.join(names) or 'Review required')}</span></li>"
         for tier, names in _tier_summary(analysis)
@@ -161,12 +175,28 @@ def _render_html_package(
     .tiers li {{ display: grid; grid-template-columns: 130px 1fr; gap: 12px; margin: 0; padding: 9px 0; border-bottom: 1px solid #edf1f6; }}
     .tiers li:last-child {{ border-bottom: 0; }}
     .tiers span {{ color: var(--muted); overflow-wrap: anywhere; }}
+    .dr-layout {{ display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(360px, 0.55fr); gap: 16px; align-items: start; }}
+    .readiness-head {{ display: grid; grid-template-columns: auto 1fr; gap: 12px; align-items: center; margin-bottom: 12px; }}
+    .readiness-score {{ width: 72px; height: 72px; border: 1px solid #b8d8f5; border-radius: 8px; background: #edf4ff; color: #074f87; display: grid; place-items: center; font-size: 22px; font-weight: 800; }}
+    .readiness-head h2 {{ margin-bottom: 4px; }}
+    .readiness-head p {{ margin: 0; color: var(--muted); font-size: 12px; line-height: 1.45; }}
+    .rubric {{ display: grid; gap: 8px; }}
+    .rubric-row {{ border: 1px solid #e7edf5; border-radius: 8px; padding: 10px; background: #fbfdff; }}
+    .rubric-top {{ display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px; }}
+    .rubric-name {{ font-size: 13px; font-weight: 800; color: var(--ink); }}
+    .rubric-status {{ border-radius: 8px; padding: 3px 7px; font-size: 11px; font-weight: 800; color: #fff; white-space: nowrap; }}
+    .rubric-status.ready {{ background: #0f766e; }}
+    .rubric-status.partial {{ background: #b45309; }}
+    .rubric-status.gap {{ background: #b91c1c; }}
+    .rubric-note {{ font-size: 12px; line-height: 1.45; color: #314158; }}
+    .dr-limits {{ margin-top: 12px; padding-left: 18px; }}
+    .dr-limits li {{ font-size: 12px; }}
         .insight-list {{ display: grid; gap: 10px; }}
         .insight-row {{ border: 1px solid #e7edf5; border-radius: 8px; padding: 12px; background: #fbfdff; }}
         .insight-h {{ font-size: 13px; font-weight: 800; color: var(--ink); margin-bottom: 5px; }}
         .insight-b {{ font-size: 13px; line-height: 1.5; color: #314158; }}
         footer {{ margin-top: 16px; color: var(--muted); font-size: 12px; }}
-        @media (max-width: 900px) {{ .shell {{ padding: 12px; }} header {{ flex-direction: column; }} .meta-pills {{ justify-content: flex-start; }} .grid {{ grid-template-columns: 1fr; }} nav {{ grid-template-columns: 1fr; position: static; }} }}
+        @media (max-width: 900px) {{ .shell {{ padding: 12px; }} header {{ flex-direction: column; }} .meta-pills {{ justify-content: flex-start; }} .grid {{ grid-template-columns: 1fr; }} .dr-layout {{ grid-template-columns: 1fr; }} nav {{ grid-template-columns: 1fr; position: static; }} }}
   </style>
 </head>
 <body>
@@ -184,7 +214,7 @@ def _render_html_package(
     </nav>
     <main>
     <section id="as-is" class="panel active"><div class="diagram">{primary_svg}</div></section>
-    <section id="dr" class="panel"><div class="diagram">{dr_svg}</div></section>
+    <section id="dr" class="panel"><div class="dr-layout"><div class="diagram">{dr_svg}</div><aside class="block"><div class="readiness-head"><div class="readiness-score">{dr_score}</div><div><h2>DR Readiness Rubric</h2><p><strong>{dr_rating}</strong> · {dr_summary}</p></div></div><div class="rubric">{dr_rows}</div><ul class="dr-limits">{dr_limitations}</ul></aside></div></section>
         <section id="talking" class="panel"><div class="grid"><div class="block"><h2>Customer Intent</h2><div class="intent">{intent_rows}</div></div><div class="block"><h2>Recommended Narrative</h2><div class="insight-list">{talking_points}</div></div></div></section>
         <section id="limits" class="panel"><div class="grid"><div class="block"><h2>Service Tiers</h2><ul class="tiers">{tier_summary}</ul></div><div class="block"><h2>Assumptions And Constraints</h2><div class="insight-list">{limitations}</div></div></div></section>
   </main>
@@ -216,6 +246,7 @@ def _build_manifest(
 ) -> dict[str, Any]:
     profile = _profile_from_analysis(analysis)
     limitations = _limitations(analysis, profile)
+    dr_readiness = _build_dr_readiness_rubric(analysis, profile)
     source_provider = _source_label(analysis)
     raw_warnings = [str(w) for w in analysis.get("warnings", []) if w]
     unsupported = analysis.get("unsupported_assumptions") or analysis.get("unsupported") or []
@@ -241,6 +272,7 @@ def _build_manifest(
         "mapping_references": _mapping_references(analysis),
         "alz_profile": build_alz_profile(analysis),
         "traceability_map": build_traceability_map(analysis),
+        "dr_readiness": dr_readiness,
         "warnings": raw_warnings[:10],
         "limitations": [
             {"title": title, "detail": detail}
@@ -402,6 +434,224 @@ def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[t
     if dr_mode != "single-region":
         points.append(("Review DR before commitment", f"The DR view should be reviewed as a {dr_mode} pattern before committing RTO/RPO or runbook ownership."))
     return points[:6]
+
+
+def _build_dr_readiness_rubric(analysis: dict[str, Any], profile: dict[str, str]) -> dict[str, Any]:
+    context = _dr_readiness_context(analysis, profile)
+    dimensions = [
+        _score_dr_dimension(
+            "backup",
+            "Backup",
+            context,
+            ready_any=("backup", "recovery services", "snapshot", "point-in-time", "pitr", "vault"),
+            partial_any=("database", "sql", "storage", "blob", "file"),
+            ready_note="Backup policy evidence is present for detected data services.",
+            partial_note="Data services are detected, but backup policy, retention, or restore-test inputs are incomplete.",
+            gap_note="No backup or restore input was provided for the package.",
+        ),
+        _score_dr_dimension(
+            "replication",
+            "Replication",
+            context,
+            ready_any=("multi-region", "active-passive", "active-standby", "active-active", "geo-replication", "cross-region", "zone-redundant"),
+            partial_any=("availability zone", "zone", "ha", "99.9"),
+            ready_note="Availability intent indicates multi-region or cross-zone replication.",
+            partial_note="High availability is indicated, but cross-region replication evidence is incomplete.",
+            gap_note="No replication mode or RPO evidence was provided.",
+        ),
+        _score_dr_dimension(
+            "failover",
+            "Failover Routing",
+            context,
+            ready_any=("front door", "traffic manager", "global load", "failover", "waf", "application gateway"),
+            partial_any=("load balancer", "gateway", "ingress"),
+            ready_note="Global or regional failover routing services are detected.",
+            partial_note="Ingress is detected, but failover routing ownership or probe behavior is incomplete.",
+            gap_note="No failover routing component was detected.",
+        ),
+        _score_dr_dimension(
+            "identity",
+            "Identity Dependency",
+            context,
+            ready_any=("entra", "managed identity", "key vault", "rbac", "identity"),
+            partial_any=("secret", "iam", "credential", "oauth"),
+            ready_note="Identity and secret-management dependencies are represented in the detected services or intent.",
+            partial_note="Identity is implied, but dependency recovery order and break-glass ownership are incomplete.",
+            gap_note="No identity dependency input was provided.",
+        ),
+        _score_dr_dimension(
+            "durability",
+            "Data Durability",
+            context,
+            ready_any=("zone-redundant", "geo-redundant", "grs", "zrs", "sql", "storage", "blob", "files"),
+            partial_any=("database", "data", "file"),
+            ready_note="Durable data services or redundancy terms are present in the topology.",
+            partial_note="Data services are present, but durability tier and retention commitments are incomplete.",
+            gap_note="No durable data-store input was detected.",
+        ),
+        _score_dr_dimension(
+            "observability",
+            "Observability",
+            context,
+            ready_any=("monitor", "application insights", "log analytics", "alerts", "workbooks", "cloudwatch"),
+            partial_any=("logging", "metrics", "dashboard"),
+            ready_note="Monitoring, logging, or alerting services are included for DR review.",
+            partial_note="Telemetry is implied, but alert thresholds and DR dashboard ownership are incomplete.",
+            gap_note="No DR observability input was detected.",
+        ),
+        _score_dr_dimension(
+            "runbook",
+            "Runbook Completeness",
+            context,
+            ready_any=("runbook", "game day", "failover test", "owner", "operations"),
+            partial_any=("rto", "rpo", "recovery time", "recovery point"),
+            ready_note="Runbook, owner, or failover-test evidence is present.",
+            partial_note="RTO/RPO intent is present, but runbook owner, test cadence, or rollback steps are incomplete.",
+            gap_note="No runbook owner, test cadence, or failover procedure was provided.",
+        ),
+    ]
+    total = sum(int(item["points"]) for item in dimensions)
+    score = round((total / (len(dimensions) * 2)) * 100)
+    rating = "High readiness" if score >= 80 else "Medium readiness" if score >= 50 else "Low readiness"
+    detected = context["detected_services"]
+    availability = profile.get("availability") or "availability target not specified"
+    summary = f"{availability}; detected services reviewed: {', '.join(detected[:5]) if detected else 'none'}."
+    limitations = [str(item["limitation"]) for item in dimensions if item.get("limitation")]
+    if not limitations:
+        limitations = ["Rubric is still advisory until the customer validates recovery ownership and test evidence."]
+    return {
+        "schema_version": "dr-readiness-rubric/v1",
+        "score": score,
+        "rating": rating,
+        "summary": summary,
+        "dimensions": dimensions,
+        "limitations": limitations[:7],
+    }
+
+
+def _dr_readiness_context(analysis: dict[str, Any], profile: dict[str, str]) -> dict[str, Any]:
+    text_parts = [str(value) for value in profile.values() if value]
+    guided_answers = analysis.get("guided_answers")
+    if isinstance(guided_answers, dict):
+        text_parts.extend(_flatten_dr_values(guided_answers))
+    customer_intent = analysis.get("customer_intent")
+    if isinstance(customer_intent, dict):
+        text_parts.extend(_flatten_dr_values(customer_intent))
+    explicit = analysis.get("dr_readiness") or analysis.get("dr_readiness_inputs")
+    if isinstance(explicit, dict):
+        text_parts.extend(_flatten_dr_values(explicit))
+
+    detected_services: list[str] = []
+    categories: list[str] = []
+    for mapping in analysis.get("mappings", []):
+        if not isinstance(mapping, dict):
+            continue
+        service = mapping.get("azure_service") or mapping.get("target") or mapping.get("source_service")
+        if service:
+            detected_services.append(str(service))
+            text_parts.append(str(service))
+        if mapping.get("category"):
+            categories.append(str(mapping["category"]))
+            text_parts.append(str(mapping["category"]))
+    for connection in analysis.get("service_connections", []):
+        if isinstance(connection, dict):
+            text_parts.extend(_flatten_dr_values(connection))
+
+    return {
+        "text": " ".join(text_parts).lower(),
+        "detected_services": _dedupe(detected_services),
+        "categories": _dedupe(categories),
+    }
+
+
+def _score_dr_dimension(
+    key: str,
+    label: str,
+    context: dict[str, Any],
+    *,
+    ready_any: tuple[str, ...],
+    partial_any: tuple[str, ...],
+    ready_note: str,
+    partial_note: str,
+    gap_note: str,
+) -> dict[str, Any]:
+    text = str(context.get("text") or "")
+    if any(term in text for term in ready_any):
+        return {
+            "key": key,
+            "label": label,
+            "status": "ready",
+            "points": 2,
+            "note": _dr_note_with_services(ready_note, context),
+        }
+    if any(term in text for term in partial_any):
+        return {
+            "key": key,
+            "label": label,
+            "status": "partial",
+            "points": 1,
+            "note": _dr_note_with_services(partial_note, context),
+            "limitation": f"{label}: {partial_note}",
+        }
+    return {
+        "key": key,
+        "label": label,
+        "status": "gap",
+        "points": 0,
+        "note": gap_note,
+        "limitation": f"{label}: {gap_note}",
+    }
+
+
+def _dr_note_with_services(note: str, context: dict[str, Any]) -> str:
+    services = context.get("detected_services") or []
+    if not services:
+        return note
+    return f"{note} Detected services: {', '.join(services[:4])}."
+
+
+def _render_dr_rubric_row(item: dict[str, Any]) -> str:
+    status = str(item.get("status") or "gap")
+    label = html.escape(str(item.get("label") or "Review item"))
+    note = html.escape(str(item.get("note") or "Review required."))
+    status_label = html.escape(status.title())
+    return (
+        '<div class="rubric-row">'
+        '<div class="rubric-top">'
+        f'<div class="rubric-name">{label}</div>'
+        f'<div class="rubric-status {html.escape(status)}">{status_label}</div>'
+        '</div>'
+        f'<div class="rubric-note">{note}</div>'
+        '</div>'
+    )
+
+
+def _flatten_dr_values(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for item in value.values():
+            parts.extend(_flatten_dr_values(item))
+        return parts
+    if isinstance(value, (list, tuple, set)):
+        parts = []
+        for item in value:
+            parts.extend(_flatten_dr_values(item))
+        return parts
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        cleaned = item.strip()
+        key = cleaned.lower()
+        if cleaned and key not in seen:
+            seen.add(key)
+            out.append(cleaned)
+    return out
 
 
 def _source_label(analysis: dict[str, Any]) -> str:

--- a/backend/routers/services.py
+++ b/backend/routers/services.py
@@ -223,8 +223,14 @@ async def service_update_storage_preflight(_auth=Depends(verify_api_key)):
             "Managed identity Blob Storage preflight failed",
             details={
                 "ok": False,
-                "account_url_configured": result.get("account_url_configured", False),
-                "container": result.get("container", "service-catalog"),
+                "account_url_configured": False,
+                "container": "service-catalog",
+                "reason": "preflight_failed",
             },
         )
-    return result
+    return {
+        "ok": True,
+        "account_url_configured": True,
+        "container": "service-catalog",
+        "operations": ["write", "read", "list", "delete"],
+    }

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -57,6 +57,45 @@ GCP_ANALYSIS: dict = {
 }
 
 
+HIGH_DR_ANALYSIS: dict = {
+    **SAMPLE_ANALYSIS,
+    "title": "High DR Package Test",
+    "mappings": [
+        {"source_service": "Route 53", "azure_service": "Azure Front Door", "category": "Networking", "confidence": 0.95},
+        {"source_service": "RDS", "azure_service": "Azure SQL", "category": "Database", "confidence": 0.92},
+        {"source_service": "S3", "azure_service": "Blob Storage", "category": "Storage", "confidence": 0.94},
+        {"source_service": "IAM", "azure_service": "Entra ID", "category": "Identity", "confidence": 0.91},
+        {"source_service": "KMS", "azure_service": "Key Vault", "category": "Secrets", "confidence": 0.91},
+        {"source_service": "CloudWatch", "azure_service": "Azure Monitor", "category": "Monitoring", "confidence": 0.93},
+        {"source_service": "AWS Backup", "azure_service": "Recovery Services vault", "category": "Backup", "confidence": 0.9},
+    ],
+    "guided_answers": {
+        **SAMPLE_ANALYSIS["guided_answers"],
+        "arch_ha": "Multi-region active-passive with geo-replication",
+        "arch_dr_rpo": "<5 min",
+        "ops_runbook_owner": "Platform operations owner with quarterly game day",
+        "ops_failover_test": "Documented failover test and rollback runbook",
+        "data_backup_policy": "Recovery Services vault backup with restore testing",
+    },
+}
+
+
+LOW_DR_ANALYSIS: dict = {
+    "title": "Low DR Package Test",
+    "source_provider": "AWS",
+    "target_provider": "azure",
+    "zones": [{"id": 1, "name": "single-tier", "number": 1, "services": []}],
+    "mappings": [
+        {"source_service": "EC2", "azure_service": "Virtual Machines", "category": "Compute", "confidence": 0.83},
+    ],
+    "guided_answers": {
+        "env_target": "Development",
+        "arch_deploy_region": "East US",
+        "arch_ha": "Single region",
+    },
+}
+
+
 MIXED_ANALYSIS: dict = json.loads(
     (Path(__file__).parent / "fixtures" / "architecture_package_mixed_analysis.json").read_text(
         encoding="utf-8"
@@ -98,6 +137,8 @@ def test_architecture_package_html_manifest_contains_traceability_fields():
     assert len(manifest["customer_intent_profile_hash"]) == 64
     assert result["filename"] in manifest["artifact_filenames"]
     assert {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96} in manifest["mapping_references"]
+    assert manifest["dr_readiness"]["schema_version"] == "dr-readiness-rubric/v1"
+    assert len(manifest["dr_readiness"]["dimensions"]) == 7
     assert "archmorph-artifact-manifest" in result["content"]
 
 
@@ -152,6 +193,7 @@ def test_html_package_contains_tabs_and_namespaced_svg_ids():
     assert "Archmorph — Package Test Architecture Package" in content
     assert "A — Target Azure Topology" in content
     assert "B — DR Topology" in content
+    assert "DR Readiness Rubric" in content
     assert "Customer Intent" in content
     assert "East US" in content
     assert "(empty)" not in content
@@ -165,6 +207,78 @@ def test_html_package_contains_tabs_and_namespaced_svg_ids():
     assert 'id="a-primary"' in content
     assert 'id="a-dr"' in content
     assert 'marker-end="url(#a)"' not in content
+
+
+@pytest.mark.parametrize(
+    ("analysis", "rating"),
+    [
+        (HIGH_DR_ANALYSIS, "High readiness"),
+        (SAMPLE_ANALYSIS, "Medium readiness"),
+        (LOW_DR_ANALYSIS, "Low readiness"),
+    ],
+)
+def test_dr_readiness_rubric_scores_high_medium_and_low_examples(analysis, rating):
+    result = generate_architecture_package(analysis, format="html")
+    readiness = result["manifest"]["dr_readiness"]
+
+    assert readiness["rating"] == rating
+    if rating == "High readiness":
+        assert readiness["score"] >= 80
+    if rating == "Low readiness":
+        assert readiness["score"] < 50
+    assert "DR Readiness Rubric" in result["content"]
+    assert rating in result["content"]
+    assert {item["key"] for item in readiness["dimensions"]} == {
+        "backup",
+        "replication",
+        "failover",
+        "identity",
+        "durability",
+        "observability",
+        "runbook",
+    }
+
+
+def test_dr_readiness_rubric_surfaces_missing_inputs_as_limitations():
+    result = generate_architecture_package(LOW_DR_ANALYSIS, format="html")
+    readiness = result["manifest"]["dr_readiness"]
+
+    assert readiness["limitations"]
+    assert any("Backup" in item for item in readiness["limitations"])
+    assert any("Runbook" in item for item in readiness["limitations"])
+    assert "No backup or restore input was provided" in result["content"]
+
+
+def test_dr_readiness_rubric_ties_notes_to_detected_services_and_intent():
+    result = generate_architecture_package(HIGH_DR_ANALYSIS, format="html")
+    readiness = result["manifest"]["dr_readiness"]
+    notes = " ".join(str(item["note"]) for item in readiness["dimensions"])
+
+    assert "Multi-region active-passive" in readiness["summary"]
+    assert "Azure SQL" in notes
+    assert "Azure Front Door" in result["content"]
+
+
+def test_dr_readiness_html_uses_sanitized_manifest_rubric():
+    analysis = {
+        **LOW_DR_ANALYSIS,
+        "mappings": [
+            {
+                "source_service": "Sensitive Store",
+                "azure_service": "Blob Storage",
+                "category": "Storage",
+                "confidence": 0.82,
+            }
+        ],
+        "dr_readiness_inputs": {"backup_note": "token: restore-token"},
+    }
+
+    result = generate_architecture_package(analysis, format="html")
+    manifest_text = json.dumps(result["manifest"])
+
+    assert "restore-token" not in manifest_text
+    assert "restore-token" not in result["content"]
+    assert "token: restore-token" not in result["content"]
 
 
 @pytest.mark.parametrize(

--- a/docs/DIAGRAM_EXPORT_SPEC.md
+++ b/docs/DIAGRAM_EXPORT_SPEC.md
@@ -793,6 +793,23 @@ def generate_diagram(
           "schema_version": "azure-landing-zone-profile/v1",
           "name": "caf-avm-baseline"
         },
+        "dr_readiness": {
+          "schema_version": "dr-readiness-rubric/v1",
+          "score": 71,
+          "rating": "Medium readiness",
+          "summary": "Multi-region active-passive; detected services reviewed: Application Gateway, AKS, Azure SQL.",
+          "dimensions": [
+            {
+              "key": "backup",
+              "label": "Backup",
+              "status": "partial",
+              "points": 1,
+              "note": "Data services are detected, but backup policy, retention, or restore-test inputs are incomplete.",
+              "limitation": "Backup: Data services are detected, but backup policy, retention, or restore-test inputs are incomplete."
+            }
+          ],
+          "limitations": ["Backup: Data services are detected, but backup policy, retention, or restore-test inputs are incomplete."]
+        },
         "warnings": ["review warning text"],
         "limitations": [
           { "title": "Validate low-confidence mappings", "detail": "Owner validation is required." }
@@ -802,6 +819,8 @@ def generate_diagram(
       ```
 
       The manifest is emitted for both `format=html` and `format=svg` package exports. It is returned as the response `manifest` field and embedded into the artifact bytes as `archmorph-artifact-manifest` metadata. Manifest values are sanitized before emission; secret-like keys or values such as passwords, tokens, credentials, API keys, and connection strings are redacted. Raw `guided_answers` are intentionally excluded; reviewers should use `customer_intent_profile_hash` for profile traceability without exposing the source answer payload.
+
+      The DR tab in Architecture Package HTML includes a DR readiness rubric. The rubric scores seven review dimensions: backup, replication, failover routing, identity dependency, data durability, observability, and runbook completeness. Each dimension is marked `ready`, `partial`, or `gap` based on explicit customer intent, guided-answer evidence, detected Azure services, and service categories. Missing inputs are emitted as limitations; the renderer does not invent backup policies, RPOs, failover owners, or runbook evidence when those inputs are absent. The score is advisory and should be treated as a review artifact for platform, security, and operations owners, not as a production DR certification.
 
       Azure Landing Zone profile contract:
 

--- a/docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md
+++ b/docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md
@@ -36,7 +36,7 @@ Artifacts are written to `smoke-artifacts/architecture-package/<timestamp>/` by 
 | IaC | Terraform, Bicep, and CloudFormation outputs are non-empty, format-shaped, and free of markdown fences |
 | HLD | Markdown HLD is generated and customer DOCX/PDF/PPTX exports decode to real documents |
 | Cost | Cost JSON contains service rows and the CSV export contains a `TOTAL` row |
-| Architecture Package | HTML contains target, DR, customer intent, constraints, and inline SVG sections |
+| Architecture Package | HTML contains target, DR, DR readiness rubric, customer intent, constraints, and inline SVG sections |
 | Target and DR SVG | SVG XML parses and contains expected target/DR topology language |
 | Classic diagram | Excalidraw parses as JSON, Draw.io parses as mxGraph XML, and VDX parses as Visio XML |
 


### PR DESCRIPTION
## Summary
- add a seven-dimension DR readiness rubric to the Architecture Package DR tab and manifest
- surface missing backup, replication, failover, identity, durability, observability, and runbook inputs as limitations instead of guessing
- sanitize the storage preflight route response so raw service-updater exception text cannot flow to callers
- document the rubric contract and smoke evidence expectations

Closes #674
Fixes code scanning alert #207

## Validation
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m ruff check architecture_package.py routers/services.py tests/test_architecture_package.py tests/test_api.py tests/test_service_updater.py
- /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest -q tests/test_architecture_package.py tests/test_architecture_package_visual_snapshots.py tests/test_api.py::TestServiceUpdates tests/test_service_updater.py::TestBlobPersistence::test_blob_preflight_requires_account_url tests/test_service_updater.py::TestBlobPersistence::test_blob_preflight_exercises_managed_identity_operations tests/test_service_updater.py::TestBlobPersistence::test_blob_preflight_cleans_probe_after_list_failure