### PR TITLE
fix(security): forbid extra fields on API schemas

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "AWSCredentialsInput": {
+        "additionalProperties": false,
         "properties": {
           "access_key_id": {
             "anyOf": [
@@ -60,6 +61,7 @@
         "type": "object"
       },
       "AddEventRequest": {
+        "additionalProperties": false,
         "properties": {
           "data": {
             "additionalProperties": true,
@@ -92,6 +94,7 @@
         "type": "object"
       },
       "AddServicesRequest": {
+        "additionalProperties": false,
         "description": "Request body for natural language service additions.",
         "properties": {
           "text": {
@@ -106,6 +109,7 @@
         "type": "object"
       },
       "AdminLoginRequest": {
+        "additionalProperties": false,
         "description": "Body for POST /api/admin/login.",
         "properties": {
           "key": {
@@ -173,6 +177,7 @@
         "type": "object"
       },
       "AgentCreate": {
+        "additionalProperties": false,
         "properties": {
           "model": {
             "default": "gpt-4o",
@@ -206,6 +211,7 @@
         "type": "object"
       },
       "AgentCreateSchema": {
+        "additionalProperties": false,
         "properties": {
           "data_sources": {
             "default": [],
@@ -273,6 +279,7 @@
         "type": "object"
       },
       "AgentResponse": {
+        "additionalProperties": false,
         "properties": {
           "created_at": {
             "title": "Created At",
@@ -332,6 +339,7 @@
         "type": "object"
       },
       "AgentResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "anyOf": [
@@ -377,6 +385,7 @@
         "type": "object"
       },
       "AgentUpdate": {
+        "additionalProperties": false,
         "properties": {
           "model": {
             "anyOf": [
@@ -443,6 +452,7 @@
         "type": "object"
       },
       "AgentUpdateSchema": {
+        "additionalProperties": false,
         "properties": {
           "data_sources": {
             "anyOf": [
@@ -530,6 +540,7 @@
         "type": "string"
       },
       "AzureCredentialsInput": {
+        "additionalProperties": false,
         "properties": {
           "auth_method": {
             "description": "service_principal, managed_identity, default",
@@ -588,6 +599,7 @@
         "type": "object"
       },
       "BatchSKURequest": {
+        "additionalProperties": false,
         "description": "Batch translation request body.",
         "properties": {
           "provider": {
@@ -764,6 +776,7 @@
         "type": "object"
       },
       "BranchRequest": {
+        "additionalProperties": false,
         "properties": {
           "label": {
             "anyOf": [
@@ -923,6 +936,7 @@
         "type": "object"
       },
       "BugReportPayload": {
+        "additionalProperties": false,
         "description": "Bug report submission.",
         "properties": {
           "actual_behavior": {
@@ -1026,6 +1040,7 @@
         "type": "object"
       },
       "BugReportRequest": {
+        "additionalProperties": false,
         "properties": {
           "context": {
             "anyOf": [
@@ -1076,6 +1091,7 @@
         "type": "object"
       },
       "ChatMessage": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "maxLength": 5000,
@@ -1104,6 +1120,7 @@
         "type": "object"
       },
       "CollectionResponse": {
+        "additionalProperties": false,
         "properties": {
           "collection_id": {
             "title": "Collection Id",
@@ -1132,6 +1149,7 @@
         "type": "object"
       },
       "CollectionStats": {
+        "additionalProperties": false,
         "properties": {
           "chunk_count": {
             "title": "Chunk Count",
@@ -1234,6 +1252,7 @@
         "type": "object"
       },
       "CostCompareRequest": {
+        "additionalProperties": false,
         "properties": {
           "zones": {
             "items": {
@@ -1250,6 +1269,7 @@
         "type": "object"
       },
       "CostConfigureRequest": {
+        "additionalProperties": false,
         "properties": {
           "overrides": {
             "items": {
@@ -1331,6 +1351,7 @@
         "type": "object"
       },
       "CostServiceInput": {
+        "additionalProperties": false,
         "properties": {
           "config": {
             "anyOf": [
@@ -1386,6 +1407,7 @@
         "type": "object"
       },
       "CostSummary": {
+        "additionalProperties": false,
         "properties": {
           "per_agent": {
             "items": {
@@ -1428,6 +1450,7 @@
         "type": "object"
       },
       "CostZoneInput": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "description": "Category name (Compute, Storage, etc.)",
@@ -1450,6 +1473,7 @@
         "type": "object"
       },
       "CreateCollectionRequest": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "default": "",
@@ -1471,6 +1495,7 @@
         "type": "object"
       },
       "CreateKeyRequest": {
+        "additionalProperties": false,
         "properties": {
           "expires_in_days": {
             "anyOf": [
@@ -1519,6 +1544,7 @@
         "type": "object"
       },
       "CreateKeyResponse": {
+        "additionalProperties": false,
         "properties": {
           "created_at": {
             "title": "Created At",
@@ -1577,6 +1603,7 @@
         "type": "object"
       },
       "CreateSessionRequest": {
+        "additionalProperties": false,
         "properties": {
           "analysis_id": {
             "maxLength": 128,
@@ -1599,6 +1626,7 @@
         "type": "object"
       },
       "CreateSessionResponse": {
+        "additionalProperties": false,
         "properties": {
           "analysis_id": {
             "title": "Analysis Id",
@@ -1627,6 +1655,7 @@
         "type": "object"
       },
       "CreateWebhookRequest": {
+        "additionalProperties": false,
         "example": {
           "description": "My CI pipeline hook",
           "events": [
@@ -1678,6 +1707,7 @@
         "type": "object"
       },
       "CredentialResponse": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "title": "Message",
@@ -1701,6 +1731,7 @@
         "type": "object"
       },
       "DeploymentExecuteRequest": {
+        "additionalProperties": false,
         "properties": {
           "infrastructure_code": {
             "title": "Infrastructure Code",
@@ -1742,6 +1773,7 @@
         "type": "object"
       },
       "DeploymentPreviewRequest": {
+        "additionalProperties": false,
         "properties": {
           "infrastructure_code": {
             "title": "Infrastructure Code",
@@ -1772,6 +1804,7 @@
         "type": "object"
       },
       "DeploymentRequest": {
+        "additionalProperties": false,
         "properties": {
           "canvas_state": {
             "anyOf": [
@@ -1808,6 +1841,7 @@
         "type": "object"
       },
       "DocumentResponse": {
+        "additionalProperties": false,
         "properties": {
           "chunk_count": {
             "title": "Chunk Count",
@@ -1851,6 +1885,7 @@
         "type": "object"
       },
       "DocumentResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "chunk_count": {
             "title": "Chunk Count",
@@ -1884,6 +1919,7 @@
         "type": "object"
       },
       "DriftBaselineCreate": {
+        "additionalProperties": false,
         "properties": {
           "designed_state": {
             "additionalProperties": true,
@@ -1923,6 +1959,7 @@
         "type": "object"
       },
       "DriftCompareRequest": {
+        "additionalProperties": false,
         "properties": {
           "live_state": {
             "additionalProperties": true,
@@ -1937,6 +1974,7 @@
         "type": "object"
       },
       "DriftFindingDecision": {
+        "additionalProperties": false,
         "properties": {
           "decision": {
             "pattern": "^(accepted|rejected|deferred|open)$",
@@ -1963,6 +2001,7 @@
         "type": "object"
       },
       "DriftRequest": {
+        "additionalProperties": false,
         "properties": {
           "designed_state": {
             "additionalProperties": true,
@@ -1983,6 +2022,7 @@
         "type": "object"
       },
       "EntityResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "attributes": {
             "additionalProperties": true,
@@ -2012,6 +2052,7 @@
         "type": "object"
       },
       "EpisodeResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "title": "Id",
@@ -2043,6 +2084,7 @@
         "type": "object"
       },
       "ExecuteRequest": {
+        "additionalProperties": false,
         "properties": {
           "message": {
             "maxLength": 10000,
@@ -2058,6 +2100,7 @@
         "type": "object"
       },
       "ExecutionInputSchema": {
+        "additionalProperties": false,
         "properties": {
           "agent_id": {
             "title": "Agent Id",
@@ -2096,6 +2139,7 @@
         "type": "object"
       },
       "ExecutionResponse": {
+        "additionalProperties": false,
         "properties": {
           "agent_id": {
             "title": "Agent Id",
@@ -2161,6 +2205,7 @@
         "type": "object"
       },
       "ExecutionResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "agent_id": {
             "title": "Agent Id",
@@ -2218,6 +2263,7 @@
         "type": "object"
       },
       "FeatureFeedbackRequest": {
+        "additionalProperties": false,
         "properties": {
           "comment": {
             "anyOf": [
@@ -2263,6 +2309,7 @@
         "type": "object"
       },
       "FeatureRequestPayload": {
+        "additionalProperties": false,
         "description": "Feature request submission.",
         "properties": {
           "description": {
@@ -2314,6 +2361,7 @@
         "type": "object"
       },
       "FlagUpdateRequest": {
+        "additionalProperties": false,
         "description": "Request body for updating a feature flag.",
         "properties": {
           "description": {
@@ -2384,6 +2432,7 @@
         "type": "object"
       },
       "GenerateBatchRequest": {
+        "additionalProperties": false,
         "description": "Request body for batch AI suggestion generation.",
         "properties": {
           "services": {
@@ -2407,6 +2456,7 @@
         "type": "object"
       },
       "GenerateRequest": {
+        "additionalProperties": false,
         "description": "Request body for triggering AI suggestion generation.",
         "properties": {
           "context_services": {
@@ -2441,6 +2491,7 @@
         "type": "object"
       },
       "GitHubIssueRequest": {
+        "additionalProperties": false,
         "properties": {
           "confidence": {
             "default": "N/A",
@@ -2509,6 +2560,7 @@
         "type": "object"
       },
       "IaCChatMessage": {
+        "additionalProperties": false,
         "description": "Request body for IaC chat messages.",
         "properties": {
           "code": {
@@ -2537,6 +2589,7 @@
         "type": "object"
       },
       "InfraImportRequest": {
+        "additionalProperties": false,
         "description": "Request body for infrastructure file import.",
         "properties": {
           "content": {
@@ -2564,6 +2617,7 @@
         "type": "object"
       },
       "IngestResponse": {
+        "additionalProperties": false,
         "properties": {
           "chunk_count": {
             "title": "Chunk Count",
@@ -2607,6 +2661,7 @@
         "type": "object"
       },
       "JiraCreateRequest": {
+        "additionalProperties": false,
         "properties": {
           "api_token": {
             "description": "Jira API token",
@@ -2664,6 +2719,7 @@
         "type": "object"
       },
       "JoinSessionRequest": {
+        "additionalProperties": false,
         "properties": {
           "role": {
             "enum": [
@@ -2697,6 +2753,7 @@
         "type": "object"
       },
       "KeyInfo": {
+        "additionalProperties": false,
         "properties": {
           "created_at": {
             "title": "Created At",
@@ -2760,6 +2817,7 @@
         "type": "object"
       },
       "LeadCaptureRequest": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "description": "iac_download, hld_download, or share",
@@ -2823,6 +2881,7 @@
         "type": "object"
       },
       "LoginRequest": {
+        "additionalProperties": false,
         "properties": {
           "code": {
             "anyOf": [
@@ -2859,6 +2918,7 @@
         "type": "object"
       },
       "MemoryConfigSchema": {
+        "additionalProperties": false,
         "properties": {
           "long_term": {
             "additionalProperties": true,
@@ -2879,6 +2939,7 @@
         "type": "object"
       },
       "ModelConfigSchema": {
+        "additionalProperties": false,
         "properties": {
           "max_tokens": {
             "title": "Max Tokens",
@@ -2955,6 +3016,7 @@
         "type": "object"
       },
       "ModelEndpointCreateSchema": {
+        "additionalProperties": false,
         "properties": {
           "capabilities": {
             "anyOf": [
@@ -3012,6 +3074,7 @@
         "type": "object"
       },
       "ModelEndpointResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "capabilities": {
             "additionalProperties": true,
@@ -3057,6 +3120,7 @@
         "type": "object"
       },
       "NPSRequest": {
+        "additionalProperties": false,
         "properties": {
           "feature_context": {
             "anyOf": [
@@ -3109,6 +3173,7 @@
         "type": "object"
       },
       "NetworkTopologyRequest": {
+        "additionalProperties": false,
         "description": "Optional overrides for network topology generation.",
         "properties": {
           "network_overrides": {
@@ -3155,6 +3220,7 @@
         "type": "object"
       },
       "NotifyEmailRequest": {
+        "additionalProperties": false,
         "description": "Request body for email notification.",
         "properties": {
           "diagram_name": {
@@ -3177,6 +3243,7 @@
         "type": "object"
       },
       "PolicyCreateSchema": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "anyOf": [
@@ -3217,6 +3284,7 @@
         "type": "object"
       },
       "PolicyResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "anyOf": [
@@ -3268,6 +3336,7 @@
         "type": "object"
       },
       "PushIaCRequest": {
+        "additionalProperties": false,
         "properties": {
           "analysis_summary": {
             "anyOf": [
@@ -3350,6 +3419,7 @@
         "type": "object"
       },
       "RefreshRequest": {
+        "additionalProperties": false,
         "properties": {
           "refresh_token": {
             "title": "Refresh Token",
@@ -3363,6 +3433,7 @@
         "type": "object"
       },
       "RestoreSessionRequest": {
+        "additionalProperties": false,
         "description": "Request body for restoring a cached analysis session.",
         "properties": {
           "analysis": {
@@ -3445,6 +3516,7 @@
         "type": "object"
       },
       "ReviewRequest": {
+        "additionalProperties": false,
         "description": "Request body for reviewing an AI mapping suggestion.",
         "properties": {
           "decision": {
@@ -3501,6 +3573,7 @@
         "type": "object"
       },
       "SaveVersionRequest": {
+        "additionalProperties": false,
         "properties": {
           "label": {
             "anyOf": [
@@ -3519,6 +3592,7 @@
         "type": "object"
       },
       "SearchRequest": {
+        "additionalProperties": false,
         "properties": {
           "collection_ids": {
             "anyOf": [
@@ -3576,6 +3650,7 @@
         "type": "object"
       },
       "SearchResponse": {
+        "additionalProperties": false,
         "properties": {
           "query": {
             "title": "Query",
@@ -3602,6 +3677,7 @@
         "type": "object"
       },
       "SearchResultItem": {
+        "additionalProperties": false,
         "properties": {
           "bm25_score": {
             "title": "Bm25 Score",
@@ -3660,6 +3736,7 @@
         "type": "object"
       },
       "ServiceCostConfig": {
+        "additionalProperties": false,
         "properties": {
           "instance_count": {
             "default": 1,
@@ -3697,6 +3774,7 @@
         "type": "object"
       },
       "SlackNotifyRequest": {
+        "additionalProperties": false,
         "example": {
           "confidence": "high",
           "cost_estimate": "$450/month",
@@ -3757,6 +3835,7 @@
         "type": "object"
       },
       "StartRecordingRequest": {
+        "additionalProperties": false,
         "properties": {
           "analysis_id": {
             "maxLength": 128,
@@ -3784,6 +3863,7 @@
         "type": "object"
       },
       "SubmitChangeRequest": {
+        "additionalProperties": false,
         "properties": {
           "change_type": {
             "enum": [
@@ -3815,6 +3895,7 @@
         "type": "object"
       },
       "SuggestBatchRequest": {
+        "additionalProperties": false,
         "description": "Request body for batch AI mapping suggestions.",
         "properties": {
           "services": {
@@ -3838,6 +3919,7 @@
         "type": "object"
       },
       "SuggestMappingRequest": {
+        "additionalProperties": false,
         "description": "Request body for single AI mapping suggestion.",
         "properties": {
           "context_services": {
@@ -3872,6 +3954,7 @@
         "type": "object"
       },
       "TeamsNotifyRequest": {
+        "additionalProperties": false,
         "properties": {
           "confidence": {
             "default": "N/A",
@@ -3919,6 +4002,7 @@
         "type": "object"
       },
       "TerraformValidateRequest": {
+        "additionalProperties": false,
         "properties": {
           "code": {
             "maxLength": 100000,
@@ -3933,6 +4017,7 @@
         "type": "object"
       },
       "TestWebhookRequest": {
+        "additionalProperties": false,
         "properties": {
           "event_type": {
             "default": "analysis.completed",
@@ -3987,6 +4072,7 @@
         "type": "object"
       },
       "ToolAttach": {
+        "additionalProperties": false,
         "properties": {
           "tool_name": {
             "title": "Tool Name",
@@ -4033,6 +4119,7 @@
         "type": "object"
       },
       "UpdateWebhookRequest": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "anyOf": [

--- a/backend/routers/admin_core.py
+++ b/backend/routers/admin_core.py
@@ -4,7 +4,8 @@ Admin Authentication, Metrics, Monitoring, Audit, Observability, Analytics route
 """
 
 from fastapi import APIRouter, Depends, Header, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Optional, Dict, Any
 import os
 import time
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class AdminLoginRequest(BaseModel):
+class AdminLoginRequest(StrictBaseModel):
     """Body for POST /api/admin/login."""
     key: str = Field(..., min_length=1, description="Admin secret key")
 

--- a/backend/routers/agent_memory.py
+++ b/backend/routers/agent_memory.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+from strict_models import StrictBaseModel
 
 from database import get_db
 from routers.auth import get_current_user
@@ -10,7 +11,7 @@ from models.memory import AgentMemoryDocument, AgentEpisodicMemory, AgentEntityM
 
 router = APIRouter(prefix="/api/agents/{agent_id}/memory", tags=["Agent Memory"])
 
-class DocumentResponseSchema(BaseModel):
+class DocumentResponseSchema(StrictBaseModel):
     id: str
     filename: str
     file_type: str
@@ -19,7 +20,7 @@ class DocumentResponseSchema(BaseModel):
     
     model_config = ConfigDict(from_attributes=True)
 
-class EpisodeResponseSchema(BaseModel):
+class EpisodeResponseSchema(StrictBaseModel):
     id: str
     summary: str
     importance_score: float
@@ -27,7 +28,7 @@ class EpisodeResponseSchema(BaseModel):
     
     model_config = ConfigDict(from_attributes=True)
 
-class EntityResponseSchema(BaseModel):
+class EntityResponseSchema(StrictBaseModel):
     id: str
     entity_name: str
     entity_type: str

--- a/backend/routers/agent_paas.py
+++ b/backend/routers/agent_paas.py
@@ -19,7 +19,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from openai_client import get_openai_client, AZURE_OPENAI_DEPLOYMENT, openai_retry
 from agent_tools import (
@@ -53,26 +54,26 @@ MAX_REACT_ITERATIONS = 3
 # Pydantic schemas
 # ─────────────────────────────────────────────────────────────
 
-class AgentCreate(BaseModel):
+class AgentCreate(StrictBaseModel):
     name: str = Field(..., min_length=1, max_length=200)
     model: str = "gpt-4o"
     system_prompt: str = "You are a helpful AI assistant."
     rag_collections: List[str] = []
 
-class AgentUpdate(BaseModel):
+class AgentUpdate(StrictBaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=200)
     model: Optional[str] = None
     system_prompt: Optional[str] = None
     rag_collections: Optional[List[str]] = None
     status: Optional[str] = None
 
-class ToolAttach(BaseModel):
+class ToolAttach(StrictBaseModel):
     tool_name: str
 
-class ExecuteRequest(BaseModel):
+class ExecuteRequest(StrictBaseModel):
     message: str = Field(..., min_length=1, max_length=10000)
 
-class AgentResponse(BaseModel):
+class AgentResponse(StrictBaseModel):
     id: str
     name: str
     model: str
@@ -83,7 +84,7 @@ class AgentResponse(BaseModel):
     created_at: str
     updated_at: str
 
-class ExecutionResponse(BaseModel):
+class ExecutionResponse(StrictBaseModel):
     id: str
     agent_id: str
     user_message: str
@@ -95,7 +96,7 @@ class ExecutionResponse(BaseModel):
     rag_context_used: bool
     created_at: str
 
-class CostSummary(BaseModel):
+class CostSummary(StrictBaseModel):
     total_executions: int
     total_prompt_tokens: int
     total_completion_tokens: int

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 from database import get_db
 from models.agent import Agent, AgentVersion
 from models.tenant import Organization
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+from strict_models import StrictBaseModel
 import uuid
 import datetime
 
@@ -15,18 +16,18 @@ def utc_now_naive() -> datetime.datetime:
 router = APIRouter(prefix="/agents", tags=["agents"])
 
 # Pydantic schemas
-class ModelConfigSchema(BaseModel):
+class ModelConfigSchema(StrictBaseModel):
     provider: str
     model: str
     temperature: float
     max_tokens: int
     system_prompt: str
 
-class MemoryConfigSchema(BaseModel):
+class MemoryConfigSchema(StrictBaseModel):
     short_term: dict
     long_term: dict
 
-class AgentCreateSchema(BaseModel):
+class AgentCreateSchema(StrictBaseModel):
     name: str
     description: Optional[str] = None
     organization_id: str
@@ -35,7 +36,7 @@ class AgentCreateSchema(BaseModel):
     data_sources: List[dict] = []
     memory_config: Optional[MemoryConfigSchema] = None
 
-class AgentUpdateSchema(BaseModel):
+class AgentUpdateSchema(StrictBaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     model_config_data: Optional[ModelConfigSchema] = None
@@ -43,7 +44,7 @@ class AgentUpdateSchema(BaseModel):
     data_sources: Optional[List[dict]] = None
     memory_config: Optional[MemoryConfigSchema] = None
 
-class AgentResponseSchema(BaseModel):
+class AgentResponseSchema(StrictBaseModel):
     id: str
     name: str
     description: Optional[str]

--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -5,7 +5,7 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 from typing import Dict, Any
 import asyncio
 import logging
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class AddServicesRequest(BaseModel):
+class AddServicesRequest(StrictBaseModel):
     """Request body for natural language service additions."""
     text: str
 

--- a/backend/routers/api_keys_routes.py
+++ b/backend/routers/api_keys_routes.py
@@ -18,7 +18,8 @@ from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional, Set
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from routers.shared import limiter, verify_api_key
 
@@ -215,14 +216,14 @@ def validate_api_key_by_raw(raw_key: str) -> Optional[APIKeyRecord]:
 # Pydantic request/response models
 # ---------------------------------------------------------------------------
 
-class CreateKeyRequest(BaseModel):
+class CreateKeyRequest(StrictBaseModel):
     name: str = Field(..., min_length=1, max_length=128, description="Human-readable key name")
     scopes: List[str] = Field(..., min_length=1, description="Permission scopes: read, write, admin")
     rate_limit: int = Field(DEFAULT_RATE_LIMIT, ge=1, le=10000, description="Max requests per minute")
     expires_in_days: Optional[int] = Field(None, ge=1, le=365, description="Days until expiry (optional)")
 
 
-class CreateKeyResponse(BaseModel):
+class CreateKeyResponse(StrictBaseModel):
     id: str
     name: str
     key: str = Field(..., description="Full API key — shown only once")
@@ -233,7 +234,7 @@ class CreateKeyResponse(BaseModel):
     expires_at: Optional[str] = None
 
 
-class KeyInfo(BaseModel):
+class KeyInfo(StrictBaseModel):
     id: str
     name: str
     key_prefix: str

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -5,7 +5,8 @@ Social Authentication — Microsoft, Google, GitHub (Issue #246).
 """
 
 from fastapi import APIRouter, Request, Header, Query
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import Field, EmailStr
+from strict_models import StrictBaseModel
 from typing import Optional
 
 from routers.shared import limiter
@@ -26,13 +27,13 @@ from auth import (
 router = APIRouter()
 
 
-class LoginRequest(BaseModel):
+class LoginRequest(StrictBaseModel):
     provider: str = Field(..., description="azure_ad_b2c or github")
     token: Optional[str] = None
     code: Optional[str] = None
 
 
-class LeadCaptureRequest(BaseModel):
+class LeadCaptureRequest(StrictBaseModel):
     email: EmailStr
     diagram_id: str
     action: str = Field(..., description="iac_download, hld_download, or share")
@@ -121,7 +122,7 @@ async def list_providers():
     return {"providers": providers, "anonymous_allowed": config.get("anonymous_allowed", True)}
 
 
-class RefreshRequest(BaseModel):
+class RefreshRequest(StrictBaseModel):
     refresh_token: str
 
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -3,7 +3,8 @@ Chat routes — AI assistant with GitHub issue creation.
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Optional
 
 from routers.shared import limiter, verify_api_key
@@ -15,7 +16,7 @@ import asyncio
 router = APIRouter()
 
 
-class ChatMessage(BaseModel):
+class ChatMessage(StrictBaseModel):
     message: str = Field(..., min_length=1, max_length=5000)
     session_id: Optional[str] = Field(default="default", max_length=100)
 

--- a/backend/routers/collaboration_routes.py
+++ b/backend/routers/collaboration_routes.py
@@ -13,7 +13,8 @@ import uuid
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from error_envelope import ArchmorphException
 from log_sanitizer import safe
@@ -34,25 +35,25 @@ Role = Literal["architect", "devops", "manager", "security"]
 ChangeType = Literal["answer_update", "annotation", "comment", "approval"]
 
 
-class CreateSessionRequest(BaseModel):
+class CreateSessionRequest(StrictBaseModel):
     analysis_id: str = Field(..., min_length=1, max_length=128)
     owner: str = Field(..., min_length=1, max_length=128)
 
 
-class CreateSessionResponse(BaseModel):
+class CreateSessionResponse(StrictBaseModel):
     session_id: str
     share_code: str
     analysis_id: str
     owner: str
 
 
-class JoinSessionRequest(BaseModel):
+class JoinSessionRequest(StrictBaseModel):
     share_code: str = Field(..., min_length=1, max_length=16)
     user_id: str = Field(..., min_length=1, max_length=128)
     role: Role
 
 
-class SubmitChangeRequest(BaseModel):
+class SubmitChangeRequest(StrictBaseModel):
     user_id: str = Field(..., min_length=1, max_length=128)
     change_type: ChangeType
     payload: dict = Field(default_factory=dict)

--- a/backend/routers/cost_comparison_routes.py
+++ b/backend/routers/cost_comparison_routes.py
@@ -11,7 +11,8 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from error_envelope import ArchmorphException
 from routers.shared import limiter
@@ -27,7 +28,7 @@ _cost_cache = get_store("cost_comparison", maxsize=200, ttl=3600)
 
 # ── Request / Response Models ────────────────────────────────
 
-class CostServiceInput(BaseModel):
+class CostServiceInput(StrictBaseModel):
     name: str
     type: str
     provider: Optional[str] = None
@@ -35,12 +36,12 @@ class CostServiceInput(BaseModel):
     dependencies: Optional[List[str]] = None
 
 
-class CostZoneInput(BaseModel):
+class CostZoneInput(StrictBaseModel):
     name: str = Field(..., description="Category name (Compute, Storage, etc.)")
     services: List[CostServiceInput]
 
 
-class CostCompareRequest(BaseModel):
+class CostCompareRequest(StrictBaseModel):
     zones: List[CostZoneInput]
 
 

--- a/backend/routers/credentials.py
+++ b/backend/routers/credentials.py
@@ -8,7 +8,8 @@ import logging
 from typing import Optional, Dict, Any
 
 from fastapi import APIRouter, Request, Header, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from services.credential_manager import store_credentials, get_credentials, clear_credentials
 from error_envelope import ArchmorphException
@@ -21,18 +22,18 @@ logger = logging.getLogger(__name__)
 
 # --- Pydantic Models for Input ---
 
-class AWSCredentialsInput(BaseModel):
+class AWSCredentialsInput(StrictBaseModel):
     auth_method: str = Field(..., description="access_key, sso, instance_profile, assume_role")
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
     session_token: Optional[str] = None
     role_arn: Optional[str] = None
 
-class GCPCredentialsInput(BaseModel):
+class GCPCredentialsInput(StrictBaseModel):
     auth_method: str = Field(..., description="service_account_json, oauth2, workload_identity")
     service_account_json: Optional[Dict[str, Any]] = None
 
-class AzureCredentialsInput(BaseModel):
+class AzureCredentialsInput(StrictBaseModel):
     auth_method: str = Field(..., description="service_principal, managed_identity, default")
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
@@ -40,7 +41,7 @@ class AzureCredentialsInput(BaseModel):
     subscription_id: Optional[str] = None
 
 
-class CredentialResponse(BaseModel):
+class CredentialResponse(StrictBaseModel):
     status: str = "ok"
     provider: str
     message: str

--- a/backend/routers/deploy.py
+++ b/backend/routers/deploy.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 
 from routers.auth import get_current_user
 from services.terraform_runner import TerraformRunner
@@ -17,7 +17,7 @@ router = APIRouter(
     tags=["deploy"]
 )
 
-class DeploymentRequest(BaseModel):
+class DeploymentRequest(StrictBaseModel):
     project_id: str
     iac_code: Optional[str] = None
     canvas_state: Optional[dict] = None

--- a/backend/routers/deployments.py
+++ b/backend/routers/deployments.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 
 from services.azure_deploy_service import AzureDeployService
 from feature_flags import feature_flag_dependency
@@ -20,18 +20,18 @@ def get_azure_deploy_service() -> AzureDeployService:
 # ─────────────────────────────────────────────────────────────
 # Pydantic Schemas
 # ─────────────────────────────────────────────────────────────
-class DeploymentPreviewRequest(BaseModel):
+class DeploymentPreviewRequest(StrictBaseModel):
     provider: str
     infrastructure_code: str
     variables: Optional[Dict[str, Any]] = None
 
-class DeploymentExecuteRequest(BaseModel):
+class DeploymentExecuteRequest(StrictBaseModel):
     provider: str
     job_id: Optional[str] = None
     infrastructure_code: str
     variables: Optional[Dict[str, Any]] = None
 
-class DeploymentResponse(BaseModel):
+class DeploymentResponse(StrictBaseModel):
     job_id: str
     status: str
     message: Optional[str] = None

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -12,7 +12,7 @@ Other diagram-related routes have been split into focused modules (#284):
 """
 
 from fastapi import APIRouter, UploadFile, File, Request, Depends
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 from typing import Dict, Any, Optional
 import asyncio
 import base64
@@ -148,7 +148,7 @@ def _normalize_analysis(result: dict) -> dict:
 # ─────────────────────────────────────────────────────────────
 # Models
 # ─────────────────────────────────────────────────────────────
-class RestoreSessionRequest(BaseModel):
+class RestoreSessionRequest(StrictBaseModel):
     """Request body for restoring a cached analysis session."""
     analysis: Dict[str, Any]
     hld: Optional[Dict[str, Any]] = None

--- a/backend/routers/diff_routes.py
+++ b/backend/routers/diff_routes.py
@@ -6,7 +6,8 @@ Version snapshots and diffing for analysis results.
 """
 
 from fastapi import APIRouter, Request, Query
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Optional
 import logging
 
@@ -19,11 +20,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class SaveVersionRequest(BaseModel):
+class SaveVersionRequest(StrictBaseModel):
     label: Optional[str] = Field(None, max_length=200)
 
 
-class BranchRequest(BaseModel):
+class BranchRequest(StrictBaseModel):
     label: Optional[str] = Field(None, max_length=200)
 
 

--- a/backend/routers/drift.py
+++ b/backend/routers/drift.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from error_envelope import ArchmorphException
 
 from services.drift_detection import DriftDetector
@@ -15,23 +16,23 @@ router = APIRouter(prefix="/api/drift", tags=["Drift Detection"])
 
 _BASELINES: Dict[str, Dict[str, Any]] = {}
 
-class DriftRequest(BaseModel):
+class DriftRequest(StrictBaseModel):
     designed_state: Dict[str, Any]
     live_state: Dict[str, Any]
 
 
-class DriftBaselineCreate(BaseModel):
+class DriftBaselineCreate(StrictBaseModel):
     name: str = Field(..., min_length=1, max_length=120)
     designed_state: Dict[str, Any]
     live_state: Optional[Dict[str, Any]] = None
     source: str = Field(default="manual", max_length=40)
 
 
-class DriftCompareRequest(BaseModel):
+class DriftCompareRequest(StrictBaseModel):
     live_state: Dict[str, Any]
 
 
-class DriftFindingDecision(BaseModel):
+class DriftFindingDecision(StrictBaseModel):
     decision: str = Field(..., pattern="^(accepted|rejected|deferred|open)$")
     note: Optional[str] = Field(default=None, max_length=500)
 

--- a/backend/routers/executions.py
+++ b/backend/routers/executions.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+from strict_models import StrictBaseModel
 
 from database import get_db
 from routers.auth import get_current_user
@@ -12,13 +13,13 @@ from fastapi import BackgroundTasks
 
 router = APIRouter(prefix="/api/executions", tags=["Executions"])
 
-class ExecutionInputSchema(BaseModel):
+class ExecutionInputSchema(StrictBaseModel):
     agent_id: str
     messages: List[Dict[str, Any]]
     thread_id: Optional[str] = None
     stream: bool = False
 
-class ExecutionResponseSchema(BaseModel):
+class ExecutionResponseSchema(StrictBaseModel):
     id: str
     agent_id: str
     thread_id: Optional[str] = None

--- a/backend/routers/feature_flags.py
+++ b/backend/routers/feature_flags.py
@@ -8,7 +8,8 @@ PUT  /api/flags/{name}    — update a flag (admin only)
 """
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import List, Optional
 
 from routers.shared import verify_admin_key
@@ -18,7 +19,7 @@ from audit_logging import audit_logger, AuditEventType
 router = APIRouter()
 
 
-class FlagUpdateRequest(BaseModel):
+class FlagUpdateRequest(StrictBaseModel):
     """Request body for updating a feature flag."""
     enabled: Optional[bool] = None
     description: Optional[str] = None

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -3,7 +3,8 @@ Feedback & NPS routes.
 """
 
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Literal, Optional, Dict, Any
 
 from routers.shared import limiter
@@ -16,21 +17,21 @@ router = APIRouter()
 
 
 # Issue #167 — Strict input validation on all feedback models
-class NPSRequest(BaseModel):
+class NPSRequest(StrictBaseModel):
     score: int = Field(..., ge=0, le=10, description="NPS score 0-10")
     follow_up: Optional[str] = Field(None, max_length=2000)
     session_id: Optional[str] = Field(None, max_length=128)
     feature_context: Optional[str] = Field(None, max_length=256)
 
 
-class FeatureFeedbackRequest(BaseModel):
+class FeatureFeedbackRequest(StrictBaseModel):
     feature: str = Field(..., min_length=1, max_length=128, pattern=r"^[\w\-. ]+$")
     helpful: bool
     comment: Optional[str] = Field(None, max_length=2000)
     session_id: Optional[str] = Field(None, max_length=128)
 
 
-class BugReportRequest(BaseModel):
+class BugReportRequest(StrictBaseModel):
     description: str = Field(..., min_length=1, max_length=5000)
     context: Optional[Dict[str, Any]] = None
     severity: Literal["low", "medium", "high", "critical"] = "medium"

--- a/backend/routers/github_integration.py
+++ b/backend/routers/github_integration.py
@@ -3,7 +3,8 @@ API route for pushing generated IaC to GitHub as a Pull Request (#504).
 """
 
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Optional
 
 from iac_pr_push import push_iac_as_pr
@@ -12,7 +13,7 @@ from routers.shared import verify_api_key
 router = APIRouter()
 
 
-class PushIaCRequest(BaseModel):
+class PushIaCRequest(StrictBaseModel):
     repo: str = Field(..., description="GitHub repo in owner/repo format")
     iac_code: str = Field(..., description="Generated IaC code content")
     iac_format: str = Field("terraform", description="terraform, bicep, cloudformation, pulumi, aws-cdk")

--- a/backend/routers/iac_routes.py
+++ b/backend/routers/iac_routes.py
@@ -6,7 +6,8 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 import asyncio
 import logging
 import re
@@ -90,7 +91,7 @@ def _check_architecture_blockers(diagram_id: str, session: dict, force: bool) ->
     )
 
 
-class IaCChatMessage(BaseModel):
+class IaCChatMessage(StrictBaseModel):
     """Request body for IaC chat messages."""
     message: str = Field(..., min_length=1, max_length=5000)
     code: str = Field(default="", max_length=100000)
@@ -255,7 +256,7 @@ async def _run_iac_job(job_id: str, diagram_id: str, iac_format: str) -> None:
 _EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
 
-class NotifyEmailRequest(BaseModel):
+class NotifyEmailRequest(StrictBaseModel):
     """Request body for email notification."""
     email: str = Field(..., min_length=5, max_length=254)
     diagram_name: str = Field(default="", max_length=200)

--- a/backend/routers/infra_import.py
+++ b/backend/routers/infra_import.py
@@ -6,7 +6,8 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 import asyncio
 import logging
 
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class InfraImportRequest(BaseModel):
+class InfraImportRequest(StrictBaseModel):
     """Request body for infrastructure file import."""
     content: str = Field(..., min_length=10, max_length=52_428_800)
     format: str = Field(default="auto", pattern="^(auto|terraform_state|terraform_hcl|cloudformation)$")

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -7,7 +7,8 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Optional, List
 import asyncio
 import csv
@@ -474,14 +475,14 @@ Diagram type: {analysis.get('diagram_type', 'unknown')}"""
 _RI_DISCOUNTS = {"none": 0.0, "1yr": 0.30, "3yr": 0.50}
 
 
-class ServiceCostConfig(BaseModel):
+class ServiceCostConfig(StrictBaseModel):
     service: str
     instance_count: int = Field(1, ge=1, le=1000)
     sku: Optional[str] = None
     reserved_term: str = Field("none", pattern=r"^(none|1yr|3yr)$")
 
 
-class CostConfigureRequest(BaseModel):
+class CostConfigureRequest(StrictBaseModel):
     overrides: List[ServiceCostConfig]
 
 

--- a/backend/routers/integrations_routes.py
+++ b/backend/routers/integrations_routes.py
@@ -18,7 +18,8 @@ from typing import Any, Dict, List, Optional
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+from strict_models import StrictBaseModel
 
 from routers.shared import limiter, verify_api_key
 
@@ -86,7 +87,7 @@ def _validate_https(url: str, field_name: str = "webhook_url") -> None:
 # Pydantic request models
 # ---------------------------------------------------------------------------
 
-class SlackNotifyRequest(BaseModel):
+class SlackNotifyRequest(StrictBaseModel):
     webhook_url: str = Field(..., description="Slack incoming webhook URL (HTTPS)")
     diagram_id: str = Field("unknown", description="Diagram/analysis identifier")
     total_services: int = Field(0, ge=0, description="Number of services detected")
@@ -108,7 +109,7 @@ class SlackNotifyRequest(BaseModel):
     )
 
 
-class TeamsNotifyRequest(BaseModel):
+class TeamsNotifyRequest(StrictBaseModel):
     webhook_url: str = Field(..., description="Teams incoming webhook URL (HTTPS)")
     diagram_id: str = Field("unknown")
     total_services: int = Field(0, ge=0)
@@ -117,7 +118,7 @@ class TeamsNotifyRequest(BaseModel):
     summary: str = Field("", max_length=1000)
 
 
-class JiraCreateRequest(BaseModel):
+class JiraCreateRequest(StrictBaseModel):
     api_url: str = Field(..., description="Jira REST API base URL, e.g. https://myorg.atlassian.net")
     email: str = Field(..., description="Jira user email for basic auth")
     api_token: str = Field(..., description="Jira API token")
@@ -131,7 +132,7 @@ class JiraCreateRequest(BaseModel):
     summary: str = Field("", max_length=2000)
 
 
-class GitHubIssueRequest(BaseModel):
+class GitHubIssueRequest(StrictBaseModel):
     repo: str = Field(..., description="GitHub repo in owner/repo format")
     token: str = Field(..., description="GitHub personal access token")
     title: str = Field("Archmorph Migration Tracking", max_length=256)

--- a/backend/routers/models.py
+++ b/backend/routers/models.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+from strict_models import StrictBaseModel
 
 from database import get_db
 from routers.auth import get_current_user
@@ -10,7 +11,7 @@ from models.model_registry import ModelEndpoint
 
 router = APIRouter(prefix="/api/models", tags=["Model Registry"])
 
-class ModelEndpointCreateSchema(BaseModel):
+class ModelEndpointCreateSchema(StrictBaseModel):
     name: str
     provider: str
     model_version: str
@@ -18,7 +19,7 @@ class ModelEndpointCreateSchema(BaseModel):
     capabilities: Optional[Dict[str, Any]] = {}
     pricing: Optional[Dict[str, float]] = {}
 
-class ModelEndpointResponseSchema(BaseModel):
+class ModelEndpointResponseSchema(StrictBaseModel):
     id: str
     name: str
     provider: str

--- a/backend/routers/network_routes.py
+++ b/backend/routers/network_routes.py
@@ -3,7 +3,8 @@ Network Topology Routes — VPC→VNet translation, CIDR planning, NSG rules, ro
 """
 
 from fastapi import APIRouter, Depends, Query, Request, Response
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 from typing import Any, Dict, Optional
 import logging
 
@@ -31,7 +32,7 @@ _topology_cache: Dict[str, dict] = {}
 # Request / Response Models
 # ─────────────────────────────────────────────────────────────
 
-class NetworkTopologyRequest(BaseModel):
+class NetworkTopologyRequest(StrictBaseModel):
     """Optional overrides for network topology generation."""
     vnet_cidr: str = Field(default=DEFAULT_VNET_CIDR, description="VNet address space CIDR")
     subnet_prefix: int = Field(default=DEFAULT_SUBNET_PREFIX, ge=16, le=29, description="Subnet prefix length")

--- a/backend/routers/policies.py
+++ b/backend/routers/policies.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+from strict_models import StrictBaseModel
 
 from database import get_db
 from routers.auth import get_current_user
@@ -9,14 +10,14 @@ from models.policy import AgentPolicy, AgentPolicyBinding
 
 router = APIRouter(prefix="/api/policies", tags=["Policies"])
 
-class PolicyCreateSchema(BaseModel):
+class PolicyCreateSchema(StrictBaseModel):
     name: str
     description: Optional[str] = None
     policy_type: str
     rules: Dict[str, Any]
     enforcement_level: str = "block"
 
-class PolicyResponseSchema(BaseModel):
+class PolicyResponseSchema(StrictBaseModel):
     id: str
     name: str
     description: Optional[str]

--- a/backend/routers/rag_routes.py
+++ b/backend/routers/rag_routes.py
@@ -13,7 +13,8 @@ import os
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from error_envelope import ArchmorphException
 from routers.shared import limiter, verify_api_key
@@ -30,19 +31,19 @@ MAX_UPLOAD_SIZE = int(os.getenv("RAG_MAX_UPLOAD_BYTES", str(20 * 1024 * 1024)))
 # ─────────────────────────────────────────────────────────────
 # Request / Response Models
 # ─────────────────────────────────────────────────────────────
-class CreateCollectionRequest(BaseModel):
+class CreateCollectionRequest(StrictBaseModel):
     name: str = Field(..., min_length=1, max_length=200)
     description: str = Field(default="", max_length=2000)
 
 
-class CollectionResponse(BaseModel):
+class CollectionResponse(StrictBaseModel):
     collection_id: str
     name: str
     description: str
     created_at: str
 
 
-class DocumentResponse(BaseModel):
+class DocumentResponse(StrictBaseModel):
     document_id: str
     filename: str
     file_size: int
@@ -52,7 +53,7 @@ class DocumentResponse(BaseModel):
     mime_type: str = ""
 
 
-class IngestResponse(BaseModel):
+class IngestResponse(StrictBaseModel):
     document_id: str
     filename: str
     status: str
@@ -62,7 +63,7 @@ class IngestResponse(BaseModel):
     message: str = ""
 
 
-class SearchRequest(BaseModel):
+class SearchRequest(StrictBaseModel):
     query: str = Field(..., min_length=1, max_length=5000)
     collection_ids: Optional[List[str]] = Field(default=None)
     top_k: int = Field(default=5, ge=1, le=50)
@@ -70,7 +71,7 @@ class SearchRequest(BaseModel):
     metadata_filter: Optional[Dict[str, str]] = Field(default=None)
 
 
-class SearchResultItem(BaseModel):
+class SearchResultItem(StrictBaseModel):
     text: str
     score: float
     vector_score: float
@@ -83,13 +84,13 @@ class SearchResultItem(BaseModel):
     collection_name: str
 
 
-class SearchResponse(BaseModel):
+class SearchResponse(StrictBaseModel):
     results: List[SearchResultItem]
     query: str
     total_results: int
 
 
-class CollectionStats(BaseModel):
+class CollectionStats(StrictBaseModel):
     collection_id: str
     name: str
     description: str

--- a/backend/routers/replay_routes.py
+++ b/backend/routers/replay_routes.py
@@ -12,7 +12,8 @@ import uuid
 from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from error_envelope import ArchmorphException
 from log_sanitizer import safe
@@ -37,12 +38,12 @@ EventType = Literal[
 ]
 
 
-class StartRecordingRequest(BaseModel):
+class StartRecordingRequest(StrictBaseModel):
     analysis_id: str = Field(..., min_length=1, max_length=128)
     title: Optional[str] = Field(None, max_length=256)
 
 
-class AddEventRequest(BaseModel):
+class AddEventRequest(StrictBaseModel):
     replay_id: str = Field(..., min_length=1, max_length=128)
     event_type: EventType
     data: dict = Field(default_factory=dict)

--- a/backend/routers/roadmap.py
+++ b/backend/routers/roadmap.py
@@ -4,7 +4,8 @@ Roadmap — Version Timeline & Feature Requests.
 """
 
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import Field, EmailStr
+from strict_models import StrictBaseModel
 from typing import Optional
 import asyncio
 
@@ -36,7 +37,7 @@ async def roadmap_release(version: str):
     return release
 
 
-class FeatureRequestPayload(BaseModel):
+class FeatureRequestPayload(StrictBaseModel):
     """Feature request submission."""
     title: str = Field(..., min_length=5, max_length=200, description="Feature title")
     description: str = Field(..., min_length=20, max_length=2000, description="Detailed description")
@@ -65,7 +66,7 @@ async def roadmap_feature_request(request: Request, payload: FeatureRequestPaylo
     return result
 
 
-class BugReportPayload(BaseModel):
+class BugReportPayload(StrictBaseModel):
     """Bug report submission."""
     title: str = Field(..., min_length=5, max_length=200, description="Bug title")
     description: str = Field(..., min_length=20, max_length=2000, description="Bug description")

--- a/backend/routers/shared.py
+++ b/backend/routers/shared.py
@@ -11,7 +11,7 @@ from typing import Optional, List
 
 from fastapi import Security
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -147,13 +147,13 @@ async def get_session_lock(session_id: str) -> asyncio.Lock:
 # ─────────────────────────────────────────────────────────────
 # General Pydantic Models
 # ─────────────────────────────────────────────────────────────
-class Project(BaseModel):
+class Project(StrictBaseModel):
     id: Optional[str] = None
     name: str
     description: Optional[str] = None
 
 
-class ServiceMapping(BaseModel):
+class ServiceMapping(StrictBaseModel):
     source_service: str
     source_provider: str
     azure_service: str
@@ -161,7 +161,7 @@ class ServiceMapping(BaseModel):
     notes: Optional[str] = None
 
 
-class AnalysisResult(BaseModel):
+class AnalysisResult(StrictBaseModel):
     diagram_id: str
     services_detected: int
     mappings: List[ServiceMapping]

--- a/backend/routers/sku_routes.py
+++ b/backend/routers/sku_routes.py
@@ -90,10 +90,10 @@ async def translate_sku(
 # ─────────────────────────────────────────────────────────────
 # POST /api/sku/translate/batch — Batch SKU translation
 # ─────────────────────────────────────────────────────────────
-from pydantic import BaseModel
+from strict_models import StrictBaseModel
 
 
-class BatchSKURequest(BaseModel):
+class BatchSKURequest(StrictBaseModel):
     """Batch translation request body."""
     skus: List[str]
     provider: str = "aws"

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -6,7 +6,8 @@ Split from diagrams.py for maintainability (#284).
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field, field_validator
+from strict_models import StrictBaseModel
 from typing import Optional
 import asyncio
 import logging
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-class SourceProviderRequest(BaseModel):
+class SourceProviderRequest(StrictBaseModel):
     source_provider: str = Field("aws", pattern="^(aws|gcp)$")
 
     @field_validator("source_provider", mode="before")
@@ -50,7 +51,7 @@ class SuggestBatchRequest(SourceProviderRequest):
     services: list = Field(..., min_length=1, max_length=50)
 
 
-class ReviewRequest(BaseModel):
+class ReviewRequest(StrictBaseModel):
     """Request body for reviewing an AI mapping suggestion."""
     decision: str = Field(..., pattern="^(approved|rejected)$")
     reviewer: str = Field(..., min_length=1)

--- a/backend/routers/terraform.py
+++ b/backend/routers/terraform.py
@@ -5,7 +5,8 @@ Issue #123 — Auth + rate limiting added.
 """
 
 from fastapi import APIRouter, Request, Depends
-from pydantic import BaseModel, Field
+from pydantic import Field
+from strict_models import StrictBaseModel
 
 from terraform_preview import validate_terraform_syntax
 from routers.shared import limiter, verify_api_key
@@ -13,7 +14,7 @@ from routers.shared import limiter, verify_api_key
 router = APIRouter()
 
 
-class TerraformValidateRequest(BaseModel):
+class TerraformValidateRequest(StrictBaseModel):
     code: str = Field(..., max_length=100_000)  # Cap input to 100 KB
 
 

--- a/backend/routers/webhook_routes.py
+++ b/backend/routers/webhook_routes.py
@@ -11,7 +11,8 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+from strict_models import StrictBaseModel
 
 from routers.shared import limiter, verify_api_key
 from webhooks import (
@@ -33,7 +34,7 @@ router = APIRouter(tags=["Webhooks"])
 # Pydantic models
 # ---------------------------------------------------------------------------
 
-class CreateWebhookRequest(BaseModel):
+class CreateWebhookRequest(StrictBaseModel):
     url: str = Field(..., description="HTTPS endpoint to receive webhook POSTs")
     events: List[str] = Field(..., min_length=1, description="Event types to subscribe to")
     description: str = Field("", max_length=256, description="Human-readable description")
@@ -50,20 +51,20 @@ class CreateWebhookRequest(BaseModel):
     )
 
 
-class UpdateWebhookRequest(BaseModel):
+class UpdateWebhookRequest(StrictBaseModel):
     url: Optional[str] = Field(None, description="New endpoint URL")
     events: Optional[List[str]] = Field(None, description="Updated event list")
     active: Optional[bool] = Field(None, description="Enable/disable delivery")
     description: Optional[str] = Field(None, max_length=256)
 
 
-class TestWebhookRequest(BaseModel):
+class TestWebhookRequest(StrictBaseModel):
     url: str = Field(..., description="URL to send the test event to")
     secret: str = Field("test-secret", description="HMAC secret for signature")
     event_type: str = Field("analysis.completed", description="Event type to simulate")
 
 
-class WebhookInfo(BaseModel):
+class WebhookInfo(StrictBaseModel):
     id: str
     url: str
     secret: str  # masked

--- a/backend/strict_models.py
+++ b/backend/strict_models.py
@@ -1,0 +1,15 @@
+"""Strict Pydantic base classes for API boundary schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StrictBaseModel(BaseModel):
+    """Base model for user-facing API schemas.
+
+    Unknown fields are rejected instead of silently dropped to harden API
+    boundaries against over-posting and mass-assignment mistakes.
+    """
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/tests/test_pydantic_extra_policy.py
+++ b/backend/tests/test_pydantic_extra_policy.py
@@ -21,7 +21,7 @@ class _ModelVisitor(ast.NodeVisitor):
             if extra_policy not in {"allow", "forbid"}:
                 self.violations.append(
                     f"line {node.lineno}: {node.name} directly inherits BaseModel "
-                    "without explicit extra='forbid' or justified extra='allow'"
+                    "without explicit extra='forbid' or extra='allow'"
                 )
         self.generic_visit(node)
 

--- a/backend/tests/test_pydantic_extra_policy.py
+++ b/backend/tests/test_pydantic_extra_policy.py
@@ -1,0 +1,105 @@
+"""Regression coverage for strict API-boundary Pydantic models (#614)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+AUDIT_ROOTS = (BACKEND_ROOT / "routers", BACKEND_ROOT / "services")
+
+
+class _ModelVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        base_names = {_base_name(base) for base in node.bases}
+        if "BaseModel" in base_names:
+            extra_policy = _class_extra_policy(node)
+            if extra_policy not in {"allow", "forbid"}:
+                self.violations.append(
+                    f"line {node.lineno}: {node.name} directly inherits BaseModel "
+                    "without explicit extra='forbid' or justified extra='allow'"
+                )
+        self.generic_visit(node)
+
+
+def _base_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Subscript):
+        return _base_name(node.value)
+    return ""
+
+
+def _class_extra_policy(node: ast.ClassDef) -> str | None:
+    for statement in node.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "model_config" for target in statement.targets):
+            continue
+        return _config_extra_value(statement.value)
+    return None
+
+
+def _config_extra_value(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Call) and _base_name(node.func) == "ConfigDict":
+        for keyword in node.keywords:
+            if keyword.arg == "extra" and isinstance(keyword.value, ast.Constant):
+                return str(keyword.value.value)
+    return None
+
+
+def _audited_python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in AUDIT_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if "_archive" in path.parts or "__pycache__" in path.parts:
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _contains_extra_forbidden(value: object) -> bool:
+    if isinstance(value, dict):
+        if value.get("type") == "extra_forbidden":
+            return True
+        return any(_contains_extra_forbidden(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_extra_forbidden(item) for item in value)
+    return False
+
+
+def test_router_and_service_models_use_strict_base_or_explicit_extra_policy():
+    violations: list[str] = []
+    for path in _audited_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _ModelVisitor()
+        visitor.visit(tree)
+        violations.extend(
+            f"{path.relative_to(BACKEND_ROOT)}:{violation}"
+            for violation in visitor.violations
+        )
+
+    assert not violations, "\n".join(violations)
+
+
+def test_create_webhook_rejects_unknown_request_fields(test_client):
+    response = test_client.post(
+        "/api/webhooks",
+        json={
+            "url": "https://example.com/webhook",
+            "events": ["analysis.completed"],
+            "description": "strict boundary check",
+            "unexpected_admin": True,
+        },
+    )
+
+    assert response.status_code == 422
+    assert _contains_extra_forbidden(response.json())


### PR DESCRIPTION
## Summary
- add a shared StrictBaseModel with extra='forbid' for API boundary schemas
- migrate user-facing router Pydantic models to inherit the strict base while preserving existing model_config overrides
- add an AST audit plus webhook over-posting regression coverage

Closes #614

## Tests
- backend/.venv/bin/python -m pytest tests/test_pydantic_extra_policy.py -q
- backend/.venv/bin/python -m pytest tests/test_pydantic_extra_policy.py tests/test_api.py tests/test_api_versioning.py tests/test_middleware_and_routers.py tests/test_webhooks.py -q
- backend/.venv/bin/python -m pytest -q