### PR TITLE
fix(security): bound export diagram analysis payloads

### DIFF
--- a/backend/analysis_payload_bounds.py
+++ b/backend/analysis_payload_bounds.py
@@ -1,0 +1,85 @@
+"""Analysis payload size guardrails for renderer-facing routes.
+
+Issue #613: user-controlled analysis arrays must be bounded before export
+renderers iterate over them. The export-diagram route reads analysis from the
+session store rather than directly from a request body, so this module provides
+the route-layer equivalent of a Pydantic ``max_items`` contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+MAX_ANALYSIS_LIST_ITEMS = 200
+
+RENDERER_ANALYSIS_LIST_FIELDS: tuple[str, ...] = (
+    "zones",
+    "actors",
+    "regions",
+    "mappings",
+    "service_connections",
+    "replication",
+)
+
+
+class AnalysisPayloadTooLarge(ValueError):
+    """Raised when an analysis payload exceeds renderer input budgets."""
+
+    def __init__(self, field: str, count: int, limit: int):
+        self.field = field
+        self.count = count
+        self.limit = limit
+        super().__init__(
+            f"Analysis payload field '{field}' contains {count} items; "
+            f"maximum is {limit}"
+        )
+
+    @property
+    def details(self) -> dict[str, int | str]:
+        return {
+            "field": self.field,
+            "count": self.count,
+            "limit": self.limit,
+        }
+
+
+def validate_analysis_payload_bounds(
+    analysis: Mapping[str, Any],
+    *,
+    max_items: int = MAX_ANALYSIS_LIST_ITEMS,
+) -> None:
+    """Reject analysis arrays that can make export rendering unbounded.
+
+    Top-level renderer inputs are checked directly. Zone service buckets and
+    explicit ``tiers`` are nested renderer inputs, so each bucket is checked
+    independently.
+    """
+    for field in RENDERER_ANALYSIS_LIST_FIELDS:
+        value = analysis.get(field)
+        if isinstance(value, list) and len(value) > max_items:
+            raise AnalysisPayloadTooLarge(field, len(value), max_items)
+
+    zones = analysis.get("zones")
+    if isinstance(zones, list):
+        for index, zone in enumerate(zones):
+            if not isinstance(zone, Mapping):
+                continue
+            services = zone.get("services")
+            if isinstance(services, list) and len(services) > max_items:
+                raise AnalysisPayloadTooLarge(
+                    f"zones[{index}].services",
+                    len(services),
+                    max_items,
+                )
+
+    tiers = analysis.get("tiers")
+    if isinstance(tiers, Mapping):
+        for tier, entries in tiers.items():
+            if isinstance(entries, list) and len(entries) > max_items:
+                raise AnalysisPayloadTooLarge(
+                    f"tiers.{tier}",
+                    len(entries),
+                    max_items,
+                )

--- a/backend/azure_landing_zone.py
+++ b/backend/azure_landing_zone.py
@@ -54,6 +54,7 @@ from observability import (
     record_histogram,
     trace_span,
 )
+from analysis_payload_bounds import AnalysisPayloadTooLarge, validate_analysis_payload_bounds
 
 # ---------------------------------------------------------------------------
 # Constants — palette, fonts, dimensions
@@ -1168,6 +1169,15 @@ def generate_landing_zone_svg(
                     tags={"stage": "validate", "error_type": "bad_analysis_type"},
                 )
                 raise ValueError("analysis must be a dict")
+
+            try:
+                validate_analysis_payload_bounds(analysis)
+            except AnalysisPayloadTooLarge:
+                increment_counter(
+                    "archmorph.lz.errors_total",
+                    tags={"stage": "validate", "error_type": "analysis_payload_too_large"},
+                )
+                raise
 
             # #576: source_provider is implicit (read from the analysis payload) and
             # validated here. Default "aws" preserves backwards-compat with #571.

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -19,6 +19,7 @@ from service_builder import deduplicate_questions, get_smart_defaults_from_analy
 from architecture_package import generate_architecture_package
 from error_envelope import ArchmorphException
 from export_capabilities import attach_export_capability, verify_export_capability
+from analysis_payload_bounds import AnalysisPayloadTooLarge, validate_analysis_payload_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +203,11 @@ async def export_architecture_diagram(
     if not analysis:
         raise ArchmorphException(404, f"No analysis found for diagram {diagram_id}. Run /analyze first.")
 
+    try:
+        validate_analysis_payload_bounds(analysis)
+    except AnalysisPayloadTooLarge as exc:
+        raise ArchmorphException(413, str(exc), details=exc.details)
+
     if multi_page:
         analysis["multi_page"] = True
 
@@ -274,12 +280,19 @@ async def export_architecture_package(
         raise ArchmorphException(404, f"No analysis found for diagram {diagram_id}. Run /analyze first.")
 
     try:
+        validate_analysis_payload_bounds(analysis)
+    except AnalysisPayloadTooLarge as exc:
+        raise ArchmorphException(413, str(exc), details=exc.details)
+
+    try:
         result = generate_architecture_package(
             analysis,
             format=format,  # type: ignore[arg-type]
             diagram=diagram,  # type: ignore[arg-type]
             analysis_id=diagram_id,
         )
+    except AnalysisPayloadTooLarge as exc:
+        raise ArchmorphException(413, str(exc), details=exc.details)
     except ValueError as exc:
         raise ArchmorphException(400, str(exc))
 

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from architecture_package import generate_architecture_package
+from analysis_payload_bounds import MAX_ANALYSIS_LIST_ITEMS
 from customer_intent import build_customer_intent_profile
 from routers.shared import SESSION_STORE
 
@@ -360,3 +361,30 @@ def test_export_architecture_package_endpoint_returns_dr_svg(test_client):
     assert data["filename"].endswith("-dr.svg")
     assert data["manifest"]["analysis_id"] == diagram_id
     ET.fromstring(data["content"])
+
+
+def test_export_architecture_package_rejects_oversized_analysis_with_413(test_client):
+    diagram_id = "package-endpoint-oversized-test"
+    SESSION_STORE[diagram_id] = {
+        **SAMPLE_ANALYSIS,
+        "tiers": {
+            "app": [
+                {"name": f"App Service {i}", "category": "Compute"}
+                for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+            ]
+        },
+    }
+
+    try:
+        response = test_client.post(
+            f"/api/diagrams/{diagram_id}/export-architecture-package?format=html"
+        )
+    finally:
+        SESSION_STORE.delete(diagram_id)
+
+    assert response.status_code == 413, response.text
+    assert response.json()["error"]["details"] == {
+        "field": "tiers.app",
+        "count": MAX_ANALYSIS_LIST_ITEMS + 1,
+        "limit": MAX_ANALYSIS_LIST_ITEMS,
+    }

--- a/backend/tests/test_azure_landing_zone.py
+++ b/backend/tests/test_azure_landing_zone.py
@@ -21,6 +21,7 @@ from azure_landing_zone import (
     _networking_services,
     generate_landing_zone_svg,
 )
+from analysis_payload_bounds import AnalysisPayloadTooLarge, MAX_ANALYSIS_LIST_ITEMS
 from azure_landing_zone_schema import infer_tiers_from_mappings
 
 # #588 — canonical AWS estate fixture used by the tier-population +
@@ -226,6 +227,64 @@ class TestGenerator:
     def test_landing_zone_svg_invalid_dr_variant_raises(self):
         with pytest.raises(ValueError):
             generate_landing_zone_svg(SAMPLE_ANALYSIS, dr_variant="bogus")  # type: ignore[arg-type]
+
+    def test_landing_zone_svg_rejects_oversized_mappings_before_render(self):
+        oversized = {
+            **SAMPLE_ANALYSIS,
+            "mappings": [
+                {
+                    "source_service": f"Source {i}",
+                    "azure_service": f"Azure Service {i}",
+                    "category": "Compute",
+                }
+                for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+            ],
+        }
+
+        with pytest.raises(AnalysisPayloadTooLarge, match="mappings") as exc_info:
+            generate_landing_zone_svg(oversized, dr_variant="primary")
+
+        assert exc_info.value.count == MAX_ANALYSIS_LIST_ITEMS + 1
+        assert exc_info.value.limit == MAX_ANALYSIS_LIST_ITEMS
+
+    def test_landing_zone_svg_rejects_oversized_zone_services_before_render(self):
+        oversized = {
+            **SAMPLE_ANALYSIS,
+            "zones": [
+                {
+                    "id": 1,
+                    "name": "web-tier",
+                    "number": 1,
+                    "services": [
+                        {"name": f"Service {i}", "category": "Compute"}
+                        for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+                    ],
+                }
+            ],
+        }
+
+        with pytest.raises(AnalysisPayloadTooLarge, match="zones") as exc_info:
+            generate_landing_zone_svg(oversized, dr_variant="primary")
+
+        assert exc_info.value.field == "zones[0].services"
+        assert exc_info.value.count == MAX_ANALYSIS_LIST_ITEMS + 1
+
+    def test_landing_zone_svg_rejects_oversized_explicit_tier_before_render(self):
+        oversized = {
+            **SAMPLE_ANALYSIS,
+            "tiers": {
+                "app": [
+                    {"name": f"App Service {i}", "category": "Compute"}
+                    for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+                ]
+            },
+        }
+
+        with pytest.raises(AnalysisPayloadTooLarge, match="tiers.app") as exc_info:
+            generate_landing_zone_svg(oversized, dr_variant="primary")
+
+        assert exc_info.value.field == "tiers.app"
+        assert exc_info.value.count == MAX_ANALYSIS_LIST_ITEMS + 1
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +564,90 @@ class TestRouter:
         assert body["filename"].endswith("-dr.svg")
         root = ET.fromstring(body["content"])
         assert root.get("height") == str(CANVAS_H_DR)
+
+    def test_export_diagram_rejects_oversized_analysis_with_413(self, client):
+        from main import SESSION_STORE
+
+        diagram_id = "oversized-analysis-001"
+        SESSION_STORE[diagram_id] = {
+            **SAMPLE_ANALYSIS,
+            "mappings": [
+                {
+                    "source_service": f"Source {i}",
+                    "azure_service": f"Azure Service {i}",
+                    "category": "Compute",
+                }
+                for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+            ],
+        }
+        try:
+            resp = client.post(
+                f"/api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg"
+            )
+        finally:
+            SESSION_STORE.delete(diagram_id)
+
+        assert resp.status_code == 413, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "PAYLOAD_TOO_LARGE"
+        assert body["error"]["details"] == {
+            "field": "mappings",
+            "count": MAX_ANALYSIS_LIST_ITEMS + 1,
+            "limit": MAX_ANALYSIS_LIST_ITEMS,
+        }
+
+    def test_export_diagram_bounds_apply_before_mcp_export(self, client):
+        from main import SESSION_STORE
+
+        diagram_id = "oversized-analysis-drawio-001"
+        SESSION_STORE[diagram_id] = {
+            **SAMPLE_ANALYSIS,
+            "service_connections": [
+                {"source": "A", "target": "B", "type": "traffic"}
+                for _ in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+            ],
+        }
+        try:
+            resp = client.post(
+                f"/api/diagrams/{diagram_id}/export-diagram?format=drawio"
+            )
+        finally:
+            SESSION_STORE.delete(diagram_id)
+
+        assert resp.status_code == 413, resp.text
+        assert resp.json()["error"]["details"]["field"] == "service_connections"
+
+    def test_export_diagram_rejects_oversized_nested_zone_services(self, client):
+        from main import SESSION_STORE
+
+        diagram_id = "oversized-zone-services-001"
+        SESSION_STORE[diagram_id] = {
+            **SAMPLE_ANALYSIS,
+            "zones": [
+                {
+                    "id": 1,
+                    "name": "web-tier",
+                    "number": 1,
+                    "services": [
+                        {"name": f"Service {i}", "category": "Compute"}
+                        for i in range(MAX_ANALYSIS_LIST_ITEMS + 1)
+                    ],
+                }
+            ],
+        }
+        try:
+            resp = client.post(
+                f"/api/diagrams/{diagram_id}/export-diagram?format=drawio"
+            )
+        finally:
+            SESSION_STORE.delete(diagram_id)
+
+        assert resp.status_code == 413, resp.text
+        assert resp.json()["error"]["details"] == {
+            "field": "zones[0].services",
+            "count": MAX_ANALYSIS_LIST_ITEMS + 1,
+            "limit": MAX_ANALYSIS_LIST_ITEMS,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #613.

## Summary
- add a shared renderer-facing analysis payload bounds validator
- reject oversized export-diagram session payloads with 413 before rendering or MCP export
- guard direct landing-zone SVG generation before inference/render loops
- cover oversized mappings and service_connections regressions

## Validation
- `./.venv/bin/python -m pytest tests/test_azure_landing_zone.py -q`
- `./.venv/bin/python -m pytest tests/test_diagram_export.py tests/test_sample_session_recreate.py -q`
- `git diff --check`