### PR TITLE
feat(cli): add full-spine archmorph run workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,33 @@ jobs:
           ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION: "1"
 
   # ============================================
+  # CLI FULL-SPINE ARTIFACT CONTRACT
+  # ============================================
+  cli-full-spine-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install CLI test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e cli pytest
+
+      - name: Run CLI full-spine artifact contract tests
+        run: python -m pytest -q cli/tests/test_archmorph_cli_run.py
+
+      - name: Run container-backed CLI full-spine smoke
+        run: bash scripts/cli_full_spine_container_smoke.sh
+        env:
+          DOCKER_BUILDKIT: "1"
+
+  # ============================================
   # FRONTEND BUILD & TEST (npm audit in security.yml)
   # ============================================
   frontend-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,11 @@ jobs:
       - name: Install CLI test dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt
           python -m pip install -e cli pytest
 
       - name: Run CLI full-spine artifact contract tests
-        run: python -m pytest -q cli/tests/test_archmorph_cli_run.py
+        run: python -m pytest -q cli/tests/test_archmorph_cli_run.py cli/tests/test_archmorph_cli_http_smoke.py
 
       - name: Run container-backed CLI full-spine smoke
         run: bash scripts/cli_full_spine_container_smoke.sh

--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 
 ## Quick Start
 
+### Full-Spine CLI Run
+
+Start with the engineer path when the backend is running locally or in production. This uploads a diagram, analyzes it, emits IaC, exports the Azure Landing Zone SVG, estimates cost, and writes deterministic artifacts without opening the browser.
+
+```bash
+archmorph run \
+    --diagram ./fixtures/aws.png \
+    --target-rg rg-platform-prod \
+    --emit terraform,bicep,alz-svg,cost \
+    --out ./infra
+```
+
+Artifacts are written as `analysis.json`, `terraform/main.tf`, `bicep/main.bicep`, `alz.svg`, `cost-estimate.json`, and `run-summary.json`. See [docs/CLI_USAGE.md](docs/CLI_USAGE.md) for API configuration, drift baseline comparison, and GitHub PR push examples.
+
 ### Prerequisites
 - Azure subscription
 - Azure CLI installed

--- a/backend/ci_smoke.py
+++ b/backend/ci_smoke.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import os
 from copy import deepcopy
 
+_NON_PRODUCTION_ENVIRONMENTS = {"ci", "dev", "development", "local", "test"}
+
 
 def enabled() -> bool:
-    return os.getenv("ARCHMORPH_CI_SMOKE_MODE", "").lower() in {"1", "true", "yes"}
+    smoke_flag = os.getenv("ARCHMORPH_CI_SMOKE_MODE", "").lower() in {"1", "true", "yes"}
+    environment = os.getenv("ENVIRONMENT", "").lower()
+    return smoke_flag and environment in _NON_PRODUCTION_ENVIRONMENTS
 
 
 def classification() -> dict:

--- a/backend/ci_smoke.py
+++ b/backend/ci_smoke.py
@@ -1,0 +1,110 @@
+"""Deterministic backend responses for CI full-spine smoke tests."""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+
+
+def enabled() -> bool:
+    return os.getenv("ARCHMORPH_CI_SMOKE_MODE", "").lower() in {"1", "true", "yes"}
+
+
+def classification() -> dict:
+    return {
+        "is_architecture_diagram": True,
+        "confidence": 0.99,
+        "image_type": "architecture_diagram",
+        "reason": "CI smoke mode",
+    }
+
+
+def analysis(diagram_id: str) -> dict:
+    payload = {
+        "diagram_type": "AWS Architecture",
+        "title": "CLI Full-Spine Smoke",
+        "source_provider": "aws",
+        "target_provider": "azure",
+        "architecture_patterns": ["multi-AZ", "web-tier"],
+        "services_detected": 3,
+        "zones": [
+            {
+                "id": 1,
+                "name": "Application",
+                "number": 1,
+                "services": [
+                    {"aws": "EC2", "azure": "Azure Virtual Machines", "confidence": 0.92},
+                    {"aws": "S3", "azure": "Azure Blob Storage", "confidence": 0.95},
+                    {"aws": "CloudWatch", "azure": "Azure Monitor", "confidence": 0.9},
+                ],
+            }
+        ],
+        "mappings": [
+            {
+                "source_service": "EC2",
+                "source_provider": "aws",
+                "azure_service": "Azure Virtual Machines",
+                "category": "Compute",
+                "confidence": 0.92,
+            },
+            {
+                "source_service": "S3",
+                "source_provider": "aws",
+                "azure_service": "Azure Blob Storage",
+                "category": "Storage",
+                "confidence": 0.95,
+            },
+            {
+                "source_service": "CloudWatch",
+                "source_provider": "aws",
+                "azure_service": "Azure Monitor",
+                "category": "Monitoring",
+                "confidence": 0.9,
+            },
+        ],
+        "service_connections": [
+            {"from": "EC2", "to": "S3", "protocol": "HTTPS", "type": "storage"},
+            {"from": "CloudWatch", "to": "EC2", "protocol": "HTTPS", "type": "metrics"},
+        ],
+        "warnings": [],
+        "confidence_summary": {"high": 3, "medium": 0, "low": 0, "average": 0.92},
+    }
+    payload["diagram_id"] = diagram_id
+    payload["image_classification"] = classification()
+    return payload
+
+
+def iac_code(iac_format: str, project_name: str = "cli-smoke", region: str = "westeurope") -> str:
+    if iac_format == "bicep":
+        return f"""targetScope = 'subscription'
+
+param location string = '{region}'
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {{
+  name: 'rg-{project_name}'
+  location: location
+}}
+
+output resourceGroupName string = rg.name
+"""
+    if iac_format == "terraform":
+        return f"""terraform {{
+  required_version = ">= 1.5"
+}}
+
+resource "terraform_data" "main" {{
+  input = {{
+    project = "{project_name}"
+    region  = "{region}"
+  }}
+}}
+
+output "project_name" {{
+  value = terraform_data.main.input.project
+}}
+"""
+    return f"# Unsupported CI smoke IaC format: {iac_format}\n"
+
+
+def clone_analysis(diagram_id: str) -> dict:
+    return deepcopy(analysis(diagram_id))

--- a/backend/iac_generator.py
+++ b/backend/iac_generator.py
@@ -14,6 +14,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional, List, Tuple
 
