### PR TITLE
fix: skip unconfigured scheduled perf soak

### DIFF
--- a/.github/workflows/perf-soak.yml
+++ b/.github/workflows/perf-soak.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Resolve soak configuration
         id: config
         env:
+          EVENT_NAME: ${{ github.event_name }}
           INPUT_BASE_URL: ${{ inputs.base_url }}
           VAR_BASE_URL: ${{ vars.PERF_SOAK_BASE_URL }}
           SECRET_BASE_URL: ${{ secrets.PERF_SOAK_BASE_URL }}
@@ -44,28 +45,51 @@ jobs:
           INPUT_TARGET_RPS: ${{ inputs.target_rps }}
           INPUT_RUN_TIME: ${{ inputs.run_time }}
         run: |
+          skip_scheduled() {
+            reason="$1"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Landing Zone soak skipped"
+              echo ""
+              echo "$reason"
+              echo ""
+              echo "Configure PERF_SOAK_BASE_URL and PERF_SOAK_RATE_LIMIT_PROFILE=soak to enable the scheduled soak."
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
           base_url="${INPUT_BASE_URL:-${VAR_BASE_URL:-$SECRET_BASE_URL}}"
           if [ -z "$base_url" ]; then
+            if [ "$EVENT_NAME" = "schedule" ]; then
+              skip_scheduled "PERF_SOAK_BASE_URL is not configured as a variable, secret, or workflow_dispatch input."
+              exit 0
+            fi
             echo "PERF_SOAK_BASE_URL must be configured as a variable, secret, or workflow_dispatch input" >&2
             exit 1
           fi
           if [ "$RATE_LIMIT_PROFILE" != "soak" ]; then
+            if [ "$EVENT_NAME" = "schedule" ]; then
+              skip_scheduled "PERF_SOAK_RATE_LIMIT_PROFILE=soak is required; target staging must disable or raise per-IP limits for the 100 RPS soak."
+              exit 0
+            fi
             echo "PERF_SOAK_RATE_LIMIT_PROFILE=soak is required; target staging must disable or raise per-IP limits for the 100 RPS soak" >&2
             exit 1
           fi
           target_rps="${INPUT_TARGET_RPS:-$DEFAULT_TARGET_RPS}"
           run_time="${INPUT_RUN_TIME:-$DEFAULT_RUN_TIME}"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
           echo "base_url=$base_url" >> "$GITHUB_OUTPUT"
           echo "target_rps=$target_rps" >> "$GITHUB_OUTPUT"
           echo "run_time=$run_time" >> "$GITHUB_OUTPUT"
 
       - name: Install Locust
+        if: ${{ steps.config.outputs.should_run == 'true' }}
         run: |
           python -m venv "${{ runner.temp }}/locust-venv"
           "${{ runner.temp }}/locust-venv/bin/python" -m pip install --upgrade pip
           "${{ runner.temp }}/locust-venv/bin/python" -m pip install 'locust==2.32.6'
 
       - name: Run Landing Zone soak
+        if: ${{ steps.config.outputs.should_run == 'true' }}
         env:
           LANDING_ZONE_SOAK_SUMMARY_PATH: ${{ runner.temp }}/landing-zone-soak/landing-zone-soak-summary.json
           LANDING_ZONE_TARGET_RPS: ${{ steps.config.outputs.target_rps }}
@@ -84,7 +108,7 @@ jobs:
             --only-summary
 
       - name: Upload soak summary
-        if: always()
+        if: ${{ always() && steps.config.outputs.should_run == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: landing-zone-soak-summary

--- a/backend/tests/test_k6_performance_contract.py
+++ b/backend/tests/test_k6_performance_contract.py
@@ -96,6 +96,7 @@ def test_perf_soak_workflow_runs_nightly_landing_zone_locust():
 
     assert "name: Landing Zone Perf Soak" in workflow
     assert "cron:" in workflow
+    assert "EVENT_NAME: ${{ github.event_name }}" in workflow
     assert "tests/perf/locustfile_landing_zone.py" in workflow
     assert "PERF_SOAK_BASE_URL" in workflow
     assert "PERF_SOAK_API_KEY" in workflow
@@ -103,6 +104,27 @@ def test_perf_soak_workflow_runs_nightly_landing_zone_locust():
     assert "target staging must disable or raise per-IP limits" in workflow
     assert "LANDING_ZONE_TARGET_RPS" in workflow
     assert "landing-zone-soak-summary" in workflow
+
+
+def test_perf_soak_workflow_skips_scheduled_when_unconfigured():
+    workflow = PERF_SOAK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "skip_scheduled()" in workflow
+    assert "Landing Zone soak skipped" in workflow
+    assert "echo \"should_run=false\" >> \"$GITHUB_OUTPUT\"" in workflow
+    assert "if [ \"$EVENT_NAME\" = \"schedule\" ]; then" in workflow
+    assert "PERF_SOAK_BASE_URL is not configured" in workflow
+    assert "Configure PERF_SOAK_BASE_URL and PERF_SOAK_RATE_LIMIT_PROFILE=soak" in workflow
+
+
+def test_perf_soak_workflow_keeps_manual_dispatch_strict_and_gates_locust():
+    workflow = PERF_SOAK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "PERF_SOAK_BASE_URL must be configured" in workflow
+    assert "PERF_SOAK_RATE_LIMIT_PROFILE=soak is required" in workflow
+    assert "echo \"should_run=true\" >> \"$GITHUB_OUTPUT\"" in workflow
+    assert "if: ${{ steps.config.outputs.should_run == 'true' }}" in workflow
+    assert "if: ${{ always() && steps.config.outputs.should_run == 'true' }}" in workflow
 
 
 def test_observability_alerts_cover_full_spine_p95_and_burn_rate():

--- a/docs/runbooks/landing_zone_slo.md
+++ b/docs/runbooks/landing_zone_slo.md
@@ -48,6 +48,12 @@ Nightly staging soak:
 - Rate-limit guard: `vars.PERF_SOAK_RATE_LIMIT_PROFILE=soak`
 - Summary artifact: `landing-zone-soak-summary`
 
+Scheduled runs skip cleanly when `PERF_SOAK_BASE_URL` or
+`PERF_SOAK_RATE_LIMIT_PROFILE=soak` is not configured, and write the reason to
+the GitHub Actions step summary. Manual `workflow_dispatch` runs remain strict:
+missing target or rate-limit guard configuration fails before Locust is
+installed.
+
 ## Alerts
 
 `infra/observability/alerts.tf` wires Landing Zone p95 and burn-rate alerts from Application Insights `customMetrics`:


### PR DESCRIPTION
## Summary
- make scheduled Landing Zone Perf Soak runs skip cleanly when PERF_SOAK_BASE_URL or PERF_SOAK_RATE_LIMIT_PROFILE=soak is not configured
- keep workflow_dispatch/manual runs strict and fail-fast for missing soak configuration
- gate Locust install/run/upload behind should_run=true and document the scheduled skip behavior

## Tests
- cd backend && ./.venv/bin/python -m pytest tests/test_k6_performance_contract.py -q
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/perf-soak.yml"); puts "workflow yaml ok"'\n- git diff --check