### PR TITLE
feat: add vision analyzer observability

### DIFF
--- a/backend/observability.py
+++ b/backend/observability.py
@@ -44,6 +44,7 @@ except ImportError:  # pragma: no cover
 # ── Lazy OTel instrument registries ───────────────────────────
 _otel_counters: Dict[str, Any] = {}
 _otel_histograms: Dict[str, Any] = {}
+_otel_gauges: Dict[str, Any] = {}
 
 
 def _get_otel_counter(name: str):
@@ -62,6 +63,15 @@ def _get_otel_histogram(name: str):
     if name not in _otel_histograms:
         _otel_histograms[name] = _meter.create_histogram(name, description=f"Histogram: {name}")
     return _otel_histograms[name]
+
+
+def _get_otel_gauge(name: str):
+    """Get or lazily create an OTel Gauge instrument when supported."""
+    if not _OTEL_AVAILABLE or _meter is None or not hasattr(_meter, "create_gauge"):
+        return None
+    if name not in _otel_gauges:
+        _otel_gauges[name] = _meter.create_gauge(name, description=f"Gauge: {name}")
+    return _otel_gauges[name]
 
 
 # ── In-memory metrics (admin dashboard) ──────────────────────
@@ -285,7 +295,8 @@ def set_gauge(name: str, value: float, tags: Optional[Dict[str, str]] = None):
     """
     Set a gauge metric value.
 
-    In-memory only — serves the admin monitoring dashboard.
+    Writes to the in-memory store and to an OpenTelemetry Gauge instrument
+    when the installed OTel API supports synchronous gauges.
     """
     key = _make_metric_key(name, tags)
     with _metrics_lock:
@@ -295,6 +306,10 @@ def set_gauge(name: str, value: float, tags: Optional[Dict[str, str]] = None):
             "value": value,
             "timestamp": time.time(),
         }
+
+    otel_gauge = _get_otel_gauge(name)
+    if otel_gauge is not None:
+        otel_gauge.set(value, attributes=tags or {})
 
 
 def get_metrics() -> Dict[str, Any]:

--- a/backend/tests/test_vision_analyzer.py
+++ b/backend/tests/test_vision_analyzer.py
@@ -1,7 +1,63 @@
 """Tests for vision_analyzer.py — diagram image analysis via GPT-4o vision."""
 
+import json
 from unittest.mock import patch, MagicMock
+import pytest
+from cachetools import TTLCache
+
+import observability
+import vision_analyzer
 from vision_analyzer import analyze_image
+
+
+def _minimal_png():
+    import struct
+    import zlib
+
+    signature = b'\x89PNG\r\n\x1a\n'
+    ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
+    ihdr_crc = zlib.crc32(b'IHDR' + ihdr_data)
+    ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', ihdr_crc)
+    raw = b'\x00\x00\x00\x00'
+    idat_data = zlib.compress(raw)
+    idat_crc = zlib.crc32(b'IDAT' + idat_data)
+    idat = struct.pack('>I', len(idat_data)) + b'IDAT' + idat_data + struct.pack('>I', idat_crc)
+    iend_crc = zlib.crc32(b'IEND')
+    iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', iend_crc)
+    return signature + ihdr + idat + iend
+
+
+def _vision_response(payload: dict):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    return response
+
+
+def _metric_total(kind: str, name: str, tags: dict[str, str] | None = None) -> int:
+    total = 0
+    for entry in observability._metrics[kind].values():
+        if entry["name"] != name:
+            continue
+        entry_tags = entry.get("tags", {})
+        if tags is None or all(entry_tags.get(k) == v for k, v in tags.items()):
+            total += entry.get("value", len(entry.get("values", [])))
+    return total
+
+
+@pytest.fixture(autouse=True)
+def clean_vision_cache_and_metrics():
+    with vision_analyzer._vision_cache_lock:
+        vision_analyzer._vision_cache.clear()
+    observability._metrics["counters"].clear()
+    observability._metrics["histograms"].clear()
+    observability._metrics["gauges"].clear()
+    yield
+    with vision_analyzer._vision_cache_lock:
+        vision_analyzer._vision_cache.clear()
+    observability._metrics["counters"].clear()
+    observability._metrics["histograms"].clear()
+    observability._metrics["gauges"].clear()
 
 
 class TestAnalyzeImage:
@@ -35,24 +91,7 @@ class TestAnalyzeImage:
 
         mock_client.chat.completions.create.return_value = mock_response
 
