### PR TITLE
perf: add Landing Zone performance SLO soak

### DIFF
--- a/.github/workflows/perf-soak.yml
+++ b/.github/workflows/perf-soak.yml
@@ -1,0 +1,92 @@
+name: Landing Zone Perf Soak
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Staging base URL override"
+        required: false
+        type: string
+      target_rps:
+        description: "Target RPS"
+        required: false
+        default: "100"
+        type: string
+      run_time:
+        description: "Locust run time"
+        required: false
+        default: "5m"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  landing-zone-soak:
+    name: landing-zone-soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DEFAULT_TARGET_RPS: "100"
+      DEFAULT_RUN_TIME: "5m"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve soak configuration
+        id: config
+        env:
+          INPUT_BASE_URL: ${{ inputs.base_url }}
+          VAR_BASE_URL: ${{ vars.PERF_SOAK_BASE_URL }}
+          SECRET_BASE_URL: ${{ secrets.PERF_SOAK_BASE_URL }}
+          RATE_LIMIT_PROFILE: ${{ vars.PERF_SOAK_RATE_LIMIT_PROFILE }}
+          INPUT_TARGET_RPS: ${{ inputs.target_rps }}
+          INPUT_RUN_TIME: ${{ inputs.run_time }}
+        run: |
+          base_url="${INPUT_BASE_URL:-${VAR_BASE_URL:-$SECRET_BASE_URL}}"
+          if [ -z "$base_url" ]; then
+            echo "PERF_SOAK_BASE_URL must be configured as a variable, secret, or workflow_dispatch input" >&2
+            exit 1
+          fi
+          if [ "$RATE_LIMIT_PROFILE" != "soak" ]; then
+            echo "PERF_SOAK_RATE_LIMIT_PROFILE=soak is required; target staging must disable or raise per-IP limits for the 100 RPS soak" >&2
+            exit 1
+          fi
+          target_rps="${INPUT_TARGET_RPS:-$DEFAULT_TARGET_RPS}"
+          run_time="${INPUT_RUN_TIME:-$DEFAULT_RUN_TIME}"
+          echo "base_url=$base_url" >> "$GITHUB_OUTPUT"
+          echo "target_rps=$target_rps" >> "$GITHUB_OUTPUT"
+          echo "run_time=$run_time" >> "$GITHUB_OUTPUT"
+
+      - name: Install Locust
+        run: |
+          python -m venv "${{ runner.temp }}/locust-venv"
+          "${{ runner.temp }}/locust-venv/bin/python" -m pip install --upgrade pip
+          "${{ runner.temp }}/locust-venv/bin/python" -m pip install 'locust==2.32.6'
+
+      - name: Run Landing Zone soak
+        env:
+          LANDING_ZONE_SOAK_SUMMARY_PATH: ${{ runner.temp }}/landing-zone-soak/landing-zone-soak-summary.json
+          LANDING_ZONE_TARGET_RPS: ${{ steps.config.outputs.target_rps }}
+          LANDING_ZONE_USER_RPS: "1"
+          LANDING_ZONE_API_KEY: ${{ secrets.PERF_SOAK_API_KEY }}
+        run: |
+          mkdir -p "${{ runner.temp }}/landing-zone-soak"
+          users="${{ steps.config.outputs.target_rps }}"
+          "${{ runner.temp }}/locust-venv/bin/python" -m locust \
+            -f tests/perf/locustfile_landing_zone.py \
+            --headless \
+            --host "${{ steps.config.outputs.base_url }}" \
+            --users "$users" \
+            --spawn-rate "$users" \
+            --run-time "${{ steps.config.outputs.run_time }}" \
+            --only-summary
+
+      - name: Upload soak summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: landing-zone-soak-summary
+          path: ${{ runner.temp }}/landing-zone-soak/landing-zone-soak-summary.json
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### QA guardrails
 
