### PR TITLE
feat: add full-spine SLO gate and alerts

### DIFF
--- a/.github/workflows/sla-spine.yml
+++ b/.github/workflows/sla-spine.yml
@@ -1,0 +1,148 @@
+name: Full-Spine SLO Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  sla-spine:
+    name: sla-spine
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build backend image
+        run: docker build -t archmorph-backend-sla-spine ./backend
+
+      - name: Start deterministic backend
+        run: |
+          docker run -d \
+            --name archmorph-sla-spine \
+            -p 127.0.0.1:18082:8000 \
+            -e ENVIRONMENT=test \
+            -e RATE_LIMIT_ENABLED=false \
+            -e ARCHMORPH_CI_SMOKE_MODE=1 \
+            -e ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false \
+            -e ARCHMORPH_DISABLE_IAC_CLI_VALIDATION=1 \
+            -e DATABASE_URL=sqlite:///./data/archmorph-sla-spine.db \
+            archmorph-backend-sla-spine \
+            uvicorn main:app --host 0.0.0.0 --port 8000
+
+          echo "Waiting for backend health..."
+          for i in {1..90}; do
+            if curl -fsS http://127.0.0.1:18082/api/health >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs archmorph-sla-spine
+          exit 1
+
+      - name: Install Locust
+        run: |
+          python -m venv "${{ runner.temp }}/locust-venv"
+          "${{ runner.temp }}/locust-venv/bin/python" -m pip install --upgrade pip
+          "${{ runner.temp }}/locust-venv/bin/python" -m pip install 'locust==2.32.6'
+
+      - name: Run full-spine Locust SLO gate
+        id: sla
+        continue-on-error: true
+        env:
+          SLO_SPINE_SUMMARY_PATH: ${{ runner.temp }}/sla-spine-summary/sla-spine-summary.json
+          SLO_SPINE_TARGET_RPS: "30"
+          SLO_SPINE_USER_RPS: "1"
+        run: |
+          mkdir -p "${{ runner.temp }}/sla-spine-summary"
+          "${{ runner.temp }}/locust-venv/bin/python" -m locust \
+            -f backend/tests/performance/sla_spine_locust.py \
+            --headless \
+            --host http://127.0.0.1:18082 \
+            --users 30 \
+            --spawn-rate 30 \
+            --run-time 30s \
+            --only-summary
+
+      - name: Upload SLO summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sla-spine-summary
+          path: ${{ runner.temp }}/sla-spine-summary/sla-spine-summary.json
+          if-no-files-found: warn
+
+      - name: Comment SLO summary on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        env:
+          SUMMARY_PATH: ${{ runner.temp }}/sla-spine-summary/sla-spine-summary.json
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- archmorph-sla-spine -->';
+            const summaryPath = process.env.SUMMARY_PATH;
+            let body;
+            if (!fs.existsSync(summaryPath)) {
+              body = `${marker}\n## Full-Spine SLO Gate\n\nNo SLO summary artifact was produced. Check the workflow logs.`;
+            } else {
+              const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+              const rows = Object.entries(summary.endpoints).map(([name, values]) => {
+                const status = values.passed ? 'PASS' : 'FAIL';
+                const p95 = values.p95_ms === null || values.p95_ms === undefined ? 'n/a' : `${Math.round(values.p95_ms)} ms`;
+                const threshold = `${values.threshold_ms} ms`;
+                return `| ${name} | ${p95} | ${threshold} | ${values.samples} | ${values.failures} | ${status} |`;
+              }).join('\n');
+              const failed = summary.failed.length ? summary.failed.join(', ') : 'none';
+              body = [
+                marker,
+                '## Full-Spine SLO Gate',
+                '',
+                `Target RPS: ${summary.target_rps}`,
+                `Failed endpoints: ${failed}`,
+                '',
+                '| Endpoint | p95 | Threshold | Samples | Failures | Status |',
+                '| --- | ---: | ---: | ---: | ---: | --- |',
+                rows,
+              ].join('\n');
+            }
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if SLO gate failed
+        if: steps.sla.outcome == 'failure'
+        run: exit 1
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: docker logs archmorph-sla-spine
+
+      - name: Stop backend
+        if: always()
+        run: docker rm -f archmorph-sla-spine >/dev/null 2>&1 || true

--- a/backend/main.py
+++ b/backend/main.py
@@ -284,6 +284,9 @@ class ArchmorphMiddleware(BaseHTTPMiddleware):
         )
 
         try:
