### PR TITLE
feat: expand architecture rules phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Full mapping database: 405+ services across AWS, Azure, and GCP with 122 mapping
 
 Deterministic rule engine that flags structurally invalid Azure compositions during analysis — for example, an SFTP client connecting to Azure Storage's SFTP endpoint **through Azure Front Door** (Front Door is HTTP/HTTPS only and cannot tunnel SSH). The diagram and Terraform would deploy cleanly; the runtime traffic would never connect.
 
-- 25 curated rules across 7 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature)
+- 30 curated rules across 10 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature, resilience, security, governance)
 - YAML-driven rule library at [`backend/data/architecture_rules.yaml`](backend/data/architecture_rules.yaml); override via `ARCHMORPH_ARCH_RULES_PATH`
 - Three severities: `blocker` (IaC will be wrong), `warning` (works but has gaps), `info` (best-practice nudges)
 - IaC generation refuses with `409` when blockers exist; pass `?force=true` to override

--- a/backend/architecture_rules/README.md
+++ b/backend/architecture_rules/README.md
@@ -5,7 +5,7 @@ YAML entries in `backend/data/architecture_rules.yaml`; predicates are Python
 helpers registered in `predicates.py`; `engine.py` loads and evaluates the
 library against a `vision_analyzer` analysis result.
 
-The current library has 25 curated rules. Issue #662 expands it to 40+ rules
+The current library has 30 curated rules. Issue #662 expands it to 40+ rules
 without changing the public API or moving rules out of YAML.
 
 ## Rule Schema
@@ -65,6 +65,7 @@ Existing predicates cover most additive rules:
 | `service_pair_connected` | A connection links two named services. |
 | `connection_uses_protocol` | Any connection type contains a requested protocol token. |
 | `service_count_at_least` | At least N services match one of the supplied keywords. |
+| `service_keywords_without_companion` | One or more service keywords appear without companion controls; supports `exclude_keywords` plus `companion_mode: any` or `coverage`. |
 | `category_present_without_companion` | A category appears without any required companion service. |
 | `service_in_category_with_other` | A category coexists with another named service. |
 | `path_uses_service_with_protocol_mismatch` | Traffic through a service uses an unsupported protocol. |

--- a/backend/architecture_rules/predicates.py
+++ b/backend/architecture_rules/predicates.py
@@ -255,6 +255,79 @@ def service_count_at_least(
     )
 
 