+- **Landing Zone SLO soak** — nightly Locust performance soak now exercises primary and DR Landing Zone SVG exports at the 100 RPS / 5 minute contract, publishes a JSON summary artifact, and pairs the runbook with App Insights p95 and 1h/24h burn-rate alerts.
 - **FastAPI query-parameter test guard** — CI now fails when tests send `json=` bodies to query-only FastAPI routes, and the E2E step helper converts `has_X=False` detail flags into failed steps.
 - **Mappings freshness guard** — cross-cloud service mappings now carry `last_reviewed` metadata, with non-blocking CI freshness lint and a quarterly review issue workflow.
 - **Adaptive post-upload questions** — translated architecture drafts now open immediately after analysis, while inferred defaults are shown as reviewable assumptions and only high-impact or low-confidence gaps become focused follow-up questions.

--- a/backend/main.py
+++ b/backend/main.py
@@ -287,6 +287,9 @@ class ArchmorphMiddleware(BaseHTTPMiddleware):
             request_tags = {"method": method, "path": endpoint, "status": str(status)}
             if endpoint.endswith("/generate"):
                 request_tags["format"] = request.query_params.get("format", "unknown")
+            if endpoint.endswith("/export-diagram"):
+                request_tags["format"] = request.query_params.get("format", "unknown")
+                request_tags["dr_variant"] = request.query_params.get("dr_variant", "primary")
             track_request_latency(endpoint, method, duration_ms, status)
             obs_increment_counter(
                 "http.requests.total", tags={"method": method, "path": endpoint}

--- a/backend/tests/test_k6_performance_contract.py
+++ b/backend/tests/test_k6_performance_contract.py
@@ -3,9 +3,12 @@ from pathlib import Path
 
 K6_SCRIPT = Path(__file__).parent / "performance" / "api_load_test.js"
 SLA_SPINE_SCRIPT = Path(__file__).parent / "performance" / "sla_spine_locust.py"
+LANDING_ZONE_LOCUST = Path(__file__).parents[2] / "tests" / "perf" / "locustfile_landing_zone.py"
 SLA_WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "sla-spine.yml"
+PERF_SOAK_WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "perf-soak.yml"
 ALERTS_TF = Path(__file__).parents[2] / "infra" / "observability" / "alerts.tf"
 SLO_DOC = Path(__file__).parents[2] / "docs" / "SLO.md"
+LANDING_ZONE_SLO_DOC = Path(__file__).parents[2] / "docs" / "runbooks" / "landing_zone_slo.md"
 
 
 def test_k6_summary_exposes_endpoint_latency_breakdown():
@@ -66,6 +69,42 @@ def test_sla_spine_workflow_posts_pr_summary_and_runs_locust():
     assert "issues: write" in workflow
 
 
+def test_landing_zone_locust_enforces_primary_and_dr_slos():
+    script = LANDING_ZONE_LOCUST.read_text(encoding="utf-8")
+
+    assert "LANDING_ZONE_SOAK_SUMMARY_PATH" in script
+    assert "LANDING_ZONE_TARGET_RPS" in script
+    assert "memory_ceiling_mb_per_worker" in script
+    assert "X-API-Key" in script
+    assert "X-Export-Capability" in script
+    assert "export_capability" in script
+    assert "worker_memory_mb" in script
+    assert "_FIRST_EXPORT_STARTED_AT" in script
+    expected = {
+        "landing_zone_primary": 1500,
+        "landing_zone_dr": 3000,
+    }
+    for endpoint_name, threshold_ms in expected.items():
+        assert f'"{endpoint_name}"' in script
+        assert f'"threshold_ms": {threshold_ms}' in script
+    assert "dr_variant=primary" in script
+    assert "dr_variant=dr" in script
+
+
+def test_perf_soak_workflow_runs_nightly_landing_zone_locust():
+    workflow = PERF_SOAK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "name: Landing Zone Perf Soak" in workflow
+    assert "cron:" in workflow
+    assert "tests/perf/locustfile_landing_zone.py" in workflow
+    assert "PERF_SOAK_BASE_URL" in workflow
+    assert "PERF_SOAK_API_KEY" in workflow
+    assert "PERF_SOAK_RATE_LIMIT_PROFILE" in workflow
+    assert "target staging must disable or raise per-IP limits" in workflow
+    assert "LANDING_ZONE_TARGET_RPS" in workflow
+    assert "landing-zone-soak-summary" in workflow
+
+
 def test_observability_alerts_cover_full_spine_p95_and_burn_rate():
     alerts = ALERTS_TF.read_text(encoding="utf-8")
 
@@ -82,6 +121,24 @@ def test_observability_alerts_cover_full_spine_p95_and_burn_rate():
     assert "threshold               = 2" in alerts
 
 
+def test_landing_zone_alerts_cover_variant_p95_and_multi_window_burn_rate():
+    alerts = ALERTS_TF.read_text(encoding="utf-8")
+
+    for resource_name in ("landing_zone_variant_p95_high", "landing_zone_burn_rate_high"):
+        assert resource_name in alerts
+    for text in (
+        "landing_zone_variant_slos",
+        "threshold_ms = 1500",
+        "threshold_ms = 3000",
+        "customDimensions.dr_variant",
+        "format == 'landing-zone-svg'",
+        "timestamp > ago(1h)",
+        "timestamp > ago(24h)",
+        "error_budget = 0.001",
+    ):
+        assert text in alerts
+
+
 def test_slo_doc_publishes_full_spine_contract():
     doc = SLO_DOC.read_text(encoding="utf-8")
 
@@ -93,5 +150,24 @@ def test_slo_doc_publishes_full_spine_contract():
         "drift_compare",
         "30 RPS",
         "2x",
+    ):
+        assert text in doc
+
+
+def test_landing_zone_slo_runbook_publishes_soak_contract():
+    doc = LANDING_ZONE_SLO_DOC.read_text(encoding="utf-8")
+
+    for text in (
+        "p95 < 1.5s",
+        "p95 < 3s",
+        "100 RPS for 5 min",
+        "Error rate < 0.1%",
+        "512 MB per worker",
+        "LANDING_ZONE_API_KEY",
+        "X-Export-Capability",
+        "PERF_SOAK_RATE_LIMIT_PROFILE=soak",
+        "tests/perf/locustfile_landing_zone.py",
+        "1-hour window",
+        "24-hour window",
     ):
         assert text in doc