+            request_tags = {"method": method, "path": endpoint, "status": str(status)}
+            if endpoint.endswith("/generate"):
+                request_tags["format"] = request.query_params.get("format", "unknown")
             track_request_latency(endpoint, method, duration_ms, status)
             obs_increment_counter(
                 "http.requests.total", tags={"method": method, "path": endpoint}
@@ -291,7 +294,7 @@ class ArchmorphMiddleware(BaseHTTPMiddleware):
             obs_record_histogram(
                 "http.request.duration_ms",
                 duration_ms,
-                tags={"method": method, "path": endpoint, "status": str(status)},
+                tags=request_tags,
             )
             if status >= 400:
                 obs_increment_counter(

--- a/backend/tests/performance/sla_spine_locust.py
+++ b/backend/tests/performance/sla_spine_locust.py
@@ -1,0 +1,254 @@
+"""Locust SLO gate for the Archmorph full value spine (#659)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from locust import HttpUser, constant_throughput, events, task
+from locust.exception import StopUser
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + (b"\0" * 100)
+SUMMARY_PATH = Path(os.getenv("SLO_SPINE_SUMMARY_PATH", "sla-spine-summary.json"))
+FAILURE_RATE_THRESHOLD = float(os.getenv("SLO_SPINE_FAILURE_RATE", "0.01"))
+
+SPINE_ENDPOINTS = {
+    "analyze": {
+        "method": "POST",
+        "threshold_ms": 8000,
+        "route": "/api/diagrams/{diagram_id}/analyze",
+        "description": "Diagram analysis",
+    },
+    "generate_landing_zone": {
+        "method": "POST",
+        "threshold_ms": 1500,
+        "route": "/api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg",
+        "description": "Landing-zone SVG generation",
+    },
+    "generate_iac_terraform": {
+        "method": "POST",
+        "threshold_ms": 12000,
+        "route": "/api/diagrams/{diagram_id}/generate?format=terraform&force=true",
+        "description": "Terraform generation",
+    },
+    "generate_iac_bicep": {
+        "method": "POST",
+        "threshold_ms": 12000,
+        "route": "/api/diagrams/{diagram_id}/generate?format=bicep&force=true",
+        "description": "Bicep generation",
+    },
+    "drift_compare": {
+        "method": "POST",
+        "threshold_ms": 5000,
+        "route": "/api/drift/baselines/{baseline_id}/compare",
+        "description": "Drift baseline comparison",
+    },
+}
+
+DESIGNED_STATE = {
+    "nodes": [
+        {"id": "web", "type": "static_web_app", "sku": "standard"},
+        {"id": "api", "type": "container_app", "sku": "consumption"},
+        {"id": "store", "type": "storage_account", "sku": "standard_lrs"},
+    ]
+}
+
+LIVE_STATE = {
+    "nodes": [
+        {"resource_id": "web", "resource_type": "static_web_app", "sku": "standard"},
+        {"resource_id": "api", "resource_type": "container_app", "sku": "dedicated"},
+        {"resource_id": "store", "resource_type": "storage_account", "sku": "standard_lrs"},
+    ]
+}
+
+
+def _post_json(user: HttpUser, path: str, payload: dict[str, Any], name: str):
+    return user.client.post(
+        path,
+        data=json.dumps(payload),
+        headers={"Content-Type": "application/json"},
+        name=name,
+        catch_response=True,
+    )
+
+
+def _expect_success(response, name: str) -> None:
+    if 200 <= response.status_code < 300:
+        response.success()
+        return
+    response.failure(f"{name} returned HTTP {response.status_code}: {response.text[:240]}")
+
+
+class FullSpineUser(HttpUser):
+    """Exercise analyze -> IaC -> ALZ -> drift compare at an aggregate 30 RPS in CI."""
+
+    wait_time = constant_throughput(float(os.getenv("SLO_SPINE_USER_RPS", "1")))
+
+    def on_start(self) -> None:
+        self.diagram_id = self._upload_diagram()
+        self.baseline_id = self._create_drift_baseline()
+        self._prime_session()
+
+    def _upload_diagram(self) -> str:
+        with self.client.post(
+            "/api/projects/sla-spine/diagrams",
+            files={"file": ("aws.png", PNG_BYTES, "image/png")},
+            name="setup_upload_diagram",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"setup upload failed: HTTP {response.status_code} {response.text[:240]}")
+                raise StopUser()
+            payload = response.json()
+            response.success()
+            return str(payload["diagram_id"])
+
+    def _prime_session(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/analyze",
+            name="setup_prime_analyze",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"setup analyze failed: HTTP {response.status_code} {response.text[:240]}")
+                raise StopUser()
+            response.success()
+
+    def _create_drift_baseline(self) -> str:
+        payload = {
+            "name": "SLA spine baseline",
+            "designed_state": DESIGNED_STATE,
+            "live_state": LIVE_STATE,
+            "source": "sla-spine",
+        }
+        with _post_json(self, "/api/drift/baselines", payload, "setup_create_drift_baseline") as response:
+            if response.status_code != 200:
+                response.failure(f"setup drift baseline failed: HTTP {response.status_code} {response.text[:240]}")
+                raise StopUser()
+            data = response.json()
+            response.success()
+            return str(data["baseline_id"])
+
+    @task(4)
+    def analyze(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/analyze",
+            name="analyze",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "analyze")
+
+    @task(2)
+    def generate_iac_terraform(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/generate?format=terraform&force=true",
+            name="generate_iac_terraform",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "generate_iac_terraform")
+
+    @task(2)
+    def generate_iac_bicep(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/generate?format=bicep&force=true",
+            name="generate_iac_bicep",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "generate_iac_bicep")
+
+    @task(1)
+    def generate_landing_zone(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/export-diagram?format=landing-zone-svg",
+            name="generate_landing_zone",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "generate_landing_zone")
+
+    @task(1)
+    def drift_compare(self) -> None:
+        with _post_json(
+            self,
+            f"/api/drift/baselines/{self.baseline_id}/compare",
+            {"live_state": LIVE_STATE},
+            "drift_compare",
+        ) as response:
+            _expect_success(response, "drift_compare")
+
+
+def _metric_value(stats, endpoint_name: str, value_name: str):
+    entry = stats.get(endpoint_name, SPINE_ENDPOINTS[endpoint_name]["method"])
+    if entry is None or entry.num_requests == 0:
+        return None
+    if value_name == "p95_ms":
+        return entry.get_response_time_percentile(0.95)
+    if value_name == "avg_ms":
+        return entry.avg_response_time
+    if value_name == "max_ms":
+        return entry.max_response_time
+    if value_name == "failure_rate":
+        return entry.num_failures / entry.num_requests
+    return None
+
+
+def _build_endpoint_summary(stats) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {}
+    for endpoint_name, target in SPINE_ENDPOINTS.items():
+        entry = stats.get(endpoint_name, target["method"])
+        samples = entry.num_requests if entry is not None else 0
+        failures = entry.num_failures if entry is not None else 0
+        p95_ms = _metric_value(stats, endpoint_name, "p95_ms")
+        failure_rate = _metric_value(stats, endpoint_name, "failure_rate")
+        passed = (
+            samples > 0
+            and p95_ms is not None
+            and p95_ms < target["threshold_ms"]
+            and failure_rate is not None
+            and failure_rate < FAILURE_RATE_THRESHOLD
+        )
+        summary[endpoint_name] = {
+            "description": target["description"],
+            "route": target["route"],
+            "method": target["method"],
+            "samples": samples,
+            "failures": failures,
+            "failure_rate": failure_rate,
+            "p95_ms": p95_ms,
+            "avg_ms": _metric_value(stats, endpoint_name, "avg_ms"),
+            "max_ms": _metric_value(stats, endpoint_name, "max_ms"),
+            "threshold_ms": target["threshold_ms"],
+            "passed": passed,
+        }
+    return summary
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    print("\nArchmorph full-spine SLO summary")
+    print(f"target_rps={summary['target_rps']} failed={summary['failed']}")
+    for endpoint_name, values in summary["endpoints"].items():
+        status = "PASS" if values["passed"] else "FAIL"
+        print(
+            f"{status} {endpoint_name}: "
+            f"p95={values['p95_ms']}ms threshold={values['threshold_ms']}ms "
+            f"samples={values['samples']} failures={values['failures']}"
+        )
+    print("")
+
+
+@events.quitting.add_listener
+def enforce_spine_slos(environment, **_kwargs) -> None:
+    endpoint_summary = _build_endpoint_summary(environment.stats)
+    failed = [name for name, values in endpoint_summary.items() if not values["passed"]]
+    summary = {
+        "target_rps": int(os.getenv("SLO_SPINE_TARGET_RPS", "30")),
+        "failure_rate_threshold": FAILURE_RATE_THRESHOLD,
+        "failed": failed,
+        "endpoints": endpoint_summary,
+    }
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    _print_summary(summary)
+    if failed:
+        environment.process_exit_code = 1

--- a/backend/tests/performance/sla_spine_locust.py
+++ b/backend/tests/performance/sla_spine_locust.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,9 @@ from locust.exception import StopUser
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + (b"\0" * 100)
 SUMMARY_PATH = Path(os.getenv("SLO_SPINE_SUMMARY_PATH", "sla-spine-summary.json"))
 FAILURE_RATE_THRESHOLD = float(os.getenv("SLO_SPINE_FAILURE_RATE", "0.01"))
+TARGET_RPS = int(os.getenv("SLO_SPINE_TARGET_RPS", "30"))
+MIN_RPS_RATIO = float(os.getenv("SLO_SPINE_MIN_RPS_RATIO", "0.85"))
+_RUN_STARTED_AT: float | None = None
 
 SPINE_ENDPOINTS = {
     "analyze": {
@@ -224,9 +228,19 @@ def _build_endpoint_summary(stats) -> dict[str, dict[str, Any]]:
     return summary
 
 
+def _achieved_rps(endpoint_summary: dict[str, dict[str, Any]], elapsed_seconds: float) -> float:
+    if elapsed_seconds <= 0:
+        return 0.0
+    protected_samples = sum(values["samples"] for values in endpoint_summary.values())
+    return protected_samples / elapsed_seconds
+
+
 def _print_summary(summary: dict[str, Any]) -> None:
     print("\nArchmorph full-spine SLO summary")
-    print(f"target_rps={summary['target_rps']} failed={summary['failed']}")
+    print(
+        f"target_rps={summary['target_rps']} achieved_rps={summary['achieved_rps']:.2f} "
+        f"min_rps={summary['minimum_rps']:.2f} failed={summary['failed']}"
+    )
     for endpoint_name, values in summary["endpoints"].items():
         status = "PASS" if values["passed"] else "FAIL"
         print(
@@ -237,12 +251,28 @@ def _print_summary(summary: dict[str, Any]) -> None:
     print("")
 
 
+@events.test_start.add_listener
+def record_run_start(**_kwargs) -> None:
+    global _RUN_STARTED_AT
+    _RUN_STARTED_AT = time.perf_counter()
+
+
 @events.quitting.add_listener
 def enforce_spine_slos(environment, **_kwargs) -> None:
     endpoint_summary = _build_endpoint_summary(environment.stats)
+    elapsed_seconds = time.perf_counter() - _RUN_STARTED_AT if _RUN_STARTED_AT else 0.0
+    achieved_rps = _achieved_rps(endpoint_summary, elapsed_seconds)
+    minimum_rps = TARGET_RPS * MIN_RPS_RATIO
+    throughput_passed = achieved_rps >= minimum_rps
     failed = [name for name, values in endpoint_summary.items() if not values["passed"]]
+    if not throughput_passed:
+        failed.append("throughput")
     summary = {
-        "target_rps": int(os.getenv("SLO_SPINE_TARGET_RPS", "30")),
+        "target_rps": TARGET_RPS,
+        "achieved_rps": achieved_rps,
+        "minimum_rps": minimum_rps,
+        "elapsed_seconds": elapsed_seconds,
+        "throughput_passed": throughput_passed,
         "failure_rate_threshold": FAILURE_RATE_THRESHOLD,
         "failed": failed,
         "endpoints": endpoint_summary,

--- a/backend/tests/test_analyze_latency_regression.py
+++ b/backend/tests/test_analyze_latency_regression.py
@@ -6,7 +6,8 @@ PNG_BYTES = b"\x89PNG\r\n\x1a\n" + (b"\0" * 100)
 
 def _p95(values: list[float]) -> float:
     ordered = sorted(values)
-    index = max(0, int(len(ordered) * 0.95) - 1)
+    index = int(len(ordered) * 95 / 100)
+    index = min(index, len(ordered) - 1)
     return ordered[index]
 
 

--- a/backend/tests/test_analyze_latency_regression.py
+++ b/backend/tests/test_analyze_latency_regression.py
@@ -1,0 +1,31 @@
+import time
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + (b"\0" * 100)
+
+
+def _p95(values: list[float]) -> float:
+    ordered = sorted(values)
+    index = max(0, int(len(ordered) * 0.95) - 1)
+    return ordered[index]
+
+
+def test_ci_smoke_analyze_p95_under_200ms_regression_guard(test_client, monkeypatch):
+    monkeypatch.setenv("ARCHMORPH_CI_SMOKE_MODE", "1")
+    monkeypatch.setenv("ENVIRONMENT", "test")
+
+    upload_response = test_client.post(
+        "/api/projects/slo-regression/diagrams",
+        files={"file": ("aws.png", PNG_BYTES, "image/png")},
+    )
+    assert upload_response.status_code == 200
+    diagram_id = upload_response.json()["diagram_id"]
+
+    durations_ms = []
+    for _ in range(10):
+        started = time.perf_counter()
+        response = test_client.post(f"/api/diagrams/{diagram_id}/analyze")
+        durations_ms.append((time.perf_counter() - started) * 1000)
+        assert response.status_code == 200
+
+    assert _p95(durations_ms) < 200

--- a/backend/tests/test_k6_performance_contract.py
+++ b/backend/tests/test_k6_performance_contract.py
@@ -31,6 +31,8 @@ def test_sla_spine_locust_enforces_endpoint_p95s():
 
     assert "constant_throughput" in script
     assert "SLO_SPINE_SUMMARY_PATH" in script
+    assert "achieved_rps" in script
+    assert "SLO_SPINE_MIN_RPS_RATIO" in script
     expected = {
         "analyze": 8000,
         "generate_landing_zone": 1500,
@@ -69,12 +71,14 @@ def test_observability_alerts_cover_full_spine_p95_and_burn_rate():
 
     for resource_name in ("spine_request_p95_high", "spine_burn_rate_high"):
         assert resource_name in alerts
-    for key in ("analyze", "iac_generate", "drift_compare"):
+    for key in ("analyze", "iac_terraform", "iac_bicep", "drift_compare"):
         assert key in alerts
     for threshold in ("threshold_ms = 8000", "threshold_ms = 12000", "threshold_ms = 5000"):
         assert threshold in alerts
     assert "timestamp > ago(5m)" in alerts
     assert "timestamp > ago(1h)" in alerts
+    assert "(/v1)?" in alerts
+    assert "customDimensions.format" in alerts
     assert "threshold               = 2" in alerts
 
 

--- a/backend/tests/test_k6_performance_contract.py
+++ b/backend/tests/test_k6_performance_contract.py
@@ -2,6 +2,10 @@ from pathlib import Path
 
 
 K6_SCRIPT = Path(__file__).parent / "performance" / "api_load_test.js"
+SLA_SPINE_SCRIPT = Path(__file__).parent / "performance" / "sla_spine_locust.py"
+SLA_WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "sla-spine.yml"
+ALERTS_TF = Path(__file__).parents[2] / "infra" / "observability" / "alerts.tf"
+SLO_DOC = Path(__file__).parents[2] / "docs" / "SLO.md"
 
 
 def test_k6_summary_exposes_endpoint_latency_breakdown():
@@ -20,3 +24,70 @@ def test_k6_requests_tag_static_endpoints():
     assert "tags:" in script
     assert "endpoint:" in script
     assert "ep.name" in script
+
+
+def test_sla_spine_locust_enforces_endpoint_p95s():
+    script = SLA_SPINE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "constant_throughput" in script
+    assert "SLO_SPINE_SUMMARY_PATH" in script
+    expected = {
+        "analyze": 8000,
+        "generate_landing_zone": 1500,
+        "generate_iac_terraform": 12000,
+        "generate_iac_bicep": 12000,
+        "drift_compare": 5000,
+    }
+    for endpoint_name, threshold_ms in expected.items():
+        assert f'"{endpoint_name}"' in script
+        assert f'"threshold_ms": {threshold_ms}' in script
+    for route in (
+        "/api/diagrams/{diagram_id}/analyze",
+        "/api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg",
+        "/api/diagrams/{diagram_id}/generate?format=terraform&force=true",
+        "/api/diagrams/{diagram_id}/generate?format=bicep&force=true",
+        "/api/drift/baselines/{baseline_id}/compare",
+    ):
+        assert route in script
+
+
+def test_sla_spine_workflow_posts_pr_summary_and_runs_locust():
+    workflow = SLA_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "name: sla-spine" in workflow
+    assert "locust-venv" in workflow
+    assert "locust==" in workflow
+    assert "backend/tests/performance/sla_spine_locust.py" in workflow
+    assert "ARCHMORPH_CI_SMOKE_MODE=1" in workflow
+    assert "ENVIRONMENT=test" in workflow
+    assert "Full-Spine SLO Gate" in workflow
+    assert "issues: write" in workflow
+
+
+def test_observability_alerts_cover_full_spine_p95_and_burn_rate():
+    alerts = ALERTS_TF.read_text(encoding="utf-8")
+
+    for resource_name in ("spine_request_p95_high", "spine_burn_rate_high"):
+        assert resource_name in alerts
+    for key in ("analyze", "iac_generate", "drift_compare"):
+        assert key in alerts
+    for threshold in ("threshold_ms = 8000", "threshold_ms = 12000", "threshold_ms = 5000"):
+        assert threshold in alerts
+    assert "timestamp > ago(5m)" in alerts
+    assert "timestamp > ago(1h)" in alerts
+    assert "threshold               = 2" in alerts
+
+
+def test_slo_doc_publishes_full_spine_contract():
+    doc = SLO_DOC.read_text(encoding="utf-8")
+
+    for text in (
+        "analyze",
+        "generate_landing_zone",
+        "generate_iac_terraform",
+        "generate_iac_bicep",
+        "drift_compare",
+        "30 RPS",
+        "2x",
+    ):
+        assert text in doc

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -23,14 +23,15 @@ The `sla-spine` GitHub Actions job runs Locust at 30 RPS against a single-proces
 - `ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false`
 - `ARCHMORPH_DISABLE_IAC_CLI_VALIDATION=1`
 
-This keeps the gate stable by using the same mocked/smoke analysis path as the CLI full-spine smoke tests instead of depending on external Azure OpenAI latency. The Locust run writes `sla-spine-summary.json`, uploads it as an artifact, and comments a p95 table on pull requests.
+This keeps the gate stable by using the same mocked/smoke analysis path as the CLI full-spine smoke tests instead of depending on external Azure OpenAI latency. The Locust run writes `sla-spine-summary.json`, uploads it as an artifact, comments a p95 table on pull requests, and fails if achieved throughput drops below 85% of the 30 RPS target.
 
 ## Production Alerts
 
 `infra/observability/alerts.tf` defines Azure Monitor scheduled-query alerts for production telemetry:
 
 - Existing ALZ alerts cover landing-zone icon miss rate and landing-zone SVG p95.
-- Full-spine p95 alerts cover analyze, IaC generation, and drift compare using `http.request.duration_ms` custom metrics.
+- Full-spine p95 alerts cover analyze, Terraform generation, Bicep generation, and drift compare using `http.request.duration_ms` custom metrics.
+- Production IaC alerts split Terraform and Bicep with the `format` metric dimension emitted by request telemetry; route matching covers both `/api/...` and `/api/v1/...` clients.
 - Full-spine burn-rate alerts evaluate both 5-minute and 1-hour windows.
 
 Burn-rate alerts treat requests as bad when the request exceeds the operation latency SLO or returns HTTP 5xx. They alert when both windows burn faster than 2x a 99% latency/error budget. Low-sample windows are suppressed to avoid paging on empty traffic.

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -1,0 +1,42 @@
+# Archmorph Full-Spine SLOs
+
+Archmorph protects the core value spine with endpoint-specific latency SLOs, a deterministic CI gate, and Azure Monitor alerts. The spine is the path users rely on to turn an architecture image into analysis, deployment artifacts, landing-zone visuals, and drift evidence.
+
+## SLO Table
+
+| Operation | CI metric name | Route | Objective | Severity |
+| --- | --- | --- | ---: | --- |
+| Diagram analysis | `analyze` | `POST /api/diagrams/{diagram_id}/analyze` | p95 < 8s | Sev 2 |
+| Landing-zone SVG generation | `generate_landing_zone` | `POST /api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg` | p95 < 1.5s | Sev 2 |
+| Terraform generation | `generate_iac_terraform` | `POST /api/diagrams/{diagram_id}/generate?format=terraform&force=true` | p95 < 12s | Sev 2 |
+| Bicep generation | `generate_iac_bicep` | `POST /api/diagrams/{diagram_id}/generate?format=bicep&force=true` | p95 < 12s | Sev 2 |
+| Drift comparison | `drift_compare` | `POST /api/drift/baselines/{baseline_id}/compare` | p95 < 5s | Sev 3 |
+
+The CI gate also requires endpoint failure rate to stay below 1% and requires every protected endpoint to receive samples.
+
+## CI Enforcement
+
+The `sla-spine` GitHub Actions job runs Locust at 30 RPS against a single-process deterministic backend. The backend is started with:
+
+- `ENVIRONMENT=test`
+- `ARCHMORPH_CI_SMOKE_MODE=1`
+- `ARCHMORPH_EXPORT_CAPABILITY_REQUIRED=false`
+- `ARCHMORPH_DISABLE_IAC_CLI_VALIDATION=1`
+
+This keeps the gate stable by using the same mocked/smoke analysis path as the CLI full-spine smoke tests instead of depending on external Azure OpenAI latency. The Locust run writes `sla-spine-summary.json`, uploads it as an artifact, and comments a p95 table on pull requests.
+
+## Production Alerts
+
+`infra/observability/alerts.tf` defines Azure Monitor scheduled-query alerts for production telemetry:
+
+- Existing ALZ alerts cover landing-zone icon miss rate and landing-zone SVG p95.
+- Full-spine p95 alerts cover analyze, IaC generation, and drift compare using `http.request.duration_ms` custom metrics.
+- Full-spine burn-rate alerts evaluate both 5-minute and 1-hour windows.
+
+Burn-rate alerts treat requests as bad when the request exceeds the operation latency SLO or returns HTTP 5xx. They alert when both windows burn faster than 2x a 99% latency/error budget. Low-sample windows are suppressed to avoid paging on empty traffic.
+
+## Response Guidance
+
+When an SLO fails in CI, inspect the PR comment first to identify the endpoint with the highest p95 or failures. Reproduce locally with the Locust script and the same smoke-mode environment. If the regression is isolated to IaC generation or diagram export, prefer focused profiling around those route handlers before broad backend tuning.
+
+When an Azure Monitor alert fires, compare the p95 alert with the burn-rate alert. A p95-only page usually means a latency regression with enough traffic to be meaningful. A burn-rate page means the endpoint is consuming its latency/error budget across both short and long windows and should be treated as customer-impacting until ruled out.

--- a/infra/observability/alerts.tf
+++ b/infra/observability/alerts.tf
@@ -71,6 +71,32 @@ variable "tags" {
   default     = {}
 }
 
+locals {
+  spine_request_slos = {
+    analyze = {
+      name         = "analyze"
+      severity     = 2
+      threshold_ms = 8000
+      path_regex   = "^/api/diagrams/[^/]+/analyze$"
+      description  = "Analyze p95 exceeds 8 seconds."
+    }
+    iac_generate = {
+      name         = "iac-generate"
+      severity     = 2
+      threshold_ms = 12000
+      path_regex   = "^/api/diagrams/[^/]+/generate$"
+      description  = "IaC generation p95 exceeds 12 seconds."
+    }
+    drift_compare = {
+      name         = "drift-compare"
+      severity     = 3
+      threshold_ms = 5000
+      path_regex   = "^/api/drift/baselines/[^/]+/compare$"
+      description  = "Drift compare p95 exceeds 5 seconds."
+    }
+  }
+}
+
 # ─────────────────────────────────────────────────────────────
 # Alert 1 — icon resolution miss rate
 #
@@ -92,7 +118,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "lz_icon_miss_rate_hig
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
 
-  scopes               = [var.application_insights_id]
+  scopes                = [var.application_insights_id]
   target_resource_types = ["microsoft.insights/components"]
 
   criteria {
@@ -178,10 +204,126 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "lz_svg_p95_high" {
   tags                    = var.tags
 }
 
+# ─────────────────────────────────────────────────────────────
+# Full-spine request p95 alerts (#659)
+#
+# These alerts use the generic HTTP request duration histogram emitted by
+# `backend/main.py`/`backend/observability.py`. The path dimension carries raw
+# diagram/baseline IDs, so KQL normalizes with regex matching instead of alert
+# dimensions. Landing-zone SVG keeps the purpose-built ALZ p95 alert above.
+# ─────────────────────────────────────────────────────────────
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "spine_request_p95_high" {
+  for_each = local.spine_request_slos
+
+  name                = "archmorph-spine-${each.value.name}-p95-high"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  description = each.value.description
+  severity    = each.value.severity
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+
+  scopes                = [var.application_insights_id]
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query = <<-KQL
+      customMetrics
+      | where name == 'http.request.duration_ms'
+      | extend path = tostring(customDimensions.path)
+      | where path matches regex '${each.value.path_regex}'
+      | summarize p95 = percentile(value, 95)
+      | project p95
+    KQL
+
+    time_aggregation_method = "Maximum"
+    operator                = "GreaterThan"
+    threshold               = each.value.threshold_ms
+    metric_measure_column   = "p95"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 2
+      number_of_evaluation_periods             = 2
+    }
+  }
+
+  action {
+    action_groups = [var.action_group_critical_id]
+  }
+
+  auto_mitigation_enabled = true
+  tags                    = var.tags
+}
+
+# ─────────────────────────────────────────────────────────────
+# Full-spine two-window burn-rate alerts (#659)
+#
+# Bad events are requests over the endpoint latency SLO or HTTP 5xx responses.
+# The query evaluates both a 5-minute and 1-hour window and pages only when
+# both windows burn faster than 2x a 99% latency/error budget.
+# ─────────────────────────────────────────────────────────────
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "spine_burn_rate_high" {
+  for_each = local.spine_request_slos
+
+  name                = "archmorph-spine-${each.value.name}-burn-rate-high"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  description = "Two-window burn-rate alert for ${each.value.name}: 5m and 1h burn exceed 2x."
+  severity    = each.value.severity
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT1H"
+
+  scopes                = [var.application_insights_id]
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query = <<-KQL
+      let threshold_ms = todouble(${each.value.threshold_ms});
+      let error_budget = 0.01;
+      let spine = customMetrics
+        | where name == 'http.request.duration_ms'
+        | extend path = tostring(customDimensions.path), status = toint(customDimensions.status)
+        | where path matches regex '${each.value.path_regex}';
+      let short = spine
+        | where timestamp > ago(5m)
+        | summarize total = count(), bad = countif(value > threshold_ms or status >= 500)
+        | extend burn = iif(total < 10, 0.0, todouble(bad) / todouble(total) / error_budget);
+      let long = spine
+        | where timestamp > ago(1h)
+        | summarize total = count(), bad = countif(value > threshold_ms or status >= 500)
+        | extend burn = iif(total < 50, 0.0, todouble(bad) / todouble(total) / error_budget);
+      print burn_rate = min_of(toscalar(short | project burn), toscalar(long | project burn))
+    KQL
+
+    time_aggregation_method = "Maximum"
+    operator                = "GreaterThan"
+    threshold               = 2
+    metric_measure_column   = "burn_rate"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [var.action_group_critical_id]
+  }
+
+  auto_mitigation_enabled = true
+  tags                    = var.tags
+}
+
 output "alert_ids" {
-  description = "IDs of the two alert rules wired up by this module."
+  description = "IDs of the alert rules wired up by this module."
   value = {
     icon_miss_rate_high = azurerm_monitor_scheduled_query_rules_alert_v2.lz_icon_miss_rate_high.id
     svg_p95_high        = azurerm_monitor_scheduled_query_rules_alert_v2.lz_svg_p95_high.id
+    spine_p95_high      = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.spine_request_p95_high : key => alert.id }
+    spine_burn_rate     = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.spine_burn_rate_high : key => alert.id }
   }
 }

--- a/infra/observability/alerts.tf
+++ b/infra/observability/alerts.tf
@@ -77,21 +77,32 @@ locals {
       name         = "analyze"
       severity     = 2
       threshold_ms = 8000
-      path_regex   = "^/api/diagrams/[^/]+/analyze$"
+      path_regex   = "^/api(/v1)?/diagrams/[^/]+/analyze$"
+      format       = ""
       description  = "Analyze p95 exceeds 8 seconds."
     }
-    iac_generate = {
-      name         = "iac-generate"
+    iac_terraform = {
+      name         = "iac-terraform"
       severity     = 2
       threshold_ms = 12000
-      path_regex   = "^/api/diagrams/[^/]+/generate$"
-      description  = "IaC generation p95 exceeds 12 seconds."
+      path_regex   = "^/api(/v1)?/diagrams/[^/]+/generate$"
+      format       = "terraform"
+      description  = "Terraform generation p95 exceeds 12 seconds."
+    }
+    iac_bicep = {
+      name         = "iac-bicep"
+      severity     = 2
+      threshold_ms = 12000
+      path_regex   = "^/api(/v1)?/diagrams/[^/]+/generate$"
+      format       = "bicep"
+      description  = "Bicep generation p95 exceeds 12 seconds."
     }
     drift_compare = {
       name         = "drift-compare"
       severity     = 3
       threshold_ms = 5000
-      path_regex   = "^/api/drift/baselines/[^/]+/compare$"
+      path_regex   = "^/api(/v1)?/drift/baselines/[^/]+/compare$"
+      format       = ""
       description  = "Drift compare p95 exceeds 5 seconds."
     }
   }
@@ -234,6 +245,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "spine_request_p95_hig
       | where name == 'http.request.duration_ms'
       | extend path = tostring(customDimensions.path)
       | where path matches regex '${each.value.path_regex}'
+      | where '${each.value.format}' == '' or tostring(customDimensions.format) == '${each.value.format}'
       | summarize p95 = percentile(value, 95)
       | project p95
     KQL
@@ -286,8 +298,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "spine_burn_rate_high"
       let error_budget = 0.01;
       let spine = customMetrics
         | where name == 'http.request.duration_ms'
-        | extend path = tostring(customDimensions.path), status = toint(customDimensions.status)
-        | where path matches regex '${each.value.path_regex}';
+        | extend path = tostring(customDimensions.path), status = toint(customDimensions.status), format = tostring(customDimensions.format)
+        | where path matches regex '${each.value.path_regex}'
+        | where '${each.value.format}' == '' or format == '${each.value.format}';
       let short = spine
         | where timestamp > ago(5m)
         | summarize total = count(), bad = countif(value > threshold_ms or status >= 500)


### PR DESCRIPTION
## Summary
- add a dedicated `sla-spine` Locust CI gate at 30 RPS for analyze, landing-zone SVG, Terraform/Bicep generation, and drift compare
- publish endpoint-specific p95 PR comments and upload the raw SLO summary artifact
- add full-spine Azure Monitor p95 and two-window burn-rate alerts alongside existing ALZ alerts
- document the SLO contract in `docs/SLO.md` and add a 200ms deterministic analyze regression guard

Closes #659.

## Validation
- `backend/.venv/bin/python -m pytest -q backend/tests/test_k6_performance_contract.py backend/tests/test_analyze_latency_regression.py`
- `terraform -chdir=infra/observability fmt -check`
- `git diff --check`
- local 3-user Locust smoke against deterministic backend: all protected endpoints passed