-        # Create a minimal valid PNG (1x1 pixel)
-        import struct
-        import zlib
-        
-        def create_minimal_png():
-            signature = b'\x89PNG\r\n\x1a\n'
-            ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
-            ihdr_crc = zlib.crc32(b'IHDR' + ihdr_data)
-            ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', ihdr_crc)
-            raw = b'\x00\x00\x00\x00'
-            idat_data = zlib.compress(raw)
-            idat_crc = zlib.crc32(b'IDAT' + idat_data)
-            idat = struct.pack('>I', len(idat_data)) + b'IDAT' + idat_data + struct.pack('>I', idat_crc)
-            iend_crc = zlib.crc32(b'IEND')
-            iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', iend_crc)
-            return signature + ihdr + idat + iend
-
-        png_bytes = create_minimal_png()
+        png_bytes = _minimal_png()
         result = analyze_image(png_bytes, "test-diagram-id")
 
         assert isinstance(result, dict)
@@ -82,19 +121,7 @@ class TestWarningsCoercion:
     """
 
     def _png(self):
-        import struct
-        import zlib
-        signature = b'\x89PNG\r\n\x1a\n'
-        ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
-        ihdr_crc = zlib.crc32(b'IHDR' + ihdr_data)
-        ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data + struct.pack('>I', ihdr_crc)
-        raw = b'\x00\x00\x00\x00'
-        idat_data = zlib.compress(raw)
-        idat_crc = zlib.crc32(b'IDAT' + idat_data)
-        idat = struct.pack('>I', len(idat_data)) + b'IDAT' + idat_data + struct.pack('>I', idat_crc)
-        iend_crc = zlib.crc32(b'IEND')
-        iend = struct.pack('>I', 0) + b'IEND' + struct.pack('>I', iend_crc)
-        return signature + ihdr + idat + iend
+        return _minimal_png()
 
     @patch("vision_analyzer.get_openai_client")
     def test_object_warnings_are_flattened_to_strings(self, mock_client_fn):
@@ -132,4 +159,66 @@ class TestWarningsCoercion:
         assert "Falls back to description key" in result["warnings"]
         # Object with no known string key falls back to JSON serialisation
         assert any('"type"' in w and '"no_message_key"' in w for w in result["warnings"])
+
+
+class TestVisionCacheObservability:
+    @patch("vision_analyzer.get_openai_client")
+    def test_same_image_uses_cache_and_emits_hit_rate_metrics(self, mock_client_fn):
+        mock_client = MagicMock()
+        mock_client_fn.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _vision_response({
+            "diagram_type": "AWS Architecture",
+            "services_detected": 1,
+        })
+
+        first = analyze_image(_minimal_png())
+        second = analyze_image(_minimal_png())
+
+        assert first == second
+        assert mock_client.chat.completions.create.call_count == 1
+        assert _metric_total("counters", vision_analyzer.VISION_CACHE_METRIC, {"result": "miss"}) == 1
+        assert _metric_total("counters", vision_analyzer.VISION_CACHE_METRIC, {"result": "hit"}) == 1
+        assert _metric_total("histograms", vision_analyzer.VISION_LATENCY_METRIC) == 2
+
+    @patch("vision_analyzer.get_openai_client")
+    def test_model_change_changes_prompt_hash_and_cache_key(self, mock_client_fn, monkeypatch):
+        mock_client = MagicMock()
+        mock_client_fn.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = [
+            _vision_response({"diagram_type": "old-model"}),
+            _vision_response({"diagram_type": "new-model"}),
+        ]
+
+        monkeypatch.setattr(vision_analyzer, "AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
+        old_hash = vision_analyzer._compute_vision_prompt_hash("gpt-4o")
+        first = analyze_image(_minimal_png())
+
+        monkeypatch.setattr(vision_analyzer, "AZURE_OPENAI_DEPLOYMENT", "gpt-5.4")
+        new_hash = vision_analyzer._compute_vision_prompt_hash("gpt-5.4")
+        second = analyze_image(_minimal_png())
+
+        assert old_hash != new_hash
+        assert first != second
+        assert mock_client.chat.completions.create.call_count == 2
+        assert mock_client.chat.completions.create.call_args_list[0].kwargs["model"] == "gpt-4o"
+        assert mock_client.chat.completions.create.call_args_list[1].kwargs["model"] == "gpt-5.4"
+        assert _metric_total("counters", vision_analyzer.VISION_CACHE_METRIC, {"result": "miss"}) == 2
+
+    @patch("vision_analyzer.get_openai_client")
+    def test_cache_ttl_expiry_forces_fresh_analysis(self, mock_client_fn, monkeypatch):
+        mock_client = MagicMock()
+        mock_client_fn.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = [
+            _vision_response({"diagram_type": "before-expiry"}),
+            _vision_response({"diagram_type": "after-expiry"}),
+        ]
+        monkeypatch.setattr(vision_analyzer, "_vision_cache", TTLCache(maxsize=100, ttl=0))
+
+        first = analyze_image(_minimal_png())
+        second = analyze_image(_minimal_png())
+
+        assert first != second
+        assert mock_client.chat.completions.create.call_count == 2
+        assert _metric_total("counters", vision_analyzer.VISION_CACHE_METRIC, {"result": "miss"}) == 2
+        assert _metric_total("counters", vision_analyzer.VISION_CACHE_METRIC, {"result": "hit"}) == 0
 

--- a/backend/vision_analyzer.py
+++ b/backend/vision_analyzer.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import json
 import logging
+import time
 from typing import Any, Dict, Tuple
 
 from PIL import Image
@@ -16,6 +17,7 @@ import threading
 from utils.chat_coercion import coerce_to_str_list
 
 from openai_client import get_openai_client, AZURE_OPENAI_DEPLOYMENT, openai_retry
+from observability import increment_counter, record_histogram, set_gauge
 from prompt_guard import PROMPT_ARMOR
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,10 @@ _PDF_PAGE_SEPARATOR_PX = 8
 # Thread-safe in-memory cache for vision results
 _vision_cache = TTLCache(maxsize=100, ttl=3600)
 _vision_cache_lock = threading.Lock()
+
+VISION_CACHE_METRIC = "archmorph.vision.cache"
+VISION_LATENCY_METRIC = "archmorph.vision.latency_ms"
+VISION_PROMPT_HASH_METRIC = "archmorph.vision.prompt_hash"
 
 
 def _is_pdf(image_bytes: bytes, content_type: str) -> bool:
@@ -235,21 +241,73 @@ REQUIRED JSON SCHEMA TEMPLATE:
 }
 """
 