--- a/docs/runbooks/landing_zone_slo.md
+++ b/docs/runbooks/landing_zone_slo.md
@@ -1,0 +1,67 @@
+# Landing Zone Performance SLO Runbook
+
+Issue #597 defines the production-ready performance contract for `landing-zone-svg` exports.
+
+## SLOs
+
+| Variant | Route | Objective | Load Window |
+| --- | --- | ---: | --- |
+| Primary | `POST /api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=primary` | p95 < 1.5s | 100 RPS for 5 min |
+| DR | `POST /api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=dr` | p95 < 3s | 100 RPS for 5 min |
+
+Additional objectives:
+
+- Error rate < 0.1% over the 5-minute soak.
+- Sustained worker memory remains under 512 MB per worker.
+- CI smoke runs may use lower RPS for stability, but the nightly staging soak uses the 100 RPS target.
+- The nightly target must be a dedicated soak staging slot with `RATE_LIMIT_ENABLED=false` or equivalent raised per-IP limits; otherwise the test measures throttling instead of Landing Zone rendering.
+
+## Harness
+
+The Locust harness lives at `tests/perf/locustfile_landing_zone.py` and exercises both primary and DR variants against a primed diagram session. It writes a JSON summary with p95, error rate, achieved RPS, and the 512 MB worker-memory ceiling.
+
+For authenticated staging, set `LANDING_ZONE_API_KEY` or `ARCHMORPH_API_KEY`. The harness captures and rotates the one-time `X-Export-Capability` token returned by upload, analyze, and export responses.
+
+Local deterministic smoke run:
+
+```bash
+python -m venv .locust-venv
+.locust-venv/bin/python -m pip install 'locust==2.32.6'
+LANDING_ZONE_SOAK_SUMMARY_PATH=/tmp/landing-zone-soak-summary.json \
+LANDING_ZONE_TARGET_RPS=30 \
+.locust-venv/bin/python -m locust \
+  -f tests/perf/locustfile_landing_zone.py \
+  --headless \
+  --host http://127.0.0.1:8000 \
+  --users 30 \
+  --spawn-rate 30 \
+  --run-time 30s \
+  --only-summary
+```
+
+Nightly staging soak:
+
+- Workflow: `.github/workflows/perf-soak.yml`
+- Schedule: nightly UTC plus manual `workflow_dispatch`
+- Target: `vars.PERF_SOAK_BASE_URL` or `secrets.PERF_SOAK_BASE_URL`
+- API key: `secrets.PERF_SOAK_API_KEY`
+- Rate-limit guard: `vars.PERF_SOAK_RATE_LIMIT_PROFILE=soak`
+- Summary artifact: `landing-zone-soak-summary`
+
+## Alerts
+
+`infra/observability/alerts.tf` wires Landing Zone p95 and burn-rate alerts from Application Insights `customMetrics`:
+
+- Fast burn: 1-hour window, threshold 2x budget burn.
+- Slow burn: 24-hour window, evaluated together with the 1-hour window at the alert threshold configured in Terraform.
+- Bad requests are HTTP 5xx or latency above the variant SLO.
+
+The export route must emit `http.request.duration_ms` with `format=landing-zone-svg` and `dr_variant=primary|dr` dimensions so alerts can distinguish primary and DR budgets.
+
+## Triage
+
+1. Check the Locust JSON summary for failed endpoint names and p95 values.
+2. Compare primary vs DR p95; DR is allowed a 3s budget because it renders the full paired-region canvas.
+3. Check worker memory and container restarts before tuning code.
+4. If errors are HTTP 4xx, validate the setup/priming phase and session state.
+5. If errors are HTTP 5xx or latency-only, profile `generate_landing_zone_svg` and icon registry lookup before tuning infrastructure.

