### PR TITLE
fix: improve landing zone accessibility

### DIFF
--- a/e2e/core-funnel.spec.ts
+++ b/e2e/core-funnel.spec.ts
@@ -69,6 +69,30 @@ const MOCK_ANALYSIS = {
   ts: Date.now(),
 };
 
+const ACCESSIBLE_LANDING_ZONE_SVG = `
+<svg role="img" aria-labelledby="lz-title" aria-describedby="lz-desc" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180">
+  <title id="lz-title">Azure Landing Zone</title>
+  <desc id="lz-desc">Target architecture with compute and data tiers</desc>
+  <g data-tier="Compute">
+    <title>Compute tier</title>
+    <desc>Hosts application workloads</desc>
+    <g>
+      <title>Azure Kubernetes Service</title>
+      <desc>Compute tier service for container workloads</desc>
+      <rect x="20" y="30" width="120" height="50" fill="#2563eb"></rect>
+    </g>
+  </g>
+  <g data-tier="Data">
+    <title>Data tier</title>
+    <desc>Stores operational data</desc>
+    <g>
+      <title>Azure SQL Database</title>
+      <desc>Data tier service for relational data</desc>
+      <rect x="180" y="30" width="120" height="50" fill="#16a34a"></rect>
+    </g>
+  </g>
+</svg>`;
+
 function injectMockSession(page: any) {
   return page.addInitScript((data: any) => {
     sessionStorage.setItem('archmorph_active_diagram', data.diagramId);
@@ -271,5 +295,57 @@ test.describe('Accessibility: axe-core scan', () => {
 
     const critical = results.violations.filter(v => v.impact === 'critical');
     expect(critical).toHaveLength(0);
+  });
+
+  test('rendered landing-zone SVG has no serious accessibility violations', async ({ page }) => {
+    await injectMockSession(page);
+    await page.route('**/api/diagrams/e2e-test-001/export-architecture-package?format=svg', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          content: ACCESSIBLE_LANDING_ZONE_SVG,
+          filename: 'archmorph-landing-zone.svg',
+        }),
+      });
+    });
+
+    await page.goto('/#translator');
+    await expect(page.locator('#root')).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: 'Export All' }).click();
+    for (const label of [
+      'Infrastructure Code',
+      'High-Level Design',
+      'Cost Estimate',
+      'Migration Timeline',
+      'Compliance Report',
+      'PDF Analysis Report',
+    ]) {
+      const checkbox = page.getByLabel(`Include ${label}`);
+      if (await checkbox.isChecked()) {
+        await checkbox.uncheck();
+      }
+    }
+    await page.getByLabel('Architecture Package format').selectOption('svg-primary');
+    await page.getByRole('button', { name: /Generate All Selected/i }).click();
+
+    const viewer = page.getByTestId('landing-zone-viewer');
+    await expect(viewer).toBeVisible({ timeout: 10000 });
+    const svg = page.getByTestId('landing-zone-svg-preview').locator('svg');
+    await expect(svg).toHaveAttribute('role', 'img');
+    await expect(svg.locator('title').first()).toHaveText('Azure Landing Zone');
+
+    await page.getByRole('button', { name: 'Azure Kubernetes Service' }).focus();
+    await expect(page.getByTestId('landing-zone-live-region')).toContainText('Compute tier: Azure Kubernetes Service');
+
+    const results = await new AxeBuilder({ page })
+      .include('[data-testid="landing-zone-viewer"]')
+      .withTags(['wcag2a', 'wcag2aa'])
+      .disableRules(['color-contrast'])
+      .analyze();
+
+    const seriousOrCritical = results.violations.filter(v => v.impact === 'serious' || v.impact === 'critical');
+    expect(seriousOrCritical).toHaveLength(0);
   });
 });

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   X, Download, Check, Loader2, Package, FileCode,
   FileText, DollarSign, CalendarClock, ShieldCheck, FileDown,
