### PR TITLE
fix: health gate for fresh catalog provider errors

### DIFF
--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -132,7 +132,6 @@ async def health():
         checks["service_catalog_providers_failed"] = ",".join(
             freshness["providers_failed"]
         )
-        degraded = True
     # Issue #640 — generalised scheduled-job freshness signal. Any registered
     # job stale beyond its budget marks the system degraded; the watchdog
     # workflow polls this block and files an alert issue.

--- a/backend/tests/test_contract.py
+++ b/backend/tests/test_contract.py
@@ -227,6 +227,48 @@ class TestHealthContract:
                 },
             )
 
+    def test_health_provider_failure_does_not_degrade_fresh_catalog(self, client, monkeypatch):
+        import routers.health as health_router
+
+        monkeypatch.setattr(
+            health_router,
+            "get_freshness",
+            lambda: {
+                "last_check": "2026-01-01T00:00:00+00:00",
+                "age_hours": 1.0,
+                "budget_hours": 36.0,
+                "stale": False,
+                "last_errors": {"azure": "HTTP 429 from AZURE"},
+                "providers_failed": ["azure"],
+            },
+        )
+        monkeypatch.setattr(
+            health_router,
+            "get_scheduled_jobs",
+            lambda: [
+                {
+                    "name": "service_catalog_refresh",
+                    "budget_hours": 36.0,
+                    "last_success": "2026-01-01T00:00:00+00:00",
+                    "age_hours": 1.0,
+                    "stale": False,
+                    "description": "test job",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            health_router,
+            "_run_dependency_checks",
+            lambda: ({"openai": "ok", "storage": "ok"}, False, False),
+        )
+
+        data = client.get("/api/health").json()
+
+        assert data["status"] == "healthy"
+        assert data["checks"]["service_catalog_refresh"] == "fresh (1.0h)"
+        assert data["checks"]["service_catalog_providers_failed"] == "azure"
+        assert data["service_catalog_refresh"]["providers_failed"] == ["azure"]
+
     def test_health_scheduled_job_staleness_degrades(self, client, monkeypatch):
         import routers.health as health_router
 


### PR DESCRIPTION
## Summary
- keep transient service catalog provider failures visible in /api/health without degrading health while the last successful catalog refresh is still fresh
- preserve stale catalog and stale scheduled-job degradation semantics
- add a contract test for the Azure HTTP 429 deployment case

## Tests
- cd backend && ./.venv/bin/python -m pytest tests/test_contract.py::TestHealthContract tests/test_health_gate_script.py
- cd backend && ./.venv/bin/python -m ruff check routers/health.py tests/test_contract.py tests/test_health_gate_script.py