+@register_predicate("service_keywords_without_companion")
+def service_keywords_without_companion(
+    analysis: Dict[str, Any],
+    *,
+    keywords: List[str],
+    companions: List[str],
+    exclude_keywords: List[str] | None = None,
+    threshold: int = 1,
+    companion_mode: str = "any",
+) -> Optional[PredicateMatch]:
+    """Fire when services match ``keywords`` but no companion control is present.
+
+    This is useful for additive posture rules such as "stateful services without
+    backup" or "internet-facing services without WAF evidence". Set
+    ``threshold`` above 1 for broad governance rules that should only fire on
+    multi-service architectures. ``companion_mode=coverage`` treats companion
+    services as coverage evidence and only suppresses when there is at least one
+    companion signal per matched workload.
+    """
+    if not keywords or threshold < 1:
+        return None
+
+    companion_names = companions or []
+    exclusions = exclude_keywords or []
+    matched: List[str] = []
+    seen: set[str] = set()
+    for service_name in _services_in_analysis(analysis):
+        is_companion_service = any(
+            _service_matches(service_name, companion)
+            for companion in companion_names
+        )
+        is_excluded_service = any(
+            _service_matches(service_name, excluded)
+            for excluded in exclusions
+        )
+        if is_companion_service or is_excluded_service:
+            continue
+        if any(_service_matches(service_name, keyword) for keyword in keywords):
+            if service_name not in seen:
+                matched.append(service_name)
+                seen.add(service_name)
+
+    if len(matched) < threshold:
+        return None
+
+    companion_hits: List[str] = []
+    companion_seen: set[str] = set()
+    for companion in companion_names:
+        for hit in _has_service(analysis, companion):
+            if hit not in companion_seen:
+                companion_hits.append(hit)
+                companion_seen.add(hit)
+
+    if companion_mode == "coverage":
+        if len(companion_hits) >= len(matched):
+            return None
+    elif companion_hits:
+        return None
+
+    return PredicateMatch(
+        affected_services=matched,
+        evidence={
+            "keywords": keywords,
+            "missing_companions": companions,
+            "exclude_keywords": exclusions,
+            "companion_mode": companion_mode,
+            "companion_matches": companion_hits,
+            "count": len(matched),
+            "threshold": threshold,
+        },
+    )
+
+
 @register_predicate("category_present_without_companion")
 def category_present_without_companion(
     analysis: Dict[str, Any], *, category: str, companions: List[str]

--- a/backend/architecture_rules/rules-roadmap.md
+++ b/backend/architecture_rules/rules-roadmap.md
@@ -7,9 +7,9 @@ rules while keeping the engine YAML-driven and backward compatible.
 
 | Metric | Value |
 | --- | ---: |
-| Current curated rules | 25 |
+| Current curated rules | 30 |
 | Target curated rules | 40+ |
-| Rules needed for target | 15+ |
+| Rules needed for target | 10+ |
 | Current rule source | `backend/data/architecture_rules.yaml` |
 | Engine entry point | `architecture_rules.evaluate()` |
 | Test entry point | `backend/tests/test_architecture_rules.py` |
@@ -18,8 +18,8 @@ rules while keeping the engine YAML-driven and backward compatible.
 
 | Phase | Status | Scope | Exit Criteria |
 | --- | --- | --- | --- |
-| Phase 1 | In progress | Authoring guide and roadmap tracker. | `README.md` and this roadmap exist under `backend/architecture_rules/`. |
-| Phase 2 | Planned | First 5 additive rules: disaster recovery, edge security, identity, backup posture, tagging policy. | Rules, predicates if needed, and positive/negative tests merged. |
+| Phase 1 | Complete | Authoring guide and roadmap tracker. | `README.md` and this roadmap exist under `backend/architecture_rules/`. |
+| Phase 2 | Complete | First 5 additive rules: disaster recovery, edge security, identity, backup posture, tagging policy. | Rules, predicates if needed, and positive/negative tests merged. |
 | Phase 3 | Planned | Next 6 additive rules: Private Link, secrets management, observability overlap, regulated workload hints, multi-domain validation, tenancy detector. | Rules, predicates if needed, and positive/negative tests merged. |
 | Phase 4 | Planned | Additional 4+ backlog rules selected from production learnings or CTO gap candidates. | Library reaches at least 40 curated rules. |
 
@@ -27,11 +27,11 @@ rules while keeping the engine YAML-driven and backward compatible.
 
 | Candidate | Category | Likely Severity | Predicate Strategy | Status |
 | --- | --- | --- | --- | --- |
-| Cross-region replication missing for stateful workloads | resilience | warning | New `cross_region_replication_present` or composition of service/count checks. | Planned |
-| Edge service without WAF or DDoS posture | security | warning | Existing service/category predicates, possibly new endpoint predicate. | Planned |
-| Identity layer missing for user-facing app | identity-auth | warning | Existing `category_present_without_companion`. | Planned |
-| Backup posture missing for database/storage | resilience | warning | Existing companion predicate or backup-specific helper. | Planned |
-| Required tags not represented in governance design | governance | info | New tag/governance evidence predicate if analysis carries tags. | Planned |
+| Cross-region replication missing for stateful workloads | resilience | warning | `service_keywords_without_companion`. | Complete |
+| Edge service without WAF or DDoS posture | security | warning | `service_keywords_without_companion`. | Complete |
+| Identity layer missing for user-facing app | identity-auth | warning | `service_keywords_without_companion`. | Complete |
+| Backup posture missing for database/storage | resilience | warning | `service_keywords_without_companion`. | Complete |
+| Required tags not represented in governance design | governance | info | `service_keywords_without_companion` with multi-service threshold. | Complete |
 | Database or storage public path without Private Link | network-topology | warning | Existing service co-occurrence plus new endpoint predicate if needed. | Planned |
 | Secrets without Key Vault or managed secret store | security | warning | New `secret_storage_provider`. | Planned |
 | Duplicate observability stacks or no observability anchor | operations | info | Existing category/service predicates. | Planned |
@@ -48,6 +48,7 @@ rules while keeping the engine YAML-driven and backward compatible.
 | Date | Change | Rule Count |
 | --- | --- | ---: |
 | 2026-05-06 | Phase 1 scaffold: authoring guide and roadmap tracker. | 25 |
+| 2026-05-06 | Phase 2 first rule pack: DR, edge security, identity, backup, and tagging posture. | 30 |
 
 ## Validation Gates
 

--- a/backend/data/architecture_rules.yaml
+++ b/backend/data/architecture_rules.yaml
@@ -656,3 +656,189 @@ rules:
     predicate_args:
       name: Service Bus
     tags: [servicebus, sessions, tier]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 8 — Resilience / security / governance posture
+  # ────────────────────────────────────────────────────────────
+
+  - id: dr-cross-region-replication-warning
+    title: Stateful workloads need explicit cross-region recovery posture
+    severity: warning
+    category: resilience
+    message: |
+      Stateful services were detected without clear evidence of a
+      cross-region recovery pattern. Zone redundancy protects against
+      datacenter failure, but it does not by itself cover regional outage,
+      accidental deletion, or region-scoped service disruption.
+    remediation: |
+      Add explicit disaster-recovery evidence such as SQL failover groups,
+      Cosmos DB multi-region writes, geo-redundant storage, Azure Site
+      Recovery, paired-region deployment, or Traffic Manager / Front Door
+      failover routing. Document RPO/RTO targets with the chosen pattern.
+    docs_url: https://learn.microsoft.com/azure/reliability/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - SQL Database
+        - PostgreSQL
+        - MySQL
+        - Cosmos DB
+        - Storage
+        - Blob
+        - Database
+      companions:
+        - Failover Group
+        - Geo-redundant
+        - GRS
+        - RA-GRS
+        - Cross-region
+        - Paired Region
+        - Traffic Manager
+        - Site Recovery
+        - Multi-region
+      companion_mode: coverage
+    tags: [resilience, disaster-recovery, replication]
+
+  - id: edge-security-waf-ddos-warning
+    title: Internet-facing entry points need WAF or DDoS posture
+    severity: warning
+    category: security
+    message: |
+      Internet-facing entry services were detected without a clear WAF,
+      Azure Firewall, or DDoS protection signal. Public HTTP entry points
+      should declare where request inspection, managed rules, rate controls,
+      and volumetric protection are enforced.
+    remediation: |
+      Add Azure Web Application Firewall on Front Door or Application Gateway
+      for HTTP workloads. For network-layer exposure, document Azure DDoS
+      Network Protection, Azure Firewall, or an equivalent NVA pattern.
+    docs_url: https://learn.microsoft.com/azure/web-application-firewall/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Front Door
+        - Application Gateway
+        - Public IP
+        - CDN
+        - Internet
+        - External Endpoint
+      companions:
+        - WAF
+        - Web Application Firewall
+        - DDoS
+        - Azure Firewall
+        - Firewall Policy
+    tags: [edge, waf, ddos, security]
+
+  - id: identity-layer-missing-warning
+    title: Application workloads should declare an identity layer
+    severity: warning
+    category: identity-auth
+    message: |
+      Application workloads were detected without visible Microsoft Entra ID,
+      managed identity, or Key Vault integration. Without an explicit identity
+      layer, generated deployments often drift toward shared keys, embedded
+      secrets, or ad-hoc authentication.
+    remediation: |
+      Add Microsoft Entra ID for user and workload identity, enable managed
+      identities on compute resources, and store secrets/certificates in Key
+      Vault with least-privilege RBAC assignments.
+    docs_url: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - App Service
+        - Container Apps
+        - AKS
+        - Kubernetes
+        - Azure Functions
+        - API Management
+        - Virtual Machine
+      companions:
+        - Entra
+        - Azure AD
+        - Microsoft Entra
+        - Managed Identity
+        - Key Vault
+        - Workload Identity
+      companion_mode: coverage
+    tags: [identity, managed-identity, entra]
+
+  - id: backup-posture-missing-warning
+    title: Data services need an explicit backup and restore posture
+    severity: warning
+    category: resilience
+    message: |
+      Data-bearing services were detected without backup or restore evidence.
+      Replication is not a substitute for recoverable backups: operator error,
+      ransomware, bad migrations, and destructive application bugs can be
+      replicated quickly across healthy infrastructure.
+    remediation: |
+      Document Azure Backup, Recovery Services Vault / Backup Vault, database
+      point-in-time restore, immutable backup, retention period, and restore
+      test cadence for every stateful service.
+    docs_url: https://learn.microsoft.com/azure/backup/backup-overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - SQL Database
+        - PostgreSQL
+        - MySQL
+        - Cosmos DB
+        - Storage
+        - Blob
+        - Database
+        - Virtual Machine
+      companions:
+        - Backup
+        - Recovery Services Vault
+        - Backup Vault
+        - Point-in-time Restore
+        - PITR
+        - Immutable Backup
+        - Snapshot
+      exclude_keywords:
+        - Failover Group
+        - Geo-redundant
+      companion_mode: coverage
+    tags: [backup, restore, resilience]
+
+  - id: tagging-policy-missing-info
+    title: Multi-service designs should include tagging or policy governance
+    severity: info
+    category: governance
+    message: |
+      A multi-service architecture was detected without tagging or Azure Policy
+      evidence. Missing ownership, environment, cost-center, and data-class tags
+      make cost allocation, incident response, and compliance reporting harder
+      once the design is deployed.
+    remediation: |
+      Add an Azure Policy or landing-zone governance component that enforces
+      required tags such as owner, environment, costCenter, application, and
+      dataClassification. Apply inheritance at management group, subscription,
+      or resource-group scope where appropriate.
+    docs_url: https://learn.microsoft.com/azure/azure-resource-manager/management/tag-resources
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - App Service
+        - Container Apps
+        - Front Door
+        - Application Gateway
+        - SQL Database
+        - PostgreSQL
+        - MySQL
+        - Cosmos DB
+        - Storage
+        - Service Bus
+        - Key Vault
+        - Virtual Network
+      companions:
+        - Tagging
+        - Tags
+        - Azure Policy
+        - Management Group
+        - Cost Management
+        - Resource Graph
+      threshold: 3
+    tags: [tagging, governance, policy]

--- a/backend/tests/test_architecture_rules.py
+++ b/backend/tests/test_architecture_rules.py
@@ -79,9 +79,96 @@ def sane_web_analysis():
     }
 
 
