### PR TITLE
docs: scaffold architecture rule roadmap

### DIFF
--- a/backend/architecture_rules/README.md
+++ b/backend/architecture_rules/README.md
@@ -1,0 +1,118 @@
+# Architecture Rule Authoring Guide
+
+This package owns the deterministic architecture-limitations engine. Rules are
+YAML entries in `backend/data/architecture_rules.yaml`; predicates are Python
+helpers registered in `predicates.py`; `engine.py` loads and evaluates the
+library against a `vision_analyzer` analysis result.
+
+The current library has 25 curated rules. Issue #662 expands it to 40+ rules
+without changing the public API or moving rules out of YAML.
+
+## Rule Schema
+
+Every rule entry must include these fields:
+
+```yaml
+- id: private-link-missing-for-database
+  title: Database is public without Private Link
+  severity: warning
+  category: network-topology
+  message: |
+    Explain the architecture risk in customer-facing language.
+  remediation: |
+    Explain the Azure-native fix or tradeoff.
+  docs_url: https://learn.microsoft.com/azure/private-link/private-link-overview
+  predicate: services_all_present
+  predicate_args:
+    names:
+      - Azure SQL
+      - Public endpoint
+  tags: [networking, private-link, database]
+```
+
+Field guidance:
+
+| Field | Guidance |
+| --- | --- |
+| `id` | Stable kebab-case identifier. Tests and UI may depend on it. |
+| `title` | Short user-visible headline. |
+| `severity` | `blocker`, `warning`, or `info`. |
+| `category` | Grouping key for UI and reports, such as `protocol`, `network-topology`, `identity-auth`, `data-plane`, `region`, `tier-feature`, `resilience`, `security`, or `governance`. |
+| `message` | Why the design is risky or invalid. Keep it actionable. |
+| `remediation` | Azure-native next steps, including alternatives when there is no single fix. |
+| `docs_url` | Official Microsoft Learn URL wherever possible. |
+| `predicate` | Name registered with `@register_predicate` in `predicates.py`. |
+| `predicate_args` | Keyword args passed directly to the predicate. |
+| `references` | Optional extra links. |
+| `tags` | Optional labels for backlog, tests, and filtering. |
+
+Severity guidance:
+
+| Severity | Use When | Runtime Behavior |
+| --- | --- | --- |
+| `blocker` | Generated IaC would be non-functional or materially wrong. | IaC generation is blocked unless forced. |
+| `warning` | Design can work, but has a reliability, security, cost, or migration gap. | Surfaced to users; IaC is allowed. |
+| `info` | Best-practice nudge or SKU/tier awareness. | Surfaced as advisory context. |
+
+## Predicate Catalog
+
+Existing predicates cover most additive rules:
+
+| Predicate | Fires When |
+| --- | --- |
+| `service_present` | A fuzzy service-name match exists. |
+| `services_all_present` | Every requested service name is present. |
+| `service_pair_connected` | A connection links two named services. |
+| `connection_uses_protocol` | Any connection type contains a requested protocol token. |
+| `service_count_at_least` | At least N services match one of the supplied keywords. |
+| `category_present_without_companion` | A category appears without any required companion service. |
+| `service_in_category_with_other` | A category coexists with another named service. |
+| `path_uses_service_with_protocol_mismatch` | Traffic through a service uses an unsupported protocol. |
+
+When adding a predicate, keep it composable and tolerant of noisy model output:
+
+1. Accept `analysis: dict` plus keyword-only args.
+2. Return `None` when the evidence is absent or ambiguous.
+3. Return `PredicateMatch(affected_services=[...], evidence={...})` when it fires.
+4. Use `_service_matches`, `_has_service`, `_services_in_analysis`, and `_connections` instead of strict string equality.
+5. Avoid external calls, non-determinism, and side effects.
+
+## Test Pattern
+
+Each rule must have at least one positive and one negative assertion. Prefer a
+small fixture in `backend/tests/test_architecture_rules.py` unless the case needs
+a shared JSON fixture.
+
+Positive test shape:
+
+```python
+def test_private_link_rule_fires(public_database_analysis):
+    issues = evaluate(public_database_analysis)
+    assert "private-link-missing-for-database" in {issue.rule_id for issue in issues}
+```
+
+Negative test shape:
+
+```python
+def test_private_link_rule_does_not_fire_when_private_link_present(private_database_analysis):
+    issues = evaluate(private_database_analysis)
+    assert "private-link-missing-for-database" not in {issue.rule_id for issue in issues}
+```
+
+Run the focused suite before opening a PR:
+
+```sh
+cd backend
+./.venv/bin/python -m pytest tests/test_architecture_rules.py tests/test_iac_blocker_gate.py -q
+```
+
+## Contributor Checklist
+
+1. Confirm the new rule is not already represented in `architecture_rules.yaml`.
+2. Use an existing predicate when possible.
+3. Add a reusable predicate only when at least two rules can plausibly share it.
+4. Keep `message` and `remediation` customer-readable.
+5. Link to official Microsoft Learn docs.
+6. Add positive and negative tests.
+7. Run the focused architecture-rules tests.
+8. Update `rules-roadmap.md` when the total rule count or #662 phase status changes.