+
+def _vision_prompt() -> str:
+    return PROMPT_ARMOR + "\n\n" + SYSTEM_PROMPT
+
+
+def _compute_vision_prompt_hash(model_name: str) -> str:
+    source = _vision_prompt()[:200] + model_name
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
+
+
+def _compute_vision_cache_key(compressed_bytes: bytes, model_name: str, prompt_hash: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(compressed_bytes)
+    digest.update(b"\0")
+    digest.update(model_name.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(prompt_hash.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _emit_prompt_hash_metric(model_name: str, prompt_hash: str) -> None:
+    set_gauge(
+        VISION_PROMPT_HASH_METRIC,
+        1.0,
+        tags={"model": model_name, "prompt_hash": prompt_hash},
+    )
+
+
+def _record_vision_latency(start_time: float, cache_hit: bool, model_name: str, prompt_hash: str) -> None:
+    record_histogram(
+        VISION_LATENCY_METRIC,
+        (time.perf_counter() - start_time) * 1000,
+        tags={
+            "cache_hit": str(cache_hit).lower(),
+            "model": model_name,
+            "prompt_hash": prompt_hash,
+        },
+    )
+
+
+VISION_PROMPT_HASH = _compute_vision_prompt_hash(AZURE_OPENAI_DEPLOYMENT)
+_emit_prompt_hash_metric(AZURE_OPENAI_DEPLOYMENT, VISION_PROMPT_HASH)
+
 def analyze_image(image_bytes: bytes, content_type: str = "image/png") -> Dict[str, Any]:
     """
     Analyze a cloud architecture diagram image using GPT-4o vision directly.
     """
+    start_time = time.perf_counter()
     compressed_bytes, compressed_type, img_w, img_h = compress_image(image_bytes, content_type)
     
     if isinstance(compressed_bytes, str):
         compressed_bytes = compressed_bytes.encode("utf-8")
 
-    cache_key = hashlib.sha256(compressed_bytes).hexdigest()
+    model_name = AZURE_OPENAI_DEPLOYMENT
+    prompt_hash = _compute_vision_prompt_hash(model_name)
+    _emit_prompt_hash_metric(model_name, prompt_hash)
+
+    cache_key = _compute_vision_cache_key(compressed_bytes, model_name, prompt_hash)
     with _vision_cache_lock:
         cached = _vision_cache.get(cache_key)
     if cached is not None:
         logger.info("Vision cache HIT (key=%s…)", cache_key[:12])
+        increment_counter(VISION_CACHE_METRIC, tags={"result": "hit", "model": model_name})
+        _record_vision_latency(start_time, True, model_name, prompt_hash)
         return cached
+
+    increment_counter(VISION_CACHE_METRIC, tags={"result": "miss", "model": model_name})
 
     b64_image = base64.b64encode(compressed_bytes).decode("utf-8")
     client = get_openai_client()
@@ -257,9 +315,9 @@ def analyze_image(image_bytes: bytes, content_type: str = "image/png") -> Dict[s
     logger.info("Sending base64 image to native GPT-4o vision analyzer (%d bytes, %dx%d)", len(compressed_bytes), img_w, img_h)
 
     response = openai_retry(client.chat.completions.create)(
-        model=AZURE_OPENAI_DEPLOYMENT,
+        model=model_name,
         messages=[
-            {"role": "system", "content": PROMPT_ARMOR + "\n\n" + SYSTEM_PROMPT},
+            {"role": "system", "content": _vision_prompt()},
             {
                 "role": "user",
                 "content": [
@@ -304,3 +362,5 @@ def analyze_image(image_bytes: bytes, content_type: str = "image/png") -> Dict[s
     except Exception as e:
         logger.error(f"Failed to parse GPT-4o output. Error: {e}")
         raise RuntimeError("GPT-4o vision did not return a valid JSON schema.") from e
+    finally:
+        _record_vision_latency(start_time, False, model_name, prompt_hash)

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1591,6 +1591,84 @@ resource "azurerm_application_insights_workbook" "dashboard" {
         name = "openai-metrics"
       },
 
+      # Vision analyzer custom metrics (#656)
+      {
+        type    = 1
+        content = { json = "## 👁️ Vision Analyzer Health\nCache effectiveness, prompt-version hash, and latency split by cache state." }
+        name    = "section-vision-analyzer"
+      },
+      {
+        type = 3
+        content = {
+          version       = "KqlItem/1.0"
+          query         = <<-KQL
+            customMetrics
+            | where name == "archmorph.vision.cache"
+            | extend result = tostring(customDimensions.result)
+            | summarize total = sum(valueCount) by result
+            | summarize
+                Hits = sumif(total, result == "hit"),
+                Misses = sumif(total, result == "miss"),
+                Total = sum(total)
+            | extend HitRatePct = round(100.0 * Hits / iff(Total == 0, 1, Total), 2)
+            | project ["Hit Rate %"] = HitRatePct, Hits, Misses, Total
+          KQL
+          size          = 4
+          title         = "Vision Cache Hit Rate"
+          queryType     = 0
+          resourceType  = "microsoft.insights/components"
+          visualization = "tiles"
+        }
+        customWidth = "33"
+        name        = "vision-cache-hit-rate"
+      },
+      {
+        type = 3
+        content = {
+          version       = "KqlItem/1.0"
+          query         = <<-KQL
+            customMetrics
+            | where name == "archmorph.vision.prompt_hash"
+            | extend
+                Model = tostring(customDimensions.model),
+                PromptHash = tostring(customDimensions.prompt_hash)
+            | summarize LastSeen = max(timestamp), Samples = sum(valueCount) by Model, PromptHash
+            | order by LastSeen desc
+          KQL
+          size          = 1
+          title         = "Vision Prompt Version Hash"
+          queryType     = 0
+          resourceType  = "microsoft.insights/components"
+          visualization = "table"
+        }
+        customWidth = "34"
+        name        = "vision-prompt-hash"
+      },
+      {
+        type = 3
+        content = {
+          version       = "KqlItem/1.0"
+          query         = <<-KQL
+            customMetrics
+            | where name == "archmorph.vision.latency_ms"
+            | extend cache_hit = tostring(customDimensions.cache_hit)
+            | summarize
+                P50 = percentile(value, 50),
+                P95 = percentile(value, 95),
+                P99 = percentile(value, 99)
+              by cache_hit, bin(timestamp, {TimeRange:grain})
+            | render timechart
+          KQL
+          size          = 0
+          title         = "Vision Latency by Cache State (ms)"
+          queryType     = 0
+          resourceType  = "microsoft.insights/components"
+          visualization = "timechart"
+        }
+        customWidth = "33"
+        name        = "vision-latency-by-cache-state"
+      },
+
       # ══════════════════════════════════════════════════════════
       # SECTION 6: Infrastructure Metrics
       # ══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add vision analyzer cache hit/miss, latency, and prompt-hash telemetry
- include model + prompt hash in the vision cache key so model/prompt changes avoid stale cache hits
- add deterministic tests for cache hits, model changes, and TTL expiry
- add a Vision Analyzer Health section to the Azure Monitor workbook

## Validation
- ./backend/.venv/bin/python -m pytest tests/test_vision_analyzer.py tests/test_observability.py -q
- terraform -chdir=infra validate

Closes #656