### PR TITLE
fix(security): block private webhook targets

### DIFF
--- a/backend/routers/webhook_routes.py
+++ b/backend/routers/webhook_routes.py
@@ -23,6 +23,7 @@ from webhooks import (
     update_webhook,
     delete_webhook,
     get_delivery_logs,
+    validate_webhook_target_url_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -88,8 +89,10 @@ class WebhookInfo(StrictBaseModel):
 )
 @limiter.limit("10/minute")
 async def create_webhook(body: CreateWebhookRequest, request: Request, _auth=Depends(verify_api_key)):
-    if not body.url.startswith("https://"):
-        raise ArchmorphException(400, "Webhook URL must use HTTPS")
+    try:
+        await validate_webhook_target_url_async(body.url, resolve=True)
+    except ValueError as exc:
+        raise ArchmorphException(400, str(exc))
 
     # Validate event types against known list
     invalid = [e for e in body.events if e not in ALL_EVENT_TYPES]
@@ -136,8 +139,11 @@ async def update_webhook_route(
     if not wh:
         raise ArchmorphException(404, f"Webhook not found: {webhook_id}")
 
-    if body.url and not body.url.startswith("https://"):
-        raise ArchmorphException(400, "Webhook URL must use HTTPS")
+    if body.url:
+        try:
+            await validate_webhook_target_url_async(body.url, resolve=True)
+        except ValueError as exc:
+            raise ArchmorphException(400, str(exc))
 
     if body.events:
         invalid = [e for e in body.events if e not in ALL_EVENT_TYPES]
@@ -208,8 +214,10 @@ async def test_webhook(body: TestWebhookRequest, request: Request, _auth=Depends
     import uuid as _uuid
     from datetime import datetime as _dt, timezone as _tz
 
-    if not body.url.startswith("https://"):
-        raise ArchmorphException(400, "Test URL must use HTTPS")
+    try:
+        await validate_webhook_target_url_async(body.url, resolve=True)
+    except ValueError as exc:
+        raise ArchmorphException(400, str(exc))
 
     delivery_id = f"test-{_uuid.uuid4().hex[:12]}"
     envelope = {

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for webhooks.py and routers/webhooks.py — Sprint 9 #175."""
 import asyncio
+import socket
 import pytest
 from unittest.mock import patch
 
@@ -19,6 +20,8 @@ from webhooks import (
     emit_event,
     compute_signature,
     verify_signature,
+    validate_webhook_target_url,
+    _deliver_payload,
     clear_all,
     ALL_EVENT_TYPES,
     INTEGRATION_REQUIREMENTS,
@@ -26,8 +29,9 @@ from webhooks import (
 
 
 @pytest.fixture(autouse=True)
-def reset_state():
+def reset_state(monkeypatch):
     """Clear all webhook state between tests."""
+    monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8"]))
     clear_all()
     yield
     clear_all()
@@ -136,6 +140,140 @@ class TestWebhookCRUD:
 
 
 # ---------------------------------------------------------------------------
+# SSRF protection
+# ---------------------------------------------------------------------------
+
+def _mock_getaddrinfo(addresses):
+    def _resolver(hostname, port, *args, **kwargs):
+        return [
+            (
+                socket.AF_INET6 if ":" in address else socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                (address, port, 0, 0) if ":" in address else (address, port),
+            )
+            for address in addresses
+        ]
+
+    return _resolver
+
+
+class TestWebhookSSRFProtection:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com/hook",
+            "https://127.0.0.1/hook",
+            "https://10.0.0.5/hook",
+            "https://172.16.0.10/hook",
+            "https://192.168.1.10/hook",
+            "https://169.254.169.254/latest/meta-data",
+            "https://[::1]/hook",
+            "https://[fc00::1]/hook",
+            "https://localhost/hook",
+            "https://user:pass@example.com/hook",
+            "https://example.com:bad/hook",
+            "https://example.com:0/hook",
+        ],
+    )
+    def test_register_rejects_unsafe_literal_targets(self, url):
+        with pytest.raises(ValueError):
+            register_webhook(url=url, events=["analysis.completed"])
+
+    def test_validation_rejects_hostname_resolving_to_private_ip(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            validate_webhook_target_url("https://customer.example/hook", resolve=True)
+
+    def test_validation_rejects_mixed_public_and_private_dns_answers(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8", "10.0.0.5"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            validate_webhook_target_url("https://customer.example/hook", resolve=True)
+
+    def test_validation_rejects_scoped_ipv6_dns_answer(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["fe80::1%eth0"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            validate_webhook_target_url("https://customer.example/hook", resolve=True)
+
+    def test_register_rejects_hostname_resolving_to_private_ip(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            register_webhook(url="https://customer.example/hook", events=["analysis.completed"])
+
+    def test_update_rejects_hostname_resolving_to_private_ip(self, monkeypatch):
+        wh = register_webhook(url="https://example.com/hook", events=["analysis.completed"])
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            update_webhook(wh.id, url="https://customer.example/hook")
+
+    def test_delivery_blocks_private_dns_before_http_client_opens(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        with patch("webhooks.asyncio.open_connection") as mock_open_connection:
+            result = asyncio.run(
+                _deliver_payload(
+                    "https://customer.example/hook",
+                    b"{}",
+                    "sig",
+                    "analysis.completed",
+                    "dlv-test",
+                )
+            )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "non-public IP" in result.error
+        mock_open_connection.assert_not_called()
+
+    def test_create_route_rejects_hostname_resolving_to_private_ip(self, test_client, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        response = test_client.post(
+            "/api/webhooks",
+            json={
+                "url": "https://customer.example/hook",
+                "events": ["analysis.completed"],
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_test_route_rejects_hostname_resolving_to_private_ip(self, test_client, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        response = test_client.post(
+            "/api/webhooks/test",
+            json={"url": "https://customer.example/hook"},
+        )
+
+        assert response.status_code == 400
+
+    def test_slack_integration_rejects_unsafe_webhook_url(self):
+        with pytest.raises(ValueError):
+            register_integration(
+                integration_type="slack",
+                name="Internal Slack",
+                config={"webhook_url": "https://127.0.0.1/hook"},
+            )
+
+    def test_slack_integration_rejects_private_dns_answer(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["10.0.0.5"]))
+
+        with pytest.raises(ValueError, match="non-public IP"):
+            register_integration(
+                integration_type="slack",
+                name="Internal Slack",
+                config={"webhook_url": "https://customer.example/hook"},
+            )
+
+
+# ---------------------------------------------------------------------------
 # Dispatch & Delivery
 # ---------------------------------------------------------------------------
 
@@ -179,7 +317,9 @@ class TestDispatch:
 # ---------------------------------------------------------------------------
 
 class TestIntegrations:
-    def test_register_slack_integration(self):
+    def test_register_slack_integration(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8"]))
+
         integ = register_integration(
             integration_type="slack",
             name="My Slack",
@@ -189,7 +329,9 @@ class TestIntegrations:
         assert integ.name == "My Slack"
         assert integ.enabled is True
 
-    def test_register_teams_integration(self):
+    def test_register_teams_integration(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8"]))
+
         integ = register_integration(
             integration_type="teams",
             name="My Teams",
@@ -205,13 +347,17 @@ class TestIntegrations:
         with pytest.raises((ValueError, KeyError)):
             register_integration(integration_type="slack", name="Bad", config={})
 
-    def test_list_integrations(self):
+    def test_list_integrations(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8"]))
+
         register_integration("slack", "S1", {"webhook_url": "https://a.com"})
         register_integration("teams", "T1", {"webhook_url": "https://b.com"})
         result = list_integrations()
         assert len(result) == 2
 
-    def test_delete_integration(self):
+    def test_delete_integration(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo(["8.8.8.8"]))
+
         integ = register_integration("slack", "S1", {"webhook_url": "https://a.com"})
         assert delete_integration(integ.id) is True
         assert get_integration(integ.id) is None

--- a/backend/webhooks.py
+++ b/backend/webhooks.py
@@ -6,10 +6,14 @@ delivery logging, and built-in integrations (Slack, Teams, Azure DevOps).
 """
 
 import asyncio
+import concurrent.futures
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
+import socket
+import ssl
 import threading
 import time
 import uuid
@@ -18,6 +22,7 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -120,6 +125,299 @@ _delivery_logs: deque = deque(maxlen=_MAX_LOGS)
 MAX_RETRIES = 3
 RETRY_BACKOFF_BASE = 2  # seconds — exponential: 2, 4, 8
 DELIVERY_TIMEOUT = 10  # seconds
+DNS_RESOLUTION_TIMEOUT = 3  # seconds
+
+
+def _contains_control_characters(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
+
+
+def _reject_control_characters(*values: str) -> None:
+    if any(_contains_control_characters(value) for value in values):
+        raise WebhookTargetError("Webhook URL must not include control characters")
+
+
+class WebhookTargetError(ValueError):
+    """Raised when a webhook URL targets an unsafe outbound destination."""
+
+
+@dataclass(frozen=True)
+class WebhookTarget:
+    hostname: str
+    port: int
+    path: str
+    needs_resolution: bool
+    literal_address: Optional[str] = None
+
+
+def _normalize_ip_address(address: str) -> Optional[str]:
+    candidate = address.split("%", 1)[0]
+    try:
+        ip = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+        ip = ip.ipv4_mapped
+    return str(ip)
+
+
+def _is_forbidden_ip(address: str) -> bool:
+    normalized = _normalize_ip_address(address)
+    if normalized is None:
+        return True
+    return not ipaddress.ip_address(normalized).is_global
+
+
+def _addresses_from_addr_info(addr_info: list) -> List[str]:
+    addresses: List[str] = []
+    for entry in addr_info:
+        sockaddr = entry[4]
+        if not sockaddr:
+            continue
+        address = sockaddr[0]
+        if address not in addresses:
+            addresses.append(address)
+
+    if not addresses:
+        raise WebhookTargetError("Webhook target host could not be resolved")
+    return addresses
+
+
+def _resolve_host_addresses(hostname: str, port: int) -> List[str]:
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="webhook-dns")
+    future = executor.submit(socket.getaddrinfo, hostname, port, type=socket.SOCK_STREAM)
+    try:
+        addr_info = future.result(timeout=DNS_RESOLUTION_TIMEOUT)
+    except socket.gaierror as exc:
+        raise WebhookTargetError("Webhook target host could not be resolved") from exc
+    except concurrent.futures.TimeoutError as exc:
+        future.cancel()
+        raise WebhookTargetError("Webhook target DNS lookup timed out") from exc
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return _addresses_from_addr_info(addr_info)
+
+
+async def _resolve_host_addresses_async(hostname: str, port: int) -> List[str]:
+    try:
+        addr_info = await asyncio.wait_for(
+            asyncio.get_running_loop().getaddrinfo(
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+            ),
+            timeout=DNS_RESOLUTION_TIMEOUT,
+        )
+    except socket.gaierror as exc:
+        raise WebhookTargetError("Webhook target host could not be resolved") from exc
+    except asyncio.TimeoutError as exc:
+        raise WebhookTargetError("Webhook target DNS lookup timed out") from exc
+    return _addresses_from_addr_info(addr_info)
+
+
+def _parse_webhook_target(url: str) -> WebhookTarget:
+    _reject_control_characters(url)
+    parsed = urlsplit(url)
+    _reject_control_characters(parsed.scheme, parsed.netloc, parsed.path, parsed.query)
+    if parsed.scheme.lower() != "https":
+        raise WebhookTargetError("Webhook URL must use HTTPS")
+    if not parsed.hostname:
+        raise WebhookTargetError("Webhook URL must include a host")
+    if parsed.username or parsed.password:
+        raise WebhookTargetError("Webhook URL must not include credentials")
+    try:
+        parsed_port = parsed.port
+    except ValueError as exc:
+        raise WebhookTargetError("Webhook URL port is invalid") from exc
+    port = 443 if parsed_port is None else parsed_port
+    if port < 1 or port > 65535:
+        raise WebhookTargetError("Webhook URL port is invalid")
+
+    hostname = parsed.hostname.rstrip(".").lower()
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise WebhookTargetError("Webhook target host is not allowed")
+
+    literal_address: Optional[str] = None
+    try:
+        host_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        literal_address = str(host_ip.ipv4_mapped if isinstance(host_ip, ipaddress.IPv6Address) and host_ip.ipv4_mapped else host_ip)
+        if _is_forbidden_ip(literal_address):
+            raise WebhookTargetError("Webhook target host is not allowed")
+        return WebhookTarget(hostname=hostname, port=port, path=path, needs_resolution=False, literal_address=literal_address)
+
+    return WebhookTarget(hostname=hostname, port=port, path=path, needs_resolution=True)
+
+
+def _reject_forbidden_addresses(addresses: List[str]) -> None:
+    if any(_is_forbidden_ip(address) for address in addresses):
+        raise WebhookTargetError("Webhook target host resolves to a non-public IP address")
+
+
+def validate_webhook_target_url(url: str, *, resolve: bool = False) -> None:
+    """Validate that a webhook URL is HTTPS and does not target private networks."""
+    target = _parse_webhook_target(url)
+
+    if not resolve or not target.needs_resolution:
+        return
+
+    addresses = _resolve_host_addresses(target.hostname, target.port)
+    _reject_forbidden_addresses(addresses)
+
+
+async def validate_webhook_target_url_async(url: str, *, resolve: bool = False) -> None:
+    """Async variant of webhook URL validation for request and delivery paths."""
+    target = _parse_webhook_target(url)
+
+    if not resolve or not target.needs_resolution:
+        return
+
+    addresses = await _resolve_host_addresses_async(target.hostname, target.port)
+    _reject_forbidden_addresses(addresses)
+
+
+def _validated_target_addresses(target: WebhookTarget, addresses: List[str]) -> List[str]:
+    if target.literal_address:
+        return [target.literal_address]
+    _reject_forbidden_addresses(addresses)
+    return [_normalize_ip_address(address) or address for address in addresses]
+
+
+async def _resolve_target_addresses_async(target: WebhookTarget) -> List[str]:
+    if not target.needs_resolution:
+        return _validated_target_addresses(target, [])
+    return _validated_target_addresses(
+        target,
+        await _resolve_host_addresses_async(target.hostname, target.port),
+    )
+
+
+def _resolve_target_addresses(target: WebhookTarget) -> List[str]:
+    if not target.needs_resolution:
+        return _validated_target_addresses(target, [])
+    return _validated_target_addresses(target, _resolve_host_addresses(target.hostname, target.port))
+
+
+def _host_header(target: WebhookTarget) -> str:
+    host = target.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if target.port != 443:
+        return f"{host}:{target.port}"
+    return host
+
+
+def _format_http_headers(headers: Dict[str, str]) -> str:
+    lines: List[str] = []
+    for key, value in headers.items():
+        if _contains_control_characters(key) or _contains_control_characters(str(value)):
+            raise WebhookTargetError("Webhook request headers must not include control characters")
+        lines.append(f"{key}: {value}")
+    return "\r\n".join(lines)
+
+
+def _http_response_status(response_head: bytes) -> int:
+    status_line = response_head.split(b"\r\n", 1)[0].decode("ascii", errors="replace")
+    parts = status_line.split(" ", 2)
+    if len(parts) < 2 or not parts[1].isdigit():
+        raise WebhookTargetError("Webhook target returned an invalid HTTP response")
+    return int(parts[1])
+
+
+def _webhook_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
+async def _post_https_pinned_async(
+    url: str,
+    *,
+    content: bytes,
+    headers: Dict[str, str],
+    timeout: float,
+) -> int:
+    target = _parse_webhook_target(url)
+    addresses = await _resolve_target_addresses_async(target)
+    ssl_context = _webhook_ssl_context()
+    request_headers = {
+        **headers,
+        "Host": _host_header(target),
+        "Content-Length": str(len(content)),
+        "Connection": "close",
+    }
+    request = (
+        f"POST {target.path} HTTP/1.1\r\n"
+        + _format_http_headers(request_headers)
+        + "\r\n\r\n"
+    ).encode("utf-8") + content
+
+    last_error: Optional[Exception] = None
+    for address in addresses:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(
+                    address,
+                    target.port,
+                    ssl=ssl_context,
+                    server_hostname=target.hostname,
+                ),
+                timeout=timeout,
+            )
+            try:
+                writer.write(request)
+                await asyncio.wait_for(writer.drain(), timeout=timeout)
+                response_head = await asyncio.wait_for(reader.read(1024), timeout=timeout)
+                return _http_response_status(response_head)
+            finally:
+                writer.close()
+                await writer.wait_closed()
+        except Exception as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    raise WebhookTargetError("Webhook target host could not be resolved")
+
+
+def _post_https_pinned_json(url: str, *, payload: Dict[str, Any], timeout: float) -> int:
+    target = _parse_webhook_target(url)
+    addresses = _resolve_target_addresses(target)
+    body = json.dumps(payload, default=str).encode("utf-8")
+    ssl_context = _webhook_ssl_context()
+    request_headers = {
+        "Host": _host_header(target),
+        "Content-Type": "application/json",
+        "Content-Length": str(len(body)),
+        "User-Agent": "Archmorph-Webhooks/1.0",
+        "Connection": "close",
+    }
+    request = (
+        f"POST {target.path} HTTP/1.1\r\n"
+        + _format_http_headers(request_headers)
+        + "\r\n\r\n"
+    ).encode("utf-8") + body
+
+    last_error: Optional[Exception] = None
+    for address in addresses:
+        try:
+            with socket.create_connection((address, target.port), timeout=timeout) as sock:
+                with ssl_context.wrap_socket(sock, server_hostname=target.hostname) as tls_sock:
+                    tls_sock.settimeout(timeout)
+                    tls_sock.sendall(request)
+                    return _http_response_status(tls_sock.recv(1024))
+        except Exception as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    raise WebhookTargetError("Webhook target host could not be resolved")
 
 
 def register_webhook(
@@ -130,8 +428,7 @@ def register_webhook(
     description: str = "",
 ) -> WebhookRegistration:
     """Register a new webhook endpoint."""
-    if not url or not url.startswith(("http://", "https://")):
-        raise ValueError("Webhook URL must start with http:// or https://")
+    validate_webhook_target_url(url, resolve=True)
 
     # Validate event types
     invalid = [e for e in events if e not in ALL_EVENT_TYPES]
@@ -203,6 +500,7 @@ def update_webhook(
         if not wh:
             return None
         if url is not None:
+            validate_webhook_target_url(url, resolve=True)
             wh.url = url
         if events is not None:
             invalid = [e for e in events if e not in ALL_EVENT_TYPES]
@@ -230,25 +528,24 @@ async def _deliver_payload(
     """Attempt a single HTTP POST delivery (async)."""
     start = time.monotonic()
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                content=payload_bytes,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Archmorph-Signature": f"sha256={signature}",
-                    "X-Archmorph-Event": event_type,
-                    "X-Archmorph-Delivery": delivery_id,
-                    "User-Agent": "Archmorph-Webhooks/1.0",
-                },
-                timeout=DELIVERY_TIMEOUT,
-            )
+        status_code = await _post_https_pinned_async(
+            url,
+            content=payload_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Archmorph-Signature": f"sha256={signature}",
+                "X-Archmorph-Event": event_type,
+                "X-Archmorph-Delivery": delivery_id,
+                "User-Agent": "Archmorph-Webhooks/1.0",
+            },
+            timeout=DELIVERY_TIMEOUT,
+        )
         latency = (time.monotonic() - start) * 1000
-        success = 200 <= resp.status_code < 300
+        success = 200 <= status_code < 300
         return DeliveryAttempt(
             attempt=0,
             timestamp=datetime.now(timezone.utc).isoformat(),
-            status_code=resp.status_code,
+            status_code=status_code,
             latency_ms=round(latency, 2),
             success=success,
         )
@@ -437,6 +734,9 @@ def register_integration(
     if missing:
         raise ValueError(f"Missing required config fields: {missing}")
 
+    if integration_type in {IntegrationType.SLACK, IntegrationType.TEAMS}:
+        validate_webhook_target_url(config["webhook_url"], resolve=True)
+
     integration = IntegrationConfig(
         id=f"int-{uuid.uuid4().hex[:12]}",
         type=integration_type,
@@ -594,23 +894,23 @@ def send_to_integration(
     try:
         if integration.type == IntegrationType.SLACK:
             payload = _format_slack_message(event_type, data)
-            resp = httpx.post(
+            status_code = _post_https_pinned_json(
                 integration.config["webhook_url"],
-                json=payload,
+                payload=payload,
                 timeout=10,
             )
-            result["status_code"] = resp.status_code
-            result["success"] = 200 <= resp.status_code < 300
+            result["status_code"] = status_code
+            result["success"] = 200 <= status_code < 300
 
         elif integration.type == IntegrationType.TEAMS:
             payload = _format_teams_card(event_type, data)
-            resp = httpx.post(
+            status_code = _post_https_pinned_json(
                 integration.config["webhook_url"],
-                json=payload,
+                payload=payload,
                 timeout=10,
             )
-            result["status_code"] = resp.status_code
-            result["success"] = 200 <= resp.status_code < 300
+            result["status_code"] = status_code
+            result["success"] = 200 <= status_code < 300
 
         elif integration.type == IntegrationType.AZURE_DEVOPS:
             org = integration.config["organization"]


### PR DESCRIPTION
## Summary
- add centralized webhook target validation for HTTPS-only public destinations
- reject literal localhost/private/link-local/reserved IP targets and DNS answers resolving to non-public IPs
- validate create/update/test webhook routes and Slack/Teams integration webhook URLs
- disable delivery redirects so public webhook targets cannot bounce delivery into private networks

Closes #611

## Tests
- backend/.venv/bin/python -m pytest tests/test_webhooks.py -q
- backend/.venv/bin/python -m pytest tests/test_webhooks.py tests/test_api.py tests/test_middleware_and_routers.py -q
- backend/.venv/bin/python -m pytest -q