--- a/backend/architecture_rules/rules-roadmap.md
+++ b/backend/architecture_rules/rules-roadmap.md
@@ -1,0 +1,60 @@
+# Architecture Rules Roadmap (#662)
+
+Issue #662 expands the curated architecture-rule library from 25 rules to 40+
+rules while keeping the engine YAML-driven and backward compatible.
+
+## Current Status
+
+| Metric | Value |
+| --- | ---: |
+| Current curated rules | 25 |
+| Target curated rules | 40+ |
+| Rules needed for target | 15+ |
+| Current rule source | `backend/data/architecture_rules.yaml` |
+| Engine entry point | `architecture_rules.evaluate()` |
+| Test entry point | `backend/tests/test_architecture_rules.py` |
+
+## Phase Plan
+
+| Phase | Status | Scope | Exit Criteria |
+| --- | --- | --- | --- |
+| Phase 1 | In progress | Authoring guide and roadmap tracker. | `README.md` and this roadmap exist under `backend/architecture_rules/`. |
+| Phase 2 | Planned | First 5 additive rules: disaster recovery, edge security, identity, backup posture, tagging policy. | Rules, predicates if needed, and positive/negative tests merged. |
+| Phase 3 | Planned | Next 6 additive rules: Private Link, secrets management, observability overlap, regulated workload hints, multi-domain validation, tenancy detector. | Rules, predicates if needed, and positive/negative tests merged. |
+| Phase 4 | Planned | Additional 4+ backlog rules selected from production learnings or CTO gap candidates. | Library reaches at least 40 curated rules. |
+
+## Candidate Rule Backlog
+
+| Candidate | Category | Likely Severity | Predicate Strategy | Status |
+| --- | --- | --- | --- | --- |
+| Cross-region replication missing for stateful workloads | resilience | warning | New `cross_region_replication_present` or composition of service/count checks. | Planned |
+| Edge service without WAF or DDoS posture | security | warning | Existing service/category predicates, possibly new endpoint predicate. | Planned |
+| Identity layer missing for user-facing app | identity-auth | warning | Existing `category_present_without_companion`. | Planned |
+| Backup posture missing for database/storage | resilience | warning | Existing companion predicate or backup-specific helper. | Planned |
+| Required tags not represented in governance design | governance | info | New tag/governance evidence predicate if analysis carries tags. | Planned |
+| Database or storage public path without Private Link | network-topology | warning | Existing service co-occurrence plus new endpoint predicate if needed. | Planned |
+| Secrets without Key Vault or managed secret store | security | warning | New `secret_storage_provider`. | Planned |
+| Duplicate observability stacks or no observability anchor | operations | info | Existing category/service predicates. | Planned |
+| Regulated workload without compliance boundary | governance | warning | Existing category/service predicates plus tags. | Planned |
+| Multi-domain architecture without clear boundary services | architecture | info | New or composite domain-count predicate. | Planned |
+| Multi-tenant signals without tenant isolation | architecture | warning | New tenancy detector predicate. | Planned |
+| Queue or eventing without dead-letter path | data-plane | warning | Existing `category_present_without_companion`. | Candidate |
+| Internet-facing app without rate limiting | security | warning | Existing service/category predicates. | Candidate |
+| Stateful workload without zone or region posture | resilience | warning | Existing service/count predicates. | Candidate |
+| Cost-sensitive design using premium edge services everywhere | cost | info | Existing service-count predicates. | Candidate |
+
+## Progress Log
+
+| Date | Change | Rule Count |
+| --- | --- | ---: |
+| 2026-05-06 | Phase 1 scaffold: authoring guide and roadmap tracker. | 25 |
+
+## Validation Gates
+
+Before closing #662:
+
+- `backend/data/architecture_rules.yaml` contains at least 40 unique rule IDs.
+- Every new predicate is registered and covered by unit tests.
+- Every new rule has positive and negative fixture coverage.
+- `./.venv/bin/python -m pytest tests/test_architecture_rules.py tests/test_iac_blocker_gate.py -q` passes from `backend/`.
+- `docs/ARCHITECTURE_RULES.md` and `README.md` counts are updated if the public rule count changes.


### PR DESCRIPTION
## Summary
- add a backend-local architecture rule authoring guide
- add the #662 roadmap tracker from 25 current rules toward 40+
- document candidate rule batches, validation gates, and contributor checklist

## Validation
- ./backend/.venv/bin/python -m pytest tests/test_architecture_rules.py tests/test_iac_blocker_gate.py -q

Refs #662