+@pytest.fixture
+def phase2_missing_posture_analysis():
+    return {
+        "identified_services": [
+            {"name": "Browser", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "Azure Storage Account", "category": "Storage"},
+        ],
+        "service_connections": [
+            {"from": "Browser", "to": "Azure Front Door", "type": "HTTPS"},
+            {"from": "Azure Front Door", "to": "Azure App Service", "type": "HTTPS"},
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+            {"from": "Azure App Service", "to": "Azure Storage Account", "type": "HTTPS"},
+        ],
+    }
+
+
+@pytest.fixture
+def phase2_complete_posture_analysis():
+    return {
+        "identified_services": [
+            {"name": "Browser", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Front Door WAF Policy", "category": "Security"},
+            {"name": "Azure DDoS Network Protection", "category": "Security"},
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Managed Identity", "category": "Identity"},
+            {"name": "Microsoft Entra ID", "category": "Identity"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "SQL Failover Group", "category": "Resilience"},
+            {"name": "Azure Storage Account", "category": "Storage"},
+            {"name": "Geo-redundant Storage", "category": "Resilience"},
+            {"name": "Recovery Services Vault", "category": "Backup"},
+            {"name": "Azure Backup", "category": "Backup"},
+            {"name": "Azure Policy Tagging Initiative", "category": "Governance"},
+        ],
+        "service_connections": [
+            {"from": "Browser", "to": "Azure Front Door", "type": "HTTPS"},
+            {"from": "Azure Front Door", "to": "Azure App Service", "type": "HTTPS"},
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+            {"from": "Azure App Service", "to": "Azure Storage Account", "type": "HTTPS"},
+        ],
+    }
+
+
+@pytest.fixture
+def phase2_mixed_stateful_posture_analysis():
+    return {
+        "identified_services": [
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Managed Identity", "category": "Identity"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "SQL Failover Group", "category": "Resilience"},
+            {"name": "Azure Storage Account", "category": "Storage"},
+            {"name": "Azure Backup", "category": "Backup"},
+        ],
+        "service_connections": [
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+            {"from": "Azure App Service", "to": "Azure Storage Account", "type": "HTTPS"},
+        ],
+    }
+
+
+@pytest.fixture
+def private_backend_analysis():
+    return {
+        "identified_services": [
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Managed Identity", "category": "Identity"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "SQL Failover Group", "category": "Resilience"},
+            {"name": "Azure Backup", "category": "Backup"},
+            {"name": "Virtual Network", "category": "Networking"},
+            {"name": "Private Endpoint", "category": "Networking"},
+        ],
+        "service_connections": [
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _rule_ids(analysis):
+    return {issue.rule_id for issue in evaluate(analysis)}
 
 
 class TestServiceHelpers:
@@ -170,6 +257,42 @@ class TestSimplePredicates:
             sftp_frontdoor_analysis, protocols=["sftp"]
         )
         assert match is not None
+
+    def test_service_keywords_without_companion_positive(
+        self, phase2_missing_posture_analysis
+    ):
+        match = preds.service_keywords_without_companion(
+            phase2_missing_posture_analysis,
+            keywords=["SQL Database"],
+            companions=["Backup"],
+        )
+        assert match is not None
+        assert match.affected_services == ["Azure SQL Database"]
+
+    def test_service_keywords_without_companion_negative(
+        self, phase2_complete_posture_analysis
+    ):
+        match = preds.service_keywords_without_companion(
+            phase2_complete_posture_analysis,
+            keywords=["SQL Database"],
+            companions=["Backup"],
+        )
+        assert match is None
+
+    def test_service_keywords_without_companion_coverage_keeps_mixed_gap(
+        self, phase2_mixed_stateful_posture_analysis
+    ):
+        match = preds.service_keywords_without_companion(
+            phase2_mixed_stateful_posture_analysis,
+            keywords=["SQL Database", "Storage"],
+            companions=["Failover Group"],
+            companion_mode="coverage",
+        )
+        assert match is not None
+        assert set(match.affected_services) == {
+            "Azure SQL Database",
+            "Azure Storage Account",
+        }
 
     def test_get_predicate_unknown_returns_none(self):
         assert preds.get_predicate("does-not-exist") is None
@@ -387,6 +510,39 @@ class TestGoldenScenarios:
         }, (
             f"Expected SFTP/FrontDoor blocker rule to fire. Got: {blocker_ids}"
         )
+
+
+class TestPhase2RulePack:
+    def test_phase2_rules_fire_when_posture_missing(self, phase2_missing_posture_analysis):
+        ids = _rule_ids(phase2_missing_posture_analysis)
+        assert {
+            "dr-cross-region-replication-warning",
+            "edge-security-waf-ddos-warning",
+            "identity-layer-missing-warning",
+            "backup-posture-missing-warning",
+            "tagging-policy-missing-info",
+        }.issubset(ids)
+
+    def test_phase2_rules_do_not_fire_when_posture_present(
+        self, phase2_complete_posture_analysis
+    ):
+        ids = _rule_ids(phase2_complete_posture_analysis)
+        assert "dr-cross-region-replication-warning" not in ids
+        assert "edge-security-waf-ddos-warning" not in ids
+        assert "identity-layer-missing-warning" not in ids
+        assert "backup-posture-missing-warning" not in ids
+        assert "tagging-policy-missing-info" not in ids
+
+    def test_stateful_rules_still_fire_on_mixed_partial_coverage(
+        self, phase2_mixed_stateful_posture_analysis
+    ):
+        ids = _rule_ids(phase2_mixed_stateful_posture_analysis)
+        assert "dr-cross-region-replication-warning" in ids
+        assert "backup-posture-missing-warning" in ids
+
+    def test_edge_rule_does_not_fire_on_private_backend(self, private_backend_analysis):
+        ids = _rule_ids(private_backend_analysis)
+        assert "edge-security-waf-ddos-warning" not in ids
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -1,6 +1,6 @@
 # Architecture Limitations Engine
 
-> Status: Phase 1 (curated rules + IaC blocker gate) — landed in PR [#615](https://github.com/idokatz86/Archmorph/pull/615). Subsequent phases tracked at [#616](https://github.com/idokatz86/Archmorph/issues/616) (AI fallback), [#617](https://github.com/idokatz86/Archmorph/issues/617) (admin review queue), [#618](https://github.com/idokatz86/Archmorph/issues/618) (frontend panel), [#619](https://github.com/idokatz86/Archmorph/issues/619) (rule-library expansion).
+> Status: Phase 1 (curated rules + IaC blocker gate) — landed in PR [#615](https://github.com/idokatz86/Archmorph/pull/615). Rule-library expansion [#662](https://github.com/idokatz86/Archmorph/issues/662) has started, bringing the curated library to 30 rules. Subsequent engine phases tracked at [#616](https://github.com/idokatz86/Archmorph/issues/616) (AI fallback), [#617](https://github.com/idokatz86/Archmorph/issues/617) (admin review queue), [#618](https://github.com/idokatz86/Archmorph/issues/618) (frontend panel), [#619](https://github.com/idokatz86/Archmorph/issues/619) (rule-library expansion).
 
 ## Why this exists
 
@@ -29,9 +29,9 @@ on POST /generate: if any severity == "blocker" → 409 unless ?force=true
 | File | Purpose |
 | --- | --- |
 | [backend/architecture_rules/models.py](../backend/architecture_rules/models.py) | `Severity`, `Rule`, `ArchitectureIssue` dataclasses. |
-| [backend/architecture_rules/predicates.py](../backend/architecture_rules/predicates.py) | 8 reusable predicates + decorator-based registry. |
+| [backend/architecture_rules/predicates.py](../backend/architecture_rules/predicates.py) | 9 reusable predicates + decorator-based registry. |
 | [backend/architecture_rules/engine.py](../backend/architecture_rules/engine.py) | YAML loader, schema validation, lazy thread-safe singleton, `evaluate()`. |
-| [backend/data/architecture_rules.yaml](../backend/data/architecture_rules.yaml) | 25 curated rules. |
+| [backend/data/architecture_rules.yaml](../backend/data/architecture_rules.yaml) | 30 curated rules. |
 | [backend/routers/diagrams.py](../backend/routers/diagrams.py) | Wires `evaluate()` into the analysis enrichment pipeline. |
 | [backend/routers/iac_routes.py](../backend/routers/iac_routes.py) | 409 gate on blockers; `?force=true` override. |
 | [backend/tests/test_architecture_rules.py](../backend/tests/test_architecture_rules.py) | Engine + golden scenario tests. |


### PR DESCRIPTION
## Summary
- refs #662
- add the first five Phase 2 curated architecture rules: DR/cross-region posture, edge WAF/DDoS posture, identity layer, backup posture, and tagging policy
- add a reusable service_keywords_without_companion predicate for posture checks
- update rule docs and roadmap counts from 25 to 30 curated rules

## Tests
- cd backend && ./.venv/bin/python -m pytest tests/test_architecture_rules.py tests/test_iac_blocker_gate.py -q
- cd backend && ./.venv/bin/python -m ruff check architecture_rules/predicates.py tests/test_architecture_rules.py
- cd backend && ./.venv/bin/python - <<'PY'
from architecture_rules import list_rules
print(len(list_rules()))
PY
- git diff --check

Note: pytest emits the existing shutdown logging warning from usage_metrics after tests complete; the suite passes.