--- a/infra/observability/alerts.tf
+++ b/infra/observability/alerts.tf
@@ -106,6 +106,21 @@ locals {
       description  = "Drift compare p95 exceeds 5 seconds."
     }
   }
+
+  landing_zone_variant_slos = {
+    primary = {
+      name         = "primary"
+      severity     = 2
+      threshold_ms = 1500
+      description  = "Landing Zone primary export p95 exceeds 1.5 seconds."
+    }
+    dr = {
+      name         = "dr"
+      severity     = 2
+      threshold_ms = 3000
+      description  = "Landing Zone DR export p95 exceeds 3 seconds."
+    }
+  }
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -331,11 +346,128 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "spine_burn_rate_high"
   tags                    = var.tags
 }
 
+# ─────────────────────────────────────────────────────────────
+# Landing Zone variant p95 alerts (#597)
+#
+# These use request latency dimensions emitted by backend/main.py so primary
+# and DR variants keep separate budgets: 1.5s and 3s respectively.
+# ─────────────────────────────────────────────────────────────
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "landing_zone_variant_p95_high" {
+  for_each = local.landing_zone_variant_slos
+
+  name                = "archmorph-lz-${each.value.name}-p95-high"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  description = each.value.description
+  severity    = each.value.severity
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+
+  scopes                = [var.application_insights_id]
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query = <<-KQL
+      customMetrics
+      | where name == 'http.request.duration_ms'
+      | extend path = tostring(customDimensions.path), format = tostring(customDimensions.format), dr_variant = tostring(customDimensions.dr_variant)
+      | where path matches regex '^/api(/v1)?/diagrams/[^/]+/export-diagram$'
+      | where format == 'landing-zone-svg'
+      | where dr_variant == '${each.value.name}'
+      | summarize p95 = percentile(value, 95)
+      | project p95
+    KQL
+
+    time_aggregation_method = "Maximum"
+    operator                = "GreaterThan"
+    threshold               = each.value.threshold_ms
+    metric_measure_column   = "p95"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 2
+      number_of_evaluation_periods             = 2
+    }
+  }
+
+  action {
+    action_groups = [var.action_group_critical_id]
+  }
+
+  auto_mitigation_enabled = true
+  tags                    = var.tags
+}
+
+# ─────────────────────────────────────────────────────────────
+# Landing Zone multi-window burn-rate alerts (#597)
+#
+# Bad events are requests above the variant latency SLO or HTTP 5xx responses.
+# The query evaluates 1-hour fast burn and 24-hour slow burn windows.
+# ─────────────────────────────────────────────────────────────
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "landing_zone_burn_rate_high" {
+  for_each = local.landing_zone_variant_slos
+
+  name                = "archmorph-lz-${each.value.name}-burn-rate-high"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  description = "Multi-window burn-rate alert for Landing Zone ${each.value.name}: 1h fast and 24h slow windows."
+  severity    = each.value.severity
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "P1D"
+
+  scopes                = [var.application_insights_id]
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query = <<-KQL
+      let threshold_ms = todouble(${each.value.threshold_ms});
+      let error_budget = 0.001;
+      let lz = customMetrics
+        | where name == 'http.request.duration_ms'
+        | extend path = tostring(customDimensions.path), status = toint(customDimensions.status), format = tostring(customDimensions.format), dr_variant = tostring(customDimensions.dr_variant)
+        | where path matches regex '^/api(/v1)?/diagrams/[^/]+/export-diagram$'
+        | where format == 'landing-zone-svg'
+        | where dr_variant == '${each.value.name}';
+      let fast = lz
+        | where timestamp > ago(1h)
+        | summarize total = count(), bad = countif(value > threshold_ms or status >= 500)
+        | extend burn = iif(total < 50, 0.0, todouble(bad) / todouble(total) / error_budget);
+      let slow = lz
+        | where timestamp > ago(24h)
+        | summarize total = count(), bad = countif(value > threshold_ms or status >= 500)
+        | extend burn = iif(total < 200, 0.0, todouble(bad) / todouble(total) / error_budget);
+      print burn_rate = min_of(toscalar(fast | project burn), toscalar(slow | project burn))
+    KQL
+
+    time_aggregation_method = "Maximum"
+    operator                = "GreaterThan"
+    threshold               = 2
+    metric_measure_column   = "burn_rate"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [var.action_group_critical_id]
+  }
+
+  auto_mitigation_enabled = true
+  tags                    = var.tags
+}
+
 output "alert_ids" {
   description = "IDs of the alert rules wired up by this module."
   value = {
     icon_miss_rate_high = azurerm_monitor_scheduled_query_rules_alert_v2.lz_icon_miss_rate_high.id
     svg_p95_high        = azurerm_monitor_scheduled_query_rules_alert_v2.lz_svg_p95_high.id
+    lz_variant_p95      = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.landing_zone_variant_p95_high : key => alert.id }
+    lz_burn_rate        = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.landing_zone_burn_rate_high : key => alert.id }
     spine_p95_high      = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.spine_request_p95_high : key => alert.id }
     spine_burn_rate     = { for key, alert in azurerm_monitor_scheduled_query_rules_alert_v2.spine_burn_rate_high : key => alert.id }
   }