@@ -7,6 +7,8 @@ import {
 import { Button, Card } from '../ui';
 import api from '../../services/apiClient';
 import { loadCachedImage } from '../../services/sessionCache';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import LandingZoneViewer from './LandingZoneViewer';
 
 const DELIVERABLES = [
   {
@@ -106,7 +108,13 @@ async function generateDeliverable(diagramId, deliverable, format, hldIncludeDia
     const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
     const mime = packageFormat === 'html' ? 'text/html' : 'image/svg+xml';
     const filename = data.filename || `archmorph-architecture-package${format === 'svg-dr' ? '-dr' : ''}.${packageFormat}`;
-    return { blob: new Blob([content], { type: mime }), filename, exportCapability: data.export_capability || null };
+    return {
+      blob: new Blob([content], { type: mime }),
+      filename,
+      exportCapability: data.export_capability || null,
+      svgContent: packageFormat === 'svg' ? content : null,
+      svgVariant: format === 'svg-dr' ? 'dr' : 'primary',
+    };
   }
 
   if (id === 'hld') {
@@ -218,7 +226,7 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
   const [itemStatus, setItemStatus] = useState({});
   const [results, setResults] = useState({});
   const [generating, setGenerating] = useState(false);
-  const modalRef = useRef(null);
+  const modalRef = useFocusTrap(open);
 
   // Keyboard: Cmd+E to open
   useEffect(() => {
@@ -294,6 +302,12 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
 
   const doneCount = Object.values(itemStatus).filter(s => s === 'done').length;
   const hasResults = doneCount > 0;
+  const statusMessage = generating
+    ? `Generating ${selectedItems.length} selected deliverables`
+    : hasResults
+      ? `${doneCount} deliverable${doneCount === 1 ? '' : 's'} ready`
+      : `${selectedItems.length} of ${DELIVERABLES.length} deliverables selected`;
+  const svgPreview = results['architecture-package']?.svgContent ? results['architecture-package'] : null;
 
   if (!open) return null;
 
@@ -303,7 +317,7 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
-      aria-label="Export Hub"
+      aria-labelledby="export-hub-title"
     >
       <div
         ref={modalRef}
@@ -314,13 +328,13 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
           <div className="flex items-center gap-3">
             <Package className="w-5 h-5 text-cta" />
             <div>
-              <h2 className="text-lg font-bold text-text-primary">Generate Deliverables</h2>
+              <h2 id="export-hub-title" className="text-lg font-bold text-text-primary">Generate Deliverables</h2>
               <p className="text-xs text-text-muted">Select outputs and formats, then generate all at once</p>
             </div>
           </div>
           <button
             onClick={() => setOpen(false)}
-            className="p-1.5 rounded-lg hover:bg-secondary transition-colors cursor-pointer"
+            className="p-1.5 rounded-lg hover:bg-secondary transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-cta/50"
             aria-label="Close"
           >
             <X className="w-5 h-5 text-text-muted" />
@@ -332,6 +346,7 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
           {DELIVERABLES.map(d => {
             const Icon = d.icon;
             const status = itemStatus[d.id];
+            const checkboxId = `export-hub-${d.id}`;
             return (
               <div
                 key={d.id}
@@ -341,14 +356,23 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
               >
                 <div className="flex items-center gap-3 min-w-0">
                   <input
+                    id={checkboxId}
                     type="checkbox"
                     checked={selected[d.id]}
                     onChange={() => toggleItem(d.id)}
-                    className="accent-cta w-4 h-4 shrink-0 cursor-pointer"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        toggleItem(d.id);
+                      }
+                    }}
+                    className="accent-cta w-4 h-4 shrink-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-cta/50 focus:ring-offset-2 focus:ring-offset-primary rounded-sm"
                     aria-label={`Include ${d.label}`}
                   />
-                  <Icon className={`w-4 h-4 shrink-0 ${selected[d.id] ? 'text-cta' : 'text-text-muted'}`} />
-                  <span className={`text-sm font-medium ${selected[d.id] ? 'text-text-primary' : 'text-text-muted'}`}>{d.label}</span>
+                  <label htmlFor={checkboxId} className="flex items-center gap-3 min-w-0 cursor-pointer">
+                    <Icon className={`w-4 h-4 shrink-0 ${selected[d.id] ? 'text-cta' : 'text-text-muted'}`} aria-hidden="true" />
+                    <span className={`text-sm font-medium ${selected[d.id] ? 'text-text-primary' : 'text-text-muted'}`}>{d.label}</span>
+                  </label>
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
@@ -359,6 +383,7 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
                         value={formats[d.id] || d.defaultFormat}
                         onChange={(e) => setFormat(d.id, e.target.value)}
                         className="appearance-none text-xs px-2.5 py-1.5 pr-7 rounded-lg bg-secondary border border-border text-text-primary cursor-pointer focus:outline-none focus:ring-1 focus:ring-cta"
+                        aria-label={`${d.label} format`}
                       >
                         {d.formats.map(f => (
                           <option key={f.id} value={f.id}>{f.label}</option>
@@ -377,7 +402,7 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
                   {status === 'done' && results[d.id] && (
                     <button
                       onClick={() => downloadBlob(results[d.id].blob, results[d.id].filename)}
-                      className="p-1 rounded hover:bg-secondary transition-colors cursor-pointer"
+                      className="p-1 rounded hover:bg-secondary transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-cta/50"
                       aria-label={`Download ${d.label}`}
                       title={`Download ${results[d.id].filename}`}
                     >
@@ -388,11 +413,19 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
               </div>
             );
           })}
+          {svgPreview && (
+            <LandingZoneViewer
+              svgContent={svgPreview.svgContent}
+              variant={svgPreview.svgVariant}
+              filename={svgPreview.filename}
+            />
+          )}
         </div>
 
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t border-border bg-surface/50">
-          <p className="text-xs text-text-muted">
+          <p className="text-xs text-text-muted" role="status" aria-live="polite">
+            <span className="sr-only">{statusMessage}. </span>
             {selectedItems.length} of {DELIVERABLES.length} selected
             {hasResults && ` · ${doneCount} ready`}
           </p>

--- a/frontend/src/components/DiagramTranslator/LandingZoneViewer.jsx
+++ b/frontend/src/components/DiagramTranslator/LandingZoneViewer.jsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { Check, Layers, Server } from 'lucide-react';
+import { Card } from '../ui';
+
+function directText(element, tagName) {
+  return [...(element?.children || [])]
+    .find(child => child.tagName?.toLowerCase() === tagName)
+    ?.textContent
+    ?.trim() || '';
+}
+
+function parseLandingZoneSvg(svgContent) {
+  if (!svgContent || typeof window === 'undefined' || !window.DOMParser) {
+    return { title: 'Landing Zone SVG', description: '', services: [], tiers: [] };
+  }
+
+  const doc = new window.DOMParser().parseFromString(svgContent, 'image/svg+xml');
+  const parserError = doc.querySelector('parsererror');
+  if (parserError) {
+    return { title: 'Landing Zone SVG', description: '', services: [], tiers: [] };
+  }
+
+  const root = doc.querySelector('svg');
+  const title = directText(root, 'title') || 'Landing Zone SVG';
+  const description = directText(root, 'desc');
+  const services = [...doc.querySelectorAll('g')]
+    .map((group) => {
+      const serviceTitle = directText(group, 'title');
+      if (!serviceTitle) return null;
+      if (group.hasAttribute('data-tier') && /\btier\b/i.test(serviceTitle) && group.querySelector('g')) {
+        return null;
+      }
+      const serviceDescription = directText(group, 'desc');
+      const tier = group.closest('[data-tier]')?.getAttribute('data-tier')
+        || group.getAttribute('data-tier')
+        || serviceDescription.match(/tier[:\s-]+([^.;]+)/i)?.[1]?.trim()
+        || '';
+      return { name: serviceTitle, description: serviceDescription, tier };
+    })
+    .filter(Boolean);
+  const tierNames = [...new Set([
+    ...[...doc.querySelectorAll('[data-tier]')].map(group => group.getAttribute('data-tier')),
+    ...services.map(service => service.tier),
+  ].filter(Boolean))];
+
+  return { title, description, services, tiers: tierNames };
+}
+
+function variantLabel(variant) {
+  return variant === 'dr' ? 'DR' : 'Target';
+}
+
+export default function LandingZoneViewer({ svgContent, variant = 'primary', filename }) {
+  const [announcement, setAnnouncement] = useState('');
+  const metadata = useMemo(() => parseLandingZoneSvg(svgContent), [svgContent]);
+  const sanitizedSvg = useMemo(() => DOMPurify.sanitize(svgContent || '', {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    ADD_ATTR: ['role', 'aria-labelledby', 'aria-describedby', 'data-tier'],
+  }), [svgContent]);
+  const label = variantLabel(variant);
+
+  useEffect(() => {
+    if (!svgContent) return;
+    const serviceText = metadata.services.length === 1 ? '1 service' : `${metadata.services.length} services`;
+    const tierText = metadata.tiers.length > 0 ? ` across ${metadata.tiers.length} tiers` : '';
+    setAnnouncement(`${label} landing zone SVG rendered with ${serviceText}${tierText}.`);
+  }, [label, metadata.services.length, metadata.tiers.length, svgContent]);
+
+  const announceTier = (tier) => {
+    const count = metadata.services.filter(service => service.tier === tier).length;
+    setAnnouncement(`${tier} tier selected with ${count} service${count === 1 ? '' : 's'}.`);
+  };
+
+  const announceService = (service) => {
+    const tierText = service.tier ? `${service.tier} tier: ` : '';
+    const descriptionText = service.description ? ` ${service.description}` : '';
+    setAnnouncement(`${tierText}${service.name}.${descriptionText}`);
+  };
+
+  if (!svgContent) return null;
+
+  return (
+    <Card className="mt-4 p-4 border-cta/30 bg-cta/5">
+      <div className="flex flex-col gap-3" data-testid="landing-zone-viewer">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+              <Layers className="w-4 h-4 text-cta" aria-hidden="true" />
+              {label} Landing Zone Preview
+            </h3>
+            <p className="text-xs text-text-muted mt-1">
+              {metadata.title}{filename ? ` · ${filename}` : ''}
+            </p>
+          </div>
+          <div className="inline-flex items-center gap-1 text-xs text-cta" aria-hidden="true">
+            <Check className="w-3.5 h-3.5" />
+            Ready
+          </div>
+        </div>
+
+        <div className="sr-only" role="status" aria-live="polite" data-testid="landing-zone-live-region">
+          {announcement}
+        </div>
+
+        {metadata.description && <p className="text-xs text-text-secondary">{metadata.description}</p>}
+
+        {metadata.tiers.length > 0 && (
+          <div className="flex flex-wrap gap-2" aria-label="Landing zone tiers">
+            {metadata.tiers.map(tier => (
+              <button
+                key={tier}
+                type="button"
+                onClick={() => announceTier(tier)}
+                onFocus={() => announceTier(tier)}
+                className="px-2 py-1 rounded-md border border-border bg-secondary text-xs text-text-primary hover:border-cta/60 focus:outline-none focus:ring-2 focus:ring-cta/50"
+              >
+                {tier}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {metadata.services.length > 0 && (
+          <div className="max-h-28 overflow-y-auto rounded-lg border border-border bg-primary/60 p-2" aria-label="Landing zone services">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+              {metadata.services.slice(0, 12).map((service) => (
+                <button
+                  key={`${service.tier}-${service.name}`}
+                  type="button"
+                  onClick={() => announceService(service)}
+                  onFocus={() => announceService(service)}
+                  className="flex items-center gap-2 text-left px-2 py-1.5 rounded-md text-xs text-text-secondary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-cta/50"
+                >
+                  <Server className="w-3.5 h-3.5 text-cta shrink-0" aria-hidden="true" />
+                  <span className="truncate">{service.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div
+          data-testid="landing-zone-svg-preview"
+          tabIndex={0}
+          aria-label={`${label} landing zone SVG preview`}
+          className="max-h-72 overflow-auto rounded-lg border border-border bg-surface p-2 [&_svg]:max-w-full [&_svg]:h-auto"
+          dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/DiagramTranslator/__tests__/ExportHub.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/ExportHub.test.jsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../../services/apiClient', () => ({
+  default: { post: vi.fn(), get: vi.fn() },
+}))
+
+import api from '../../../services/apiClient'
+import ExportHub from '../ExportHub'
+
+const ACCESSIBLE_LANDING_ZONE_SVG = `
+<svg role="img" aria-labelledby="lz-title" aria-describedby="lz-desc" xmlns="http://www.w3.org/2000/svg">
+  <title id="lz-title">Azure Landing Zone</title>
+  <desc id="lz-desc">Target architecture preview</desc>
+  <g data-tier="Compute">
+    <title>Compute tier</title>
+    <desc>Hosts application workloads</desc>
+    <g>
+      <title>Azure Kubernetes Service</title>
+      <desc>Compute tier service for container workloads</desc>
+    </g>
+  </g>
+  <g data-tier="Data">
+    <title>Data tier</title>
+    <desc>Stores operational data</desc>
+    <g>
+      <title>Azure SQL Database</title>
+      <desc>Data tier service for relational data</desc>
+    </g>
+  </g>
+</svg>`
+
+function openExportHub() {
+  act(() => {
+    document.dispatchEvent(new CustomEvent('archmorph:command', { detail: 'export-hub' }))
+  })
+}
+
+describe('ExportHub accessibility', () => {
+  beforeEach(() => {
+    api.post.mockReset()
+    api.get.mockReset()
+  })
+
+  it('moves focus into the dialog and restores focus on Escape', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <button type="button">Export All</button>
+        <ExportHub diagramId="diag-1" />
+      </>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Export All' })
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+
+    openExportHub()
+
+    const dialog = await screen.findByRole('dialog', { name: 'Generate Deliverables' })
+    expect(dialog).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus())
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(trigger).toHaveFocus()
+  })
+
+  it('lets Enter toggle deliverables from the keyboard', async () => {
+    const user = userEvent.setup()
+    render(<ExportHub diagramId="diag-1" />)
+
+    openExportHub()
+
+    const iacCheckbox = await screen.findByLabelText('Include Infrastructure Code')
+    expect(iacCheckbox).toBeChecked()
+
+    iacCheckbox.focus()
+    await user.keyboard('{Enter}')
+
+    expect(iacCheckbox).not.toBeChecked()
+    expect(screen.getByRole('status')).toHaveTextContent('6 of 7 deliverables selected')
+  })
+
+  it('renders generated SVG in a live Landing Zone viewer', async () => {
+    const user = userEvent.setup()
+    api.post.mockResolvedValueOnce({
+      content: ACCESSIBLE_LANDING_ZONE_SVG,
+      filename: 'archmorph-landing-zone.svg',
+      export_capability: 'capability-token',
+    })
+
+    render(<ExportHub diagramId="diag-1" />)
+
+    openExportHub()
+    for (const label of [
+      'Infrastructure Code',
+      'High-Level Design',
+      'Cost Estimate',
+      'Migration Timeline',
+      'Compliance Report',
+      'PDF Analysis Report',
+    ]) {
+      await user.click(await screen.findByLabelText(`Include ${label}`))
+    }
+
+    await user.selectOptions(screen.getByLabelText('Architecture Package format'), 'svg-primary')
+    await user.click(screen.getByRole('button', { name: /Generate All Selected/i }))
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith(
+      expect.stringContaining('format=svg'),
+      undefined,
+      undefined,
+      undefined,
+      {},
+    ))
+
+    const viewer = await screen.findByTestId('landing-zone-viewer')
+    expect(viewer).toHaveTextContent('Target Landing Zone Preview')
+    expect(viewer).toHaveTextContent('Azure Landing Zone')
+    expect(screen.getByTestId('landing-zone-svg-preview').querySelector('svg')).toHaveAttribute('role', 'img')
+
+    await user.tab()
+    await user.click(screen.getByRole('button', { name: 'Azure Kubernetes Service' }))
+
+    expect(screen.getByTestId('landing-zone-live-region')).toHaveTextContent('Compute tier: Azure Kubernetes Service')
+  })
+})


### PR DESCRIPTION
## Summary
- wire ExportHub to the existing focus trap, add dialog labeling, visible focus rings, and Enter activation for deliverable checkboxes
- add a sanitized LandingZoneViewer preview for generated Target/DR SVGs with polite tier/service announcements
- add focused Vitest coverage and Playwright axe coverage for rendered landing-zone SVG accessibility

Closes #598

## Tests
- cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/ExportHub.test.jsx
- cd backend && ./.venv/bin/python -m pytest tests/a11y/test_landing_zone_a11y.py -q
- FRONTEND_URL=http://127.0.0.1:4175 npx playwright test e2e/core-funnel.spec.ts -g "rendered landing-zone SVG"
- FRONTEND_URL=http://127.0.0.1:4175 npx playwright test e2e/core-funnel.spec.ts
- cd frontend && npm run lint
- cd frontend && npm run build