+import ci_smoke
 from openai_client import cached_chat_completion, AZURE_OPENAI_DEPLOYMENT
 from prompt_guard import (
     sanitize_iac_param,
@@ -786,6 +787,9 @@ def generate_iac_code(analysis: Optional[dict], iac_format: str = "terraform", p
         params.get("region", "westeurope"), "region",
         allowed_values=_VALID_REGIONS, default="westeurope",
     )
+
+    if ci_smoke.enabled():
+        return ci_smoke.iac_code(iac_format, safe_project, safe_region)
 
     # No analysis — return base template
     if not analysis or not analysis.get("mappings"):

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -22,6 +22,7 @@ from routers.shared import (
     SESSION_STORE, IMAGE_STORE,
     limiter, verify_api_key, MAX_UPLOAD_SIZE, generate_session_id,
 )
+import ci_smoke
 from job_queue import job_manager
 from usage_metrics import record_event, record_funnel_step
 from export_capabilities import attach_export_capability
@@ -282,6 +283,13 @@ async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verif
     image_b64, content_type = IMAGE_STORE[diagram_id]
     image_bytes = base64.b64decode(image_b64) if isinstance(image_b64, str) else image_b64
     logger.info("Analyzing diagram %s (%s bytes)", str(diagram_id).replace('\n', '').replace('\r', ''), str(len(image_bytes)).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom
+
+    if ci_smoke.enabled():
+        result = ci_smoke.clone_analysis(diagram_id)
+        SESSION_STORE[diagram_id] = result
+        record_event("analyses_run", {"diagram_id": diagram_id, "services": result["services_detected"]})
+        record_funnel_step(diagram_id, "analyze")
+        return attach_export_capability(result, diagram_id)
 
     # No need to pre-compress, vision analyzer and classifier handle it internally
     compressed_bytes, compressed_type = image_bytes, content_type

--- a/backend/tests/test_ci_smoke.py
+++ b/backend/tests/test_ci_smoke.py
@@ -1,0 +1,18 @@
+import ci_smoke
+
+
+def test_ci_smoke_requires_non_production_environment(monkeypatch):
+    monkeypatch.setenv("ARCHMORPH_CI_SMOKE_MODE", "1")
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    assert ci_smoke.enabled() is False
+
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    assert ci_smoke.enabled() is True
+
+
+def test_ci_smoke_disabled_without_flag(monkeypatch):
+    monkeypatch.delenv("ARCHMORPH_CI_SMOKE_MODE", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+
+    assert ci_smoke.enabled() is False

--- a/backend/tests/test_cli_run_http_smoke.py
+++ b/backend/tests/test_cli_run_http_smoke.py
@@ -1,0 +1,177 @@
+"""HTTP smoke for `archmorph run` against the FastAPI app (#660)."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import requests
+import uvicorn
+from click.testing import CliRunner
+
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "false")
+os.environ.setdefault("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "1")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+REPO_DIR = BACKEND_DIR.parent
+CLI_DIR = REPO_DIR / "cli"
+if str(CLI_DIR) not in sys.path:
+    sys.path.insert(0, str(CLI_DIR))
+
+import archmorph_cli  # noqa: E402
+import usage_metrics  # noqa: E402
+from main import IMAGE_STORE, SESSION_STORE, app  # noqa: E402
+
+try:
+    atexit.unregister(usage_metrics._shutdown_flush)
+except ValueError:
+    pass
+
+
+SMOKE_ANALYSIS = {
+    "diagram_type": "AWS Architecture",
+    "title": "CLI Run Smoke",
+    "source_provider": "aws",
+    "target_provider": "azure",
+    "architecture_patterns": ["multi-AZ"],
+    "services_detected": 3,
+    "zones": [
+        {
+            "id": 1,
+            "name": "Compute",
+            "number": 1,
+            "services": [
+                {"aws": "EC2", "azure": "Azure Virtual Machines", "confidence": 0.92},
+                {"aws": "S3", "azure": "Azure Blob Storage", "confidence": 0.95},
+            ],
+        }
+    ],
+    "mappings": [
+        {"source_service": "EC2", "source_provider": "aws", "azure_service": "Azure Virtual Machines", "category": "Compute", "confidence": 0.92},
+        {"source_service": "S3", "source_provider": "aws", "azure_service": "Azure Blob Storage", "category": "Storage", "confidence": 0.95},
+        {"source_service": "CloudWatch", "source_provider": "aws", "azure_service": "Azure Monitor", "category": "Monitoring", "confidence": 0.9},
+    ],
+    "service_connections": [
+        {"from": "EC2", "to": "S3", "protocol": "HTTPS", "type": "storage"},
+        {"from": "CloudWatch", "to": "EC2", "protocol": "HTTPS", "type": "metrics"},
+    ],
+    "warnings": [],
+    "confidence_summary": {"high": 3, "medium": 0, "low": 0, "average": 0.92},
+}
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _start_server(port: int) -> tuple[uvicorn.Server, threading.Thread]:
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", lifespan="off")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"http://127.0.0.1:{port}/api/health", timeout=1)
+            if response.status_code == 200:
+                return server, thread
+        except requests.RequestException:
+            time.sleep(0.1)
+    server.should_exit = True
+    thread.join(timeout=5)
+    raise RuntimeError("test server did not become ready")
+
+
+def _mock_completion_for_iac(messages, **kwargs):
+    prompt = str(messages[-1]["content"])
+    assert "Azure Virtual Machines" in prompt
+    assert "Azure Blob Storage" in prompt
+    if "bicep" in prompt.lower():
+        content = """targetScope = 'subscription'
+param location string = 'westeurope'
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: 'rg-cli-smoke-dev'
+  location: location
+}
+"""
+    else:
+        content = """terraform {
+  required_version = ">= 1.5"
+}
+
+resource "terraform_data" "main" {
+  input = {
+    name = "rg-cli-smoke-dev"
+  }
+}
+"""
+    return MagicMock(choices=[MagicMock(message=MagicMock(content=content))], _truncated=False)
+
+
+def test_archmorph_run_smokes_over_http(monkeypatch, tmp_path):
+    import routers.diagrams as diagrams_router
+    import iac_generator
+
+    SESSION_STORE.clear()
+    IMAGE_STORE.clear()
+    monkeypatch.setattr(diagrams_router, "classify_image", lambda *_args, **_kwargs: {
+        "is_architecture_diagram": True,
+        "confidence": 0.99,
+        "image_type": "architecture_diagram",
+        "reason": "CLI smoke",
+    })
+    monkeypatch.setattr(diagrams_router, "analyze_image", lambda *_args, **_kwargs: dict(SMOKE_ANALYSIS))
+    monkeypatch.setattr(iac_generator, "cached_chat_completion", _mock_completion_for_iac)
+
+    port = _free_port()
+    server, thread = _start_server(port)
+    try:
+        diagram = tmp_path / "aws.png"
+        diagram.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\0" * 100)
+        out_dir = tmp_path / "infra"
+
+        result = CliRunner().invoke(
+            archmorph_cli.cli,
+            [
+                "--api-url",
+                f"http://127.0.0.1:{port}",
+                "run",
+                "--diagram",
+                str(diagram),
+                "--target-rg",
+                "rg-cli-smoke-dev",
+                "--emit",
+                "terraform,bicep,alz-svg,cost",
+                "--out",
+                str(out_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        analysis = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+        assert analysis["cli_run"]["target_resource_group"] == "rg-cli-smoke-dev"
+        assert analysis["iac_parameters"]["project_name"] == "cli-smoke-dev"
+        assert 'resource "terraform_data"' in (out_dir / "terraform" / "main.tf").read_text(encoding="utf-8")
+        assert "targetScope" in (out_dir / "bicep" / "main.bicep").read_text(encoding="utf-8")
+        ET.fromstring((out_dir / "alz.svg").read_text(encoding="utf-8"))
+        cost = json.loads((out_dir / "cost-estimate.json").read_text(encoding="utf-8"))
+        assert cost["currency"] == "USD"
+        summary = json.loads((out_dir / "run-summary.json").read_text(encoding="utf-8"))
+        assert summary["artifacts"]["analysis"].endswith("analysis.json")
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        SESSION_STORE.clear()
+        IMAGE_STORE.clear()

--- a/cli/archmorph_cli.py
+++ b/cli/archmorph_cli.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import pathlib
-import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +23,7 @@ CONFIG_DIR = pathlib.Path.home() / ".archmorph"
 CONFIG_PATH = CONFIG_DIR / "config.json"
 VERSION = "1.0.0"
 EXPORT_CAPABILITY_HEADER = "X-Export-Capability"
+VOLATILE_ANALYSIS_FIELDS = {"export_capability", "export_capability_expires_in"}
 
 logger = logging.getLogger("archmorph")
 
@@ -74,6 +74,13 @@ class ArchmorphClient:
         if not self.export_capability:
             return {}
         return {EXPORT_CAPABILITY_HEADER: self.export_capability}
+
+    def fork(self) -> "ArchmorphClient":
+        worker = ArchmorphClient(self.base_url)
+        worker.session.headers.clear()
+        worker.session.headers.update(self.session.headers)
+        worker.export_capability = self.export_capability
+        return worker
 
     def _remember_export_capability(self, payload: Any, resp: requests.Response) -> None:
         if isinstance(payload, dict) and payload.get("export_capability"):
@@ -397,6 +404,15 @@ def _apply_run_context(analysis: dict, target_rg: Optional[str]) -> dict:
     return enriched
 
 
+def _strip_volatile_analysis_fields(analysis: dict) -> dict:
+    return {key: value for key, value in analysis.items() if key not in VOLATILE_ANALYSIS_FIELDS}
+
+
+def _generate_iac_for_run(client: ArchmorphClient, diagram_id: str, iac_format: str, force: bool) -> dict:
+    worker_client = client.fork() if hasattr(client, "fork") else client
+    return worker_client.generate_iac_with_options(diagram_id, iac_format, force)
+
+
 # ── CLI definition ───────────────────────────────────────────
 @click.group()
 @click.option("--api-url", envvar="ARCHMORPH_API_URL", default=None, help="API base URL.")
@@ -560,6 +576,7 @@ def run_full_spine(
 
     click.echo(click.style("Analyzing architecture...", fg="cyan"))
     analysis = client.analyze_diagram(diagram_id)
+    analysis = _strip_volatile_analysis_fields(analysis)
     analysis = _apply_run_context(analysis, target_rg)
     if target_rg:
         client.restore_session(diagram_id, analysis)
@@ -570,7 +587,7 @@ def run_full_spine(
         click.echo(click.style(f"Generating IaC: {', '.join(iac_formats)}...", fg="cyan"))
         with ThreadPoolExecutor(max_workers=min(len(iac_formats), 4)) as executor:
             futures = {
-                executor.submit(client.generate_iac_with_options, diagram_id, iac_format, force_iac): iac_format
+                executor.submit(_generate_iac_for_run, client, diagram_id, iac_format, force_iac): iac_format
                 for iac_format in iac_formats
             }
             for future in as_completed(futures):

--- a/cli/archmorph_cli.py
+++ b/cli/archmorph_cli.py
@@ -10,7 +10,8 @@ import logging
 import os
 import pathlib
 import sys
-from typing import Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional
 
 import click
 import requests
@@ -22,6 +23,7 @@ CONFIG_FILENAME = ".archmorphrc"
 CONFIG_DIR = pathlib.Path.home() / ".archmorph"
 CONFIG_PATH = CONFIG_DIR / "config.json"
 VERSION = "1.0.0"
+EXPORT_CAPABILITY_HEADER = "X-Export-Capability"
 
 logger = logging.getLogger("archmorph")
 
@@ -55,6 +57,9 @@ class ArchmorphClient:
 
     def __init__(self, base_url: str, api_key: Optional[str] = None, token: Optional[str] = None):
         self.base_url = base_url.rstrip("/")
+        if self.base_url.endswith("/api"):
+            self.base_url = self.base_url[:-4]
+        self.export_capability: Optional[str] = None
         self.session = requests.Session()
         self.session.headers["User-Agent"] = f"archmorph-cli/{VERSION}"
         if api_key:
@@ -64,6 +69,19 @@ class ArchmorphClient:
 
     def _url(self, path: str) -> str:
         return f"{self.base_url}{path}"
+
+    def _capability_headers(self) -> Dict[str, str]:
+        if not self.export_capability:
+            return {}
+        return {EXPORT_CAPABILITY_HEADER: self.export_capability}
+
+    def _remember_export_capability(self, payload: Any, resp: requests.Response) -> None:
+        if isinstance(payload, dict) and payload.get("export_capability"):
+            self.export_capability = str(payload["export_capability"])
+            return
+        next_capability = resp.headers.get("X-Export-Capability-Next")
+        if next_capability:
+            self.export_capability = next_capability
 
     def _handle_response(self, resp: requests.Response) -> dict:
         """Parse JSON response or raise a readable error."""
@@ -77,9 +95,11 @@ class ArchmorphClient:
                 detail = resp.text
             raise click.ClickException(f"API error ({resp.status_code}): {detail}")
         try:
-            return resp.json()
+            payload = resp.json()
         except ValueError:
-            return {}
+            payload = {}
+        self._remember_export_capability(payload, resp)
+        return payload
 
     # ── Endpoints ────────────────────────────────────────────
     def health(self) -> dict:
@@ -112,10 +132,30 @@ class ArchmorphClient:
         resp = self.session.post(self._url(f"/api/diagrams/{diagram_id}/analyze"), timeout=120)
         return self._handle_response(resp)
 
+    def restore_session(self, diagram_id: str, analysis: dict) -> dict:
+        resp = self.session.post(
+            self._url(f"/api/diagrams/{diagram_id}/restore-session"),
+            json={"analysis": analysis},
+            timeout=30,
+        )
+        return self._handle_response(resp)
+
     def generate_iac(self, diagram_id: str, fmt: str = "terraform") -> dict:
+        return self.generate_iac_with_options(diagram_id, fmt=fmt, force=False)
+
+    def generate_iac_with_options(self, diagram_id: str, fmt: str = "terraform", force: bool = False) -> dict:
         resp = self.session.post(
             self._url(f"/api/diagrams/{diagram_id}/generate"),
-            params={"format": fmt},
+            params={"format": fmt, "force": str(force).lower()},
+            timeout=120,
+        )
+        return self._handle_response(resp)
+
+    def export_landing_zone_svg(self, diagram_id: str, dr_variant: str = "primary") -> dict:
+        resp = self.session.post(
+            self._url(f"/api/diagrams/{diagram_id}/export-diagram"),
+            params={"format": "landing-zone-svg", "dr_variant": dr_variant},
+            headers=self._capability_headers(),
             timeout=120,
         )
         return self._handle_response(resp)
@@ -132,6 +172,7 @@ class ArchmorphClient:
         resp = self.session.post(
             self._url(f"/api/diagrams/{diagram_id}/export-hld"),
             params={"format": fmt},
+            headers=self._capability_headers(),
             timeout=60,
         )
         try:
@@ -142,13 +183,50 @@ class ArchmorphClient:
             except ValueError:
                 detail = resp.text
             raise click.ClickException(f"API error ({resp.status_code}): {detail}")
+        self._remember_export_capability({}, resp)
         return resp.content
 
     def export_diagram(self, diagram_id: str, fmt: str = "excalidraw") -> dict:
         resp = self.session.post(
             self._url(f"/api/diagrams/{diagram_id}/export-diagram"),
             params={"format": fmt},
+            headers=self._capability_headers(),
             timeout=60,
+        )
+        return self._handle_response(resp)
+
+    def get_drift_baseline(self, baseline_id: str) -> dict:
+        resp = self.session.get(self._url(f"/api/drift/baselines/{baseline_id}"), timeout=30)
+        return self._handle_response(resp)
+
+    def compare_drift_baseline(self, baseline_id: str, live_state: dict) -> dict:
+        resp = self.session.post(
+            self._url(f"/api/drift/baselines/{baseline_id}/compare"),
+            json={"live_state": live_state},
+            timeout=60,
+        )
+        return self._handle_response(resp)
+
+    def push_iac_pr(
+        self,
+        repo: str,
+        iac_code: str,
+        iac_format: str,
+        analysis_summary: Optional[dict] = None,
+        cost_estimate: Optional[dict] = None,
+    ) -> dict:
+        ext_map = {"terraform": "tf", "bicep": "bicep", "cloudformation": "yaml"}
+        resp = self.session.post(
+            self._url("/api/integrations/github/push-pr"),
+            json={
+                "repo": repo,
+                "iac_code": iac_code,
+                "iac_format": iac_format,
+                "target_path": f"infra/main.{ext_map.get(iac_format, 'txt')}",
+                "analysis_summary": analysis_summary or {},
+                "cost_estimate": cost_estimate or {},
+            },
+            timeout=120,
         )
         return self._handle_response(resp)
 
@@ -226,6 +304,97 @@ def _write_binary(data: bytes, output_file: str):
     pathlib.Path(output_file).write_bytes(data)
     size_kb = len(data) / 1024
     click.echo(click.style(f"Saved {output_file} ({size_kb:.1f} KB)", fg="green"))
+
+
+def _write_json_artifact(path: pathlib.Path, data: Any) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def _write_text_artifact(path: pathlib.Path, content: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _parse_emit_list(raw_emit: str) -> List[str]:
+    aliases = {
+        "tf": "terraform",
+        "terraform": "terraform",
+        "bicep": "bicep",
+        "cloudformation": "cloudformation",
+        "cfn": "cloudformation",
+        "alz": "alz-svg",
+        "alz-svg": "alz-svg",
+        "landing-zone-svg": "alz-svg",
+        "cost": "cost",
+        "cost-estimate": "cost",
+        "all": "all",
+    }
+    requested: List[str] = []
+    for item in raw_emit.split(","):
+        key = item.strip().lower()
+        if not key:
+            continue
+        if key not in aliases:
+            raise click.ClickException(
+                f"Unsupported emit target '{item}'. Use terraform,bicep,cloudformation,alz-svg,cost,all."
+            )
+        value = aliases[key]
+        if value == "all":
+            for default_target in ["terraform", "bicep", "alz-svg", "cost"]:
+                if default_target not in requested:
+                    requested.append(default_target)
+        elif value not in requested:
+            requested.append(value)
+    return requested or ["terraform", "bicep", "alz-svg", "cost"]
+
+
+def _iac_artifact_path(output_dir: pathlib.Path, iac_format: str) -> pathlib.Path:
+    if iac_format == "terraform":
+        return output_dir / "terraform" / "main.tf"
+    if iac_format == "bicep":
+        return output_dir / "bicep" / "main.bicep"
+    return output_dir / "cloudformation" / "main.yaml"
+
+
+def _summarize_analysis(analysis: dict, diagram_id: str, target_rg: Optional[str]) -> dict:
+    mappings = analysis.get("mappings", []) if isinstance(analysis, dict) else []
+    return {
+        "diagram_id": diagram_id,
+        "target_resource_group": target_rg,
+        "source_provider": analysis.get("source_provider"),
+        "target_provider": analysis.get("target_provider", "azure"),
+        "services_detected": analysis.get("services_detected", len(mappings)),
+        "mapping_count": len(mappings) if isinstance(mappings, list) else 0,
+    }
+
+
+def _project_name_from_target_rg(target_rg: str) -> str:
+    value = target_rg.strip().lower()
+    for prefix in ("rg-", "rg_"):
+        if value.startswith(prefix):
+            value = value[len(prefix):]
+            break
+    value = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in value)
+    value = value.strip("-_")
+    return value or "cloud-migration"
+
+
+def _apply_run_context(analysis: dict, target_rg: Optional[str]) -> dict:
+    if not target_rg:
+        return analysis
+    enriched = dict(analysis)
+    iac_params = dict(enriched.get("iac_parameters") or {})
+    iac_params.setdefault("project_name", _project_name_from_target_rg(target_rg))
+    iac_params["target_resource_group"] = target_rg
+    enriched["iac_parameters"] = iac_params
+    enriched["cli_run"] = {
+        "target_resource_group": target_rg,
+        "project_name": iac_params["project_name"],
+    }
+    return enriched
 
 
 # ── CLI definition ───────────────────────────────────────────
@@ -332,6 +501,134 @@ def analyze(ctx, image_path, project_id):
             _write_output(analysis, ctx.obj["output_file"], "json")
     else:
         _write_output(analysis, ctx.obj["output_file"], ctx.obj["format"])
+
+
+# ── run ──────────────────────────────────────────────────────
+@cli.command("run")
+@click.option(
+    "--diagram",
+    "diagram_path",
+    required=True,
+    type=click.Path(exists=True),
+    help="Architecture diagram file to upload and analyze.",
+)
+@click.option("--target-rg", default=None, help="Target Azure resource group name for the run context and IaC project hint.")
+@click.option(
+    "--emit",
+    "emit_targets",
+    default="terraform,bicep,alz-svg,cost",
+    show_default=True,
+    help="Comma-separated outputs: terraform,bicep,cloudformation,alz-svg,cost,all.",
+)
+@click.option("--out", "output_dir", required=True, type=click.Path(file_okay=False), help="Directory for generated artifacts.")
+@click.option("--project-id", default="default", show_default=True, help="Project ID for the uploaded diagram.")
+@click.option("--baseline", default=None, help="Optional drift baseline ID to compare the new analysis against.")
+@click.option(
+    "--push-pr",
+    default=None,
+    metavar="OWNER/REPO",
+    help="Optional GitHub repo to open a PR with the first generated IaC artifact.",
+)
+@click.option("--force-iac", is_flag=True, help="Pass force=true to IaC generation when architecture blockers exist.")
+@click.pass_context
+def run_full_spine(
+    ctx,
+    diagram_path,
+    target_rg,
+    emit_targets,
+    output_dir,
+    project_id,
+    baseline,
+    push_pr,
+    force_iac,
+):
+    """Run the full engineer spine from diagram upload to artifacts on disk.
+
+    Example:
+      archmorph run --diagram aws.png --target-rg rg-demo --emit terraform,bicep,alz-svg --out ./infra
+    """
+    client: ArchmorphClient = ctx.obj["client"]
+    requested = _parse_emit_list(emit_targets)
+    out_root = pathlib.Path(output_dir)
+    artifact_paths: Dict[str, str] = {}
+    iac_outputs: Dict[str, str] = {}
+
+    click.echo(click.style("Uploading diagram...", fg="cyan"))
+    upload_result = client.upload_diagram(diagram_path, project_id)
+    diagram_id = upload_result["diagram_id"]
+    click.echo(click.style(f"Diagram uploaded: {diagram_id}", fg="green"))
+
+    click.echo(click.style("Analyzing architecture...", fg="cyan"))
+    analysis = client.analyze_diagram(diagram_id)
+    analysis = _apply_run_context(analysis, target_rg)
+    if target_rg:
+        client.restore_session(diagram_id, analysis)
+    artifact_paths["analysis"] = str(_write_json_artifact(out_root / "analysis.json", analysis))
+
+    iac_formats = [target for target in requested if target in {"terraform", "bicep", "cloudformation"}]
+    if iac_formats:
+        click.echo(click.style(f"Generating IaC: {', '.join(iac_formats)}...", fg="cyan"))
+        with ThreadPoolExecutor(max_workers=min(len(iac_formats), 4)) as executor:
+            futures = {
+                executor.submit(client.generate_iac_with_options, diagram_id, iac_format, force_iac): iac_format
+                for iac_format in iac_formats
+            }
+            for future in as_completed(futures):
+                iac_format = futures[future]
+                result = future.result()
+                code = result.get("code", "")
+                if not isinstance(code, str) or not code.strip():
+                    raise click.ClickException(f"{iac_format} generation returned empty code")
+                artifact_path = _iac_artifact_path(out_root, iac_format)
+                _write_text_artifact(artifact_path, code)
+                artifact_paths[iac_format] = str(artifact_path)
+                iac_outputs[iac_format] = code
+
+    cost_estimate = None
+    if "alz-svg" in requested:
+        click.echo(click.style("Generating ALZ SVG...", fg="cyan"))
+        alz = client.export_landing_zone_svg(diagram_id)
+        content = alz.get("content", "")
+        if not isinstance(content, str) or "<svg" not in content:
+            raise click.ClickException("ALZ SVG generation returned invalid content")
+        artifact_paths["alz-svg"] = str(_write_text_artifact(out_root / "alz.svg", content))
+
+    if "cost" in requested:
+        click.echo(click.style("Estimating cost...", fg="cyan"))
+        cost_estimate = client.cost_estimate(diagram_id)
+        artifact_paths["cost"] = str(_write_json_artifact(out_root / "cost-estimate.json", cost_estimate))
+
+    if baseline:
+        click.echo(click.style(f"Comparing drift baseline {baseline}...", fg="cyan"))
+        client.get_drift_baseline(baseline)
+        drift_report = client.compare_drift_baseline(baseline, analysis)
+        artifact_paths["drift"] = str(_write_json_artifact(out_root / "drift-report.json", drift_report))
+
+    if push_pr:
+        if not iac_outputs:
+            raise click.ClickException("--push-pr requires at least one IaC emit target")
+        preferred_format = "terraform" if "terraform" in iac_outputs else next(iter(iac_outputs))
+        click.echo(click.style(f"Pushing {preferred_format} IaC to GitHub PR...", fg="cyan"))
+        pr_result = client.push_iac_pr(
+            push_pr,
+            iac_outputs[preferred_format],
+            preferred_format,
+            analysis_summary=_summarize_analysis(analysis, diagram_id, target_rg),
+            cost_estimate=cost_estimate,
+        )
+        artifact_paths["github-pr"] = str(_write_json_artifact(out_root / "github-pr.json", pr_result))
+
+    summary = {
+        "diagram_id": diagram_id,
+        "target_resource_group": target_rg,
+        "emit": requested,
+        "artifacts": artifact_paths,
+    }
+    artifact_paths["run-summary"] = str(_write_json_artifact(out_root / "run-summary.json", summary))
+
+    click.echo(click.style("Full-spine run complete.", fg="green"))
+    for name, path in artifact_paths.items():
+        click.echo(f"{name}: {path}")
 
 
 # ── generate ─────────────────────────────────────────────────

--- a/cli/tests/test_archmorph_cli_http_smoke.py
+++ b/cli/tests/test_archmorph_cli_http_smoke.py
@@ -22,9 +22,11 @@ os.environ.setdefault("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "false")
 os.environ.setdefault("ARCHMORPH_DISABLE_IAC_CLI_VALIDATION", "1")
 os.environ.setdefault("ENVIRONMENT", "test")
 
-BACKEND_DIR = Path(__file__).resolve().parents[1]
-REPO_DIR = BACKEND_DIR.parent
+REPO_DIR = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_DIR / "backend"
 CLI_DIR = REPO_DIR / "cli"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
 if str(CLI_DIR) not in sys.path:
     sys.path.insert(0, str(CLI_DIR))
 

--- a/cli/tests/test_archmorph_cli_run.py
+++ b/cli/tests/test_archmorph_cli_run.py
@@ -31,6 +31,8 @@ class FakeArchmorphClient:
             "source_provider": "aws",
             "target_provider": "azure",
             "services_detected": 2,
+            "export_capability": "cap-random-response-token",
+            "export_capability_expires_in": 600,
             "mappings": [
                 {"source_service": "EC2", "azure_service": "Azure Virtual Machines", "category": "Compute"},
                 {"source_service": "S3", "azure_service": "Azure Blob Storage", "category": "Storage"},
@@ -111,7 +113,10 @@ def test_run_emits_full_spine_artifacts(monkeypatch, tmp_path):
     assert analysis["diagram_id"] == "diag-test-660"
     assert analysis["iac_parameters"]["target_resource_group"] == "rg-demo"
     assert analysis["iac_parameters"]["project_name"] == "demo"
+    assert "export_capability" not in analysis
+    assert "export_capability_expires_in" not in analysis
     assert client.restored_analysis["cli_run"]["target_resource_group"] == "rg-demo"
+    assert "export_capability" not in client.restored_analysis
     assert 'resource "azurerm_resource_group"' in (out_dir / "terraform" / "main.tf").read_text()
     assert "targetScope" in (out_dir / "bicep" / "main.bicep").read_text()
     ET.fromstring((out_dir / "alz.svg").read_text())

--- a/cli/tests/test_archmorph_cli_run.py
+++ b/cli/tests/test_archmorph_cli_run.py
@@ -1,0 +1,174 @@
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import archmorph_cli
+
+
+class FakeArchmorphClient:
+    def __init__(self, base_url, api_key=None, token=None):
+        self.base_url = base_url
+        self.api_key = api_key
+        self.token = token
+        self.generated = []
+        self.pushed = None
+        self.restored_analysis = None
+
+    def upload_diagram(self, image_path, project_id="default"):
+        assert Path(image_path).exists()
+        assert project_id == "default"
+        return {"diagram_id": "diag-test-660", "export_capability": "cap-upload"}
+
+    def analyze_diagram(self, diagram_id):
+        assert diagram_id == "diag-test-660"
+        return {
+            "diagram_id": diagram_id,
+            "source_provider": "aws",
+            "target_provider": "azure",
+            "services_detected": 2,
+            "mappings": [
+                {"source_service": "EC2", "azure_service": "Azure Virtual Machines", "category": "Compute"},
+                {"source_service": "S3", "azure_service": "Azure Blob Storage", "category": "Storage"},
+            ],
+        }
+
+    def restore_session(self, diagram_id, analysis):
+        assert diagram_id == "diag-test-660"
+        self.restored_analysis = analysis
+        return {"status": "restored", "diagram_id": diagram_id}
+
+    def generate_iac_with_options(self, diagram_id, fmt="terraform", force=False):
+        assert diagram_id == "diag-test-660"
+        assert force is False
+        self.generated.append(fmt)
+        if fmt == "terraform":
+            return {"code": 'resource "azurerm_resource_group" "main" {\n  name = "rg-demo"\n}\n'}
+        if fmt == "bicep":
+            return {"code": "targetScope = 'resourceGroup'\nresource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {\n  name: 'st660'\n}\n"}
+        return {"code": "Resources:\n  Bucket:\n    Type: AWS::S3::Bucket\n"}
+
+    def export_landing_zone_svg(self, diagram_id, dr_variant="primary"):
+        assert diagram_id == "diag-test-660"
+        assert dr_variant == "primary"
+        return {"content": '<svg xmlns="http://www.w3.org/2000/svg"><title>Target</title></svg>', "export_capability": "cap-next"}
+
+    def cost_estimate(self, diagram_id):
+        assert diagram_id == "diag-test-660"
+        return {
+            "diagram_id": diagram_id,
+            "currency": "USD",
+            "total_monthly_estimate": {"low": 10, "high": 20},
+            "services": [{"service": "Azure Blob Storage", "monthly_low": 10, "monthly_high": 20}],
+        }
+
+    def push_iac_pr(self, repo, iac_code, iac_format, analysis_summary=None, cost_estimate=None):
+        self.pushed = {
+            "repo": repo,
+            "iac_code": iac_code,
+            "iac_format": iac_format,
+            "analysis_summary": analysis_summary,
+            "cost_estimate": cost_estimate,
+        }
+        return {"success": True, "pull_request_url": "https://github.com/acme/infra/pull/1"}
+
+
+def test_run_emits_full_spine_artifacts(monkeypatch, tmp_path):
+    client = FakeArchmorphClient("http://api.test")
+
+    class ClientFactory(FakeArchmorphClient):
+        def __new__(cls, *args, **kwargs):
+            return client
+
+    monkeypatch.setattr(archmorph_cli, "ArchmorphClient", ClientFactory)
+    diagram = tmp_path / "aws.png"
+    diagram.write_bytes(b"\x89PNG\r\n\x1a\n")
+    out_dir = tmp_path / "infra"
+
+    result = CliRunner().invoke(
+        archmorph_cli.cli,
+        [
+            "--api-url",
+            "http://api.test",
+            "run",
+            "--diagram",
+            str(diagram),
+            "--target-rg",
+            "rg-demo",
+            "--emit",
+            "terraform,bicep,alz-svg,cost",
+            "--out",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    analysis = json.loads((out_dir / "analysis.json").read_text())
+    assert analysis["diagram_id"] == "diag-test-660"
+    assert analysis["iac_parameters"]["target_resource_group"] == "rg-demo"
+    assert analysis["iac_parameters"]["project_name"] == "demo"
+    assert client.restored_analysis["cli_run"]["target_resource_group"] == "rg-demo"
+    assert 'resource "azurerm_resource_group"' in (out_dir / "terraform" / "main.tf").read_text()
+    assert "targetScope" in (out_dir / "bicep" / "main.bicep").read_text()
+    ET.fromstring((out_dir / "alz.svg").read_text())
+    cost = json.loads((out_dir / "cost-estimate.json").read_text())
+    assert cost["currency"] == "USD"
+    summary = json.loads((out_dir / "run-summary.json").read_text())
+    assert summary["target_resource_group"] == "rg-demo"
+    assert set(summary["emit"]) == {"terraform", "bicep", "alz-svg", "cost"}
+
+
+def test_run_push_pr_uses_first_generated_iac(monkeypatch, tmp_path):
+    client = FakeArchmorphClient("http://api.test")
+
+    class ClientFactory(FakeArchmorphClient):
+        def __new__(cls, *args, **kwargs):
+            return client
+
+    monkeypatch.setattr(archmorph_cli, "ArchmorphClient", ClientFactory)
+    diagram = tmp_path / "aws.png"
+    diagram.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = CliRunner().invoke(
+        archmorph_cli.cli,
+        [
+            "run",
+            "--diagram",
+            str(diagram),
+            "--emit",
+            "bicep,cost",
+            "--out",
+            str(tmp_path / "out"),
+            "--push-pr",
+            "acme/infra",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.pushed["repo"] == "acme/infra"
+    assert client.pushed["iac_format"] == "bicep"
+    assert client.pushed["analysis_summary"]["diagram_id"] == "diag-test-660"
+    pr = json.loads((tmp_path / "out" / "github-pr.json").read_text())
+    assert pr["success"] is True
+
+
+def test_run_rejects_unknown_emit_target(tmp_path):
+    diagram = tmp_path / "aws.png"
+    diagram.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = CliRunner().invoke(
+        archmorph_cli.cli,
+        ["run", "--diagram", str(diagram), "--emit", "terraform,unknown", "--out", str(tmp_path / "out")],
+    )
+
+    assert result.exit_code != 0
+    assert "Unsupported emit target" in result.output
+
+
+def test_client_normalizes_api_suffix():
+    client = archmorph_cli.ArchmorphClient("https://api.archmorphai.com/api")
+    assert client._url("/api/health") == "https://api.archmorphai.com/api/health"

--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -1,0 +1,90 @@
+# Archmorph CLI Usage
+
+The CLI lets engineers run the Archmorph value spine without opening the browser: upload a diagram, analyze it, generate selected artifacts, and write deterministic files to disk.
+
+## Configure
+
+Use a local backend or the deployed API. The CLI accepts the API URL as a flag, environment variable, or saved config.
+
+```bash
+export ARCHMORPH_API_URL="http://localhost:8000"
+export ARCHMORPH_API_KEY="<api key if required>"
+```
+
+If your API URL already includes `/api`, the CLI normalizes it safely.
+
+## Full-Spine Run
+
+```bash
+archmorph run \
+  --diagram ./fixtures/aws.png \
+  --target-rg rg-platform-prod \
+  --emit terraform,bicep,alz-svg,cost \
+  --out ./infra
+```
+
+Expected output:
+
+```text
+./infra/
+  analysis.json
+  terraform/main.tf
+  bicep/main.bicep
+  alz.svg
+  cost-estimate.json
+  run-summary.json
+```
+
+`--target-rg` is persisted into `analysis.json` and the backend session as CLI run context. When the analysis does not already include IaC parameters, the CLI also derives a stable IaC project hint from the resource group name.
+
+Use `--emit all` for the default engineer bundle, or select any comma-separated subset of:
+
+```text
+terraform,bicep,cloudformation,alz-svg,cost
+```
+
+## Drift Baseline Comparison
+
+If a drift baseline already exists in Archmorph, include its ID:
+
+```bash
+archmorph run \
+  --diagram ./fixtures/aws.png \
+  --emit terraform,alz-svg,cost \
+  --baseline baseline-abc123 \
+  --out ./infra
+```
+
+This adds:
+
+```text
+./infra/drift-report.json
+```
+
+## Push Generated IaC To GitHub
+
+```bash
+archmorph run \
+  --diagram ./fixtures/aws.png \
+  --emit terraform,cost \
+  --push-pr owner/repo \
+  --out ./infra
+```
+
+The CLI sends the first generated IaC artifact to `/api/integrations/github/push-pr` and writes the API response to:
+
+```text
+./infra/github-pr.json
+```
+
+When Terraform is emitted, Terraform is preferred for the PR. Otherwise the first requested IaC format is used.
+
+## Existing Focused Commands
+
+```bash
+archmorph status
+archmorph analyze ./diagram.png --project-id default
+archmorph generate diag-123 --iac-format terraform --output main.tf
+archmorph cost diag-123 --format table
+archmorph export diag-123 --export-format excalidraw
+```

--- a/scripts/cli_full_spine_container_smoke.sh
+++ b/scripts/cli_full_spine_container_smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_NAME="${ARCHMORPH_SMOKE_IMAGE:-archmorph-backend-cli-smoke}"
+CONTAINER_NAME="${ARCHMORPH_SMOKE_CONTAINER:-archmorph-cli-smoke-$$}"
+PORT="${ARCHMORPH_SMOKE_PORT:-18080}"
+WORK_DIR="${ARCHMORPH_SMOKE_WORK_DIR:-$(mktemp -d)}"
+OUT_DIR="$WORK_DIR/out"
+DIAGRAM_PATH="$WORK_DIR/aws.png"
+API_URL="http://127.0.0.1:$PORT"
+BOOTSTRAP_PYTHON="${PYTHON:-}"
+VENV_DIR="$WORK_DIR/.venv"
+
+if [[ -z "$BOOTSTRAP_PYTHON" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    BOOTSTRAP_PYTHON="python3"
+  elif command -v python >/dev/null 2>&1; then
+    BOOTSTRAP_PYTHON="python"
+  else
+    echo "python3 or python is required" >&2
+    exit 1
+  fi
+fi
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  if [[ -z "${ARCHMORPH_SMOKE_WORK_DIR:-}" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+"$BOOTSTRAP_PYTHON" -m venv "$VENV_DIR"
+PYTHON_BIN="$VENV_DIR/bin/python"
+"$PYTHON_BIN" -m pip install --upgrade pip >/dev/null
+"$PYTHON_BIN" -m pip install -e "$ROOT_DIR/cli" >/dev/null
+
+docker build -t "$IMAGE_NAME" "$ROOT_DIR/backend" >/dev/null
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p "127.0.0.1:$PORT:8000" \
+  -e ENVIRONMENT=test \
+  -e RATE_LIMIT_ENABLED=false \
+  -e ARCHMORPH_CI_SMOKE_MODE=1 \
+  -e ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false \
+  -e ARCHMORPH_DISABLE_IAC_CLI_VALIDATION=1 \
+  -e DATABASE_URL=sqlite:///./data/archmorph-smoke.db \
+  "$IMAGE_NAME" \
+  uvicorn main:app --host 0.0.0.0 --port 8000 >/dev/null
+
+"$PYTHON_BIN" - <<PY
+import sys
+import time
+import urllib.request
+
+url = "$API_URL/api/health"
+for _ in range(90):
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            if response.status == 200:
+                sys.exit(0)
+    except Exception:
+        time.sleep(1)
+print("backend container did not become healthy", file=sys.stderr)
+sys.exit(1)
+PY
+
+mkdir -p "$OUT_DIR"
+"$PYTHON_BIN" - <<PY
+from pathlib import Path
+Path("$DIAGRAM_PATH").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\0" * 100)
+PY
+
+"$PYTHON_BIN" -m archmorph_cli --api-url "$API_URL" run \
+  --diagram "$DIAGRAM_PATH" \
+  --target-rg rg-cli-smoke-dev \
+  --emit terraform,bicep,alz-svg,cost \
+  --out "$OUT_DIR"
+
+"$PYTHON_BIN" - <<PY
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+out = Path("$OUT_DIR")
+required = [
+    out / "analysis.json",
+    out / "terraform" / "main.tf",
+    out / "bicep" / "main.bicep",
+    out / "alz.svg",
+    out / "cost-estimate.json",
+    out / "run-summary.json",
+]
+missing = [str(path) for path in required if not path.exists()]
+if missing:
+    print("Missing artifacts: " + ", ".join(missing), file=sys.stderr)
+    sys.exit(1)
+
+analysis = json.loads((out / "analysis.json").read_text(encoding="utf-8"))
+assert analysis["diagram_id"].startswith("diag-"), analysis["diagram_id"]
+assert analysis["cli_run"]["target_resource_group"] == "rg-cli-smoke-dev"
+assert analysis["services_detected"] >= 3
+
+terraform = (out / "terraform" / "main.tf").read_text(encoding="utf-8")
+bicep = (out / "bicep" / "main.bicep").read_text(encoding="utf-8")
+assert 'resource "terraform_data"' in terraform
+assert "Microsoft.Resources/resourceGroups" in bicep
+ET.fromstring((out / "alz.svg").read_text(encoding="utf-8"))
+
+cost = json.loads((out / "cost-estimate.json").read_text(encoding="utf-8"))
+assert cost["currency"] == "USD"
+summary = json.loads((out / "run-summary.json").read_text(encoding="utf-8"))
+assert summary["artifacts"]["analysis"].endswith("analysis.json")
+print("CLI container smoke artifacts validated:", out)
+PY


### PR DESCRIPTION
## Summary

Closes #660.

Adds `archmorph run` as a single-command full-spine workflow for engineers:

- Upload diagram
- Analyze architecture
- Generate Terraform and Bicep artifacts in parallel
- Export Azure Landing Zone SVG
- Emit cost estimate
- Optionally compare drift via `--baseline`
- Optionally push generated IaC to GitHub via `--push-pr owner/repo`
- Write deterministic artifacts under `--out`

## Artifact Contract

The command writes:

```text
analysis.json
terraform/main.tf
bicep/main.bicep
alz.svg
cost-estimate.json
run-summary.json
drift-report.json    # when --baseline is provided
github-pr.json       # when --push-pr is provided
```

## CI / Test Coverage

- CLI unit contract tests for deterministic artifact output, PR push behavior, invalid emit handling, API URL normalization, and volatile capability stripping
- HTTP-backed full-spine smoke test using in-process FastAPI/uvicorn, owned by the CLI test suite
- Container-backed smoke script that builds the backend image, starts it in deterministic smoke mode, runs the real CLI over HTTP, and parses/asserts all generated artifacts
- Backend regression tests for CI smoke-mode environment guardrails
- CI job now runs the CLI contract tests and the container-backed smoke

## Review Hardening

- Strips `export_capability` and `export_capability_expires_in` before persisting `analysis.json` or restoring backend session state
- Uses per-worker client/session copies for parallel IaC generation
- Requires `ARCHMORPH_CI_SMOKE_MODE` plus explicit non-production `ENVIRONMENT` before deterministic smoke responses activate

## Docs

- Added `docs/CLI_USAGE.md`
- Updated README quickstart to lead with `archmorph run`

## Scope Notes

Per CTO/Scrum alignment, this PR intentionally finishes #660 only. Adjacent items remain follow-ups:

- #659: full-spine SLO tests and alerts
- #658: Azure-only IaC output cleanup/removal of CloudFormation/Pulumi/CDK

## Local Validation

```text
pytest -q cli/tests/test_archmorph_cli_run.py cli/tests/test_archmorph_cli_http_smoke.py backend/tests/test_ci_smoke.py
7 passed

pytest -q backend/tests/test_iac_output_validation.py
1 passed, 10 skipped

ruff check backend smoke files + CLI files/tests
passed

py_compile touched Python files
passed

bash -n scripts/cli_full_spine_container_smoke.sh
passed

git diff --check
passed

bash scripts/cli_full_spine_container_smoke.sh
passed
```