--- a/tests/perf/locustfile_landing_zone.py
+++ b/tests/perf/locustfile_landing_zone.py
@@ -1,0 +1,238 @@
+"""Locust soak harness for Landing Zone SVG export (#597)."""
+
+from __future__ import annotations
+
+import json
+import os
+import resource
+import time
+from pathlib import Path
+from typing import Any
+
+from locust import HttpUser, constant_throughput, events, task
+from locust.exception import StopUser
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + (b"\0" * 100)
+SUMMARY_PATH = Path(os.getenv("LANDING_ZONE_SOAK_SUMMARY_PATH", "landing-zone-soak-summary.json"))
+TARGET_RPS = int(os.getenv("LANDING_ZONE_TARGET_RPS", "100"))
+MIN_RPS_RATIO = float(os.getenv("LANDING_ZONE_MIN_RPS_RATIO", "0.85"))
+FAILURE_RATE_THRESHOLD = float(os.getenv("LANDING_ZONE_FAILURE_RATE", "0.001"))
+MEMORY_CEILING_MB_PER_WORKER = int(os.getenv("LANDING_ZONE_MEMORY_CEILING_MB", "512"))
+API_KEY = os.getenv("LANDING_ZONE_API_KEY") or os.getenv("ARCHMORPH_API_KEY")
+_FIRST_EXPORT_STARTED_AT: float | None = None
+
+LANDING_ZONE_ENDPOINTS = {
+    "landing_zone_primary": {
+        "method": "POST",
+        "threshold_ms": 1500,
+        "route": "/api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=primary",
+        "description": "Landing-zone SVG primary variant",
+    },
+    "landing_zone_dr": {
+        "method": "POST",
+        "threshold_ms": 3000,
+        "route": "/api/diagrams/{diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=dr",
+        "description": "Landing-zone SVG DR variant",
+    },
+}
+
+
+def _expect_success(response, name: str) -> None:
+    if 200 <= response.status_code < 300:
+        response.success()
+        return
+    response.failure(f"{name} returned HTTP {response.status_code}: {response.text[:240]}")
+
+
+def _auth_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+    headers: dict[str, str] = dict(extra or {})
+    if API_KEY:
+        headers["X-API-Key"] = API_KEY
+    return headers
+
+
+def _remember_first_export_sample() -> None:
+    global _FIRST_EXPORT_STARTED_AT
+    if _FIRST_EXPORT_STARTED_AT is None:
+        _FIRST_EXPORT_STARTED_AT = time.perf_counter()
+
+
+def _worker_memory_mb() -> float:
+    rss = float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    if os.uname().sysname == "Darwin":
+        return rss / (1024 * 1024)
+    return rss / 1024
+
+
+class LandingZoneUser(HttpUser):
+    """Exercise primary and DR ALZ exports against a primed diagram session."""
+
+    wait_time = constant_throughput(float(os.getenv("LANDING_ZONE_USER_RPS", "1")))
+
+    def on_start(self) -> None:
+        self.export_capability: str | None = None
+        self.diagram_id = self._upload_diagram()
+        self._prime_analysis()
+
+    def _upload_diagram(self) -> str:
+        with self.client.post(
+            "/api/projects/landing-zone-soak/diagrams",
+            files={"file": ("aws.png", PNG_BYTES, "image/png")},
+            headers=_auth_headers(),
+            name="setup_upload_diagram",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"setup upload failed: HTTP {response.status_code} {response.text[:240]}")
+                raise StopUser()
+            payload = response.json()
+            self.export_capability = payload.get("export_capability")
+            response.success()
+            return str(payload["diagram_id"])
+
+    def _prime_analysis(self) -> None:
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/analyze",
+            headers=_auth_headers(),
+            name="setup_prime_analyze",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"setup analyze failed: HTTP {response.status_code} {response.text[:240]}")
+                raise StopUser()
+            self.export_capability = response.json().get("export_capability", self.export_capability)
+            response.success()
+
+    def _export_headers(self) -> dict[str, str]:
+        if not self.export_capability:
+            raise StopUser()
+        return _auth_headers({"X-Export-Capability": self.export_capability})
+
+    def _capture_next_capability(self, response) -> None:
+        try:
+            self.export_capability = response.json().get("export_capability", self.export_capability)
+        except ValueError:
+            pass
+
+    @task(3)
+    def landing_zone_primary(self) -> None:
+        _remember_first_export_sample()
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=primary",
+            headers=self._export_headers(),
+            name="landing_zone_primary",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "landing_zone_primary")
+            if 200 <= response.status_code < 300:
+                self._capture_next_capability(response)
+
+    @task(1)
+    def landing_zone_dr(self) -> None:
+        _remember_first_export_sample()
+        with self.client.post(
+            f"/api/diagrams/{self.diagram_id}/export-diagram?format=landing-zone-svg&dr_variant=dr",
+            headers=self._export_headers(),
+            name="landing_zone_dr",
+            catch_response=True,
+        ) as response:
+            _expect_success(response, "landing_zone_dr")
+            if 200 <= response.status_code < 300:
+                self._capture_next_capability(response)
+
+
+def _metric_value(stats, endpoint_name: str, value_name: str):
+    entry = stats.get(endpoint_name, LANDING_ZONE_ENDPOINTS[endpoint_name]["method"])
+    if entry is None or entry.num_requests == 0:
+        return None
+    if value_name == "p95_ms":
+        return entry.get_response_time_percentile(0.95)
+    if value_name == "avg_ms":
+        return entry.avg_response_time
+    if value_name == "max_ms":
+        return entry.max_response_time
+    if value_name == "failure_rate":
+        return entry.num_failures / entry.num_requests
+    return None
+
+
+def _build_endpoint_summary(stats) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {}
+    for endpoint_name, target in LANDING_ZONE_ENDPOINTS.items():
+        entry = stats.get(endpoint_name, target["method"])
+        samples = entry.num_requests if entry is not None else 0
+        failures = entry.num_failures if entry is not None else 0
+        p95_ms = _metric_value(stats, endpoint_name, "p95_ms")
+        failure_rate = _metric_value(stats, endpoint_name, "failure_rate")
+        passed = (
+            samples > 0
+            and p95_ms is not None
+            and p95_ms < target["threshold_ms"]
+            and failure_rate is not None
+            and failure_rate < FAILURE_RATE_THRESHOLD
+        )
+        summary[endpoint_name] = {
+            "description": target["description"],
+            "route": target["route"],
+            "method": target["method"],
+            "samples": samples,
+            "failures": failures,
+            "failure_rate": failure_rate,
+            "p95_ms": p95_ms,
+            "avg_ms": _metric_value(stats, endpoint_name, "avg_ms"),
+            "max_ms": _metric_value(stats, endpoint_name, "max_ms"),
+            "threshold_ms": target["threshold_ms"],
+            "passed": passed,
+        }
+    return summary
+
+
+def _achieved_rps(endpoint_summary: dict[str, dict[str, Any]], elapsed_seconds: float) -> float:
+    if elapsed_seconds <= 0:
+        return 0.0
+    return sum(values["samples"] for values in endpoint_summary.values()) / elapsed_seconds
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    print("\nArchmorph Landing Zone soak summary")
+    print(
+        f"target_rps={summary['target_rps']} achieved_rps={summary['achieved_rps']:.2f} "
+        f"min_rps={summary['minimum_rps']:.2f} failed={summary['failed']}"
+    )
+    for endpoint_name, values in summary["endpoints"].items():
+        status = "PASS" if values["passed"] else "FAIL"
+        print(
+            f"{status} {endpoint_name}: p95={values['p95_ms']}ms "
+            f"threshold={values['threshold_ms']}ms samples={values['samples']} failures={values['failures']}"
+        )
+    print("")
+
+
+@events.quitting.add_listener
+def enforce_landing_zone_slos(environment, **_kwargs) -> None:
+    endpoint_summary = _build_endpoint_summary(environment.stats)
+    elapsed_seconds = time.perf_counter() - _FIRST_EXPORT_STARTED_AT if _FIRST_EXPORT_STARTED_AT else 0.0
+    achieved_rps = _achieved_rps(endpoint_summary, elapsed_seconds)
+    minimum_rps = TARGET_RPS * MIN_RPS_RATIO
+    memory_mb = _worker_memory_mb()
+    failed = [name for name, values in endpoint_summary.items() if not values["passed"]]
+    if achieved_rps < minimum_rps:
+        failed.append("throughput")
+    if memory_mb > MEMORY_CEILING_MB_PER_WORKER:
+        failed.append("worker_memory")
+    summary = {
+        "target_rps": TARGET_RPS,
+        "achieved_rps": achieved_rps,
+        "minimum_rps": minimum_rps,
+        "elapsed_seconds": elapsed_seconds,
+        "failure_rate_threshold": FAILURE_RATE_THRESHOLD,
+        "memory_ceiling_mb_per_worker": MEMORY_CEILING_MB_PER_WORKER,
+        "worker_memory_mb": memory_mb,
+        "failed": failed,
+        "endpoints": endpoint_summary,
+    }
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    _print_summary(summary)
+    if failed:
+        environment.process_exit_code = 1


### PR DESCRIPTION
## Summary
- Add a dedicated Locust Landing Zone soak harness for primary and DR SVG export variants with p95/error-rate/throughput enforcement and JSON summary output.
- Add a nightly/manual GitHub Actions staging soak workflow and a Landing Zone SLO runbook.
- Add App Insights p95 plus 1h/24h burn-rate alert wiring and tag export request metrics with format/dr_variant dimensions.
- Extend performance contract tests and changelog coverage.

Closes #597.

## Validation
- `pushd backend >/dev/null && ./.venv/bin/python -m pytest tests/test_k6_performance_contract.py -q && popd >/dev/null`
- `python3 -m py_compile tests/perf/locustfile_landing_zone.py`
- `terraform fmt -check infra/observability/alerts.tf`
- `git diff --check`