### PR TITLE
feat: expand architecture rule library to 42 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Full mapping database: 405+ services across AWS, Azure, and GCP with 122 mapping
 
 Deterministic rule engine that flags structurally invalid Azure compositions during analysis — for example, an SFTP client connecting to Azure Storage's SFTP endpoint **through Azure Front Door** (Front Door is HTTP/HTTPS only and cannot tunnel SSH). The diagram and Terraform would deploy cleanly; the runtime traffic would never connect.
 
-- 30 curated rules across 10 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature, resilience, security, governance)
+- 42 curated rules across 12 categories (protocol, network-topology, sku-prereq, identity-auth, data-plane, region, tier-feature, resilience, security, governance, operations, cost)
 - YAML-driven rule library at [`backend/data/architecture_rules.yaml`](backend/data/architecture_rules.yaml); override via `ARCHMORPH_ARCH_RULES_PATH`
 - Three severities: `blocker` (IaC will be wrong), `warning` (works but has gaps), `info` (best-practice nudges)
 - IaC generation refuses with `409` when blockers exist; pass `?force=true` to override

--- a/backend/architecture_rules/README.md
+++ b/backend/architecture_rules/README.md
@@ -5,8 +5,8 @@ YAML entries in `backend/data/architecture_rules.yaml`; predicates are Python
 helpers registered in `predicates.py`; `engine.py` loads and evaluates the
 library against a `vision_analyzer` analysis result.
 
-The current library has 30 curated rules. Issue #662 expands it to 40+ rules
-without changing the public API or moving rules out of YAML.
+The current library has 42 curated rules. Issue #662 expands it past the 40+
+rule target without changing the public API or moving rules out of YAML.
 
 ## Rule Schema
 

--- a/backend/architecture_rules/rules-roadmap.md
+++ b/backend/architecture_rules/rules-roadmap.md
@@ -7,9 +7,9 @@ rules while keeping the engine YAML-driven and backward compatible.
 
 | Metric | Value |
 | --- | ---: |
-| Current curated rules | 30 |
+| Current curated rules | 42 |
 | Target curated rules | 40+ |
-| Rules needed for target | 10+ |
+| Rules needed for target | 0 |
 | Current rule source | `backend/data/architecture_rules.yaml` |
 | Engine entry point | `architecture_rules.evaluate()` |
 | Test entry point | `backend/tests/test_architecture_rules.py` |
@@ -20,8 +20,8 @@ rules while keeping the engine YAML-driven and backward compatible.
 | --- | --- | --- | --- |
 | Phase 1 | Complete | Authoring guide and roadmap tracker. | `README.md` and this roadmap exist under `backend/architecture_rules/`. |
 | Phase 2 | Complete | First 5 additive rules: disaster recovery, edge security, identity, backup posture, tagging policy. | Rules, predicates if needed, and positive/negative tests merged. |
-| Phase 3 | Planned | Next 6 additive rules: Private Link, secrets management, observability overlap, regulated workload hints, multi-domain validation, tenancy detector. | Rules, predicates if needed, and positive/negative tests merged. |
-| Phase 4 | Planned | Additional 4+ backlog rules selected from production learnings or CTO gap candidates. | Library reaches at least 40 curated rules. |
+| Phase 3 | Complete | Next 12 additive rules: Private Link, secrets management, observability anchor/overlap, regulated workload hints, multi-domain validation, tenancy detector, DLQ/checkpointing, API rate limiting, zone posture, and premium edge cost. | Rules and positive/negative tests merged. |
+| Phase 4 | Planned | Additional backlog rules selected from production learnings or CTO gap candidates. | Library stays above 40 curated rules while reducing noisy or overlapping findings. |
 
 ## Candidate Rule Backlog
 
@@ -32,16 +32,16 @@ rules while keeping the engine YAML-driven and backward compatible.
 | Identity layer missing for user-facing app | identity-auth | warning | `service_keywords_without_companion`. | Complete |
 | Backup posture missing for database/storage | resilience | warning | `service_keywords_without_companion`. | Complete |
 | Required tags not represented in governance design | governance | info | `service_keywords_without_companion` with multi-service threshold. | Complete |
-| Database or storage public path without Private Link | network-topology | warning | Existing service co-occurrence plus new endpoint predicate if needed. | Planned |
-| Secrets without Key Vault or managed secret store | security | warning | New `secret_storage_provider`. | Planned |
-| Duplicate observability stacks or no observability anchor | operations | info | Existing category/service predicates. | Planned |
-| Regulated workload without compliance boundary | governance | warning | Existing category/service predicates plus tags. | Planned |
-| Multi-domain architecture without clear boundary services | architecture | info | New or composite domain-count predicate. | Planned |
-| Multi-tenant signals without tenant isolation | architecture | warning | New tenancy detector predicate. | Planned |
-| Queue or eventing without dead-letter path | data-plane | warning | Existing `category_present_without_companion`. | Candidate |
-| Internet-facing app without rate limiting | security | warning | Existing service/category predicates. | Candidate |
-| Stateful workload without zone or region posture | resilience | warning | Existing service/count predicates. | Candidate |
-| Cost-sensitive design using premium edge services everywhere | cost | info | Existing service-count predicates. | Candidate |
+| Database or storage public path without Private Link | network-topology | warning | `service_keywords_without_companion`. | Complete |
+| Secrets without Key Vault or managed secret store | identity-auth | warning | `service_keywords_without_companion`. | Complete |
+| Duplicate observability stacks or no observability anchor | operations | info/warning | Existing service predicates. | Complete |
+| Regulated workload without compliance boundary | governance | warning | `service_keywords_without_companion`. | Complete |
+| Multi-domain architecture without clear boundary services | network-topology | info | `service_keywords_without_companion`. | Complete |
+| Multi-tenant signals without tenant isolation | identity-auth | warning | `service_keywords_without_companion`. | Complete |
+| Queue or eventing without dead-letter path | data-plane | warning | `service_keywords_without_companion`. | Complete |
+| Internet-facing app without rate limiting | security | warning | `service_keywords_without_companion`. | Complete |
+| Stateful workload without zone or region posture | resilience | warning | `service_keywords_without_companion`. | Complete |
+| Cost-sensitive design using premium edge services everywhere | cost | info | `services_all_present`. | Complete |
 
 ## Progress Log
 
@@ -49,6 +49,7 @@ rules while keeping the engine YAML-driven and backward compatible.
 | --- | --- | ---: |
 | 2026-05-06 | Phase 1 scaffold: authoring guide and roadmap tracker. | 25 |
 | 2026-05-06 | Phase 2 first rule pack: DR, edge security, identity, backup, and tagging posture. | 30 |
+| 2026-05-06 | Phase 3 rule pack: Private Link, secrets, observability, compliance, tenancy, eventing, API, zone, and edge-cost posture. | 42 |
 
 ## Validation Gates
 

--- a/backend/data/architecture_rules.yaml
+++ b/backend/data/architecture_rules.yaml
@@ -842,3 +842,386 @@ rules:
         - Resource Graph
       threshold: 3
     tags: [tagging, governance, policy]
+
+  # ────────────────────────────────────────────────────────────
+  # Category 9 — Phase 3 posture expansion (#662)
+  # ────────────────────────────────────────────────────────────
+
+  - id: public-data-service-without-private-link-warning
+    title: Data services should show Private Link or network isolation
+    severity: warning
+    category: network-topology
+    message: |
+      Data-bearing services were detected without visible Private Link,
+      private endpoint, VNet, service endpoint, or firewall isolation evidence.
+      Public data-plane exposure increases exfiltration risk and makes it
+      harder to prove least-privilege network access during migration review.
+    remediation: |
+      Add Private Endpoints or service endpoints for databases, storage, and
+      vaults where possible. Document firewall rules, trusted service bypass,
+      DNS resolution, and any intentionally public endpoint exceptions.
+    docs_url: https://learn.microsoft.com/azure/private-link/private-link-overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - SQL Database
+        - PostgreSQL
+        - MySQL
+        - Cosmos DB
+        - Storage
+        - Blob
+        - Key Vault
+      companions:
+        - Private Endpoint
+        - Private Link
+        - Service Endpoint
+        - Virtual Network
+        - VNet
+        - Firewall
+    tags: [privatelink, data-plane, network-isolation]
+
+  - id: workload-secrets-without-key-vault-warning
+    title: Workloads should externalize secrets through Key Vault or workload identity
+    severity: warning
+    category: identity-auth
+    message: |
+      Application workloads were detected without a clear managed secret store,
+      managed identity, or workload identity signal. This often leads to
+      environment variables, shared keys, or repository-stored credentials
+      becoming the implicit secret-management design.
+    remediation: |
+      Use Azure Key Vault with managed identity or workload identity for every
+      compute workload. Store certificates, connection strings, API keys, and
+      rotation metadata outside application code and deployment templates.
+    docs_url: https://learn.microsoft.com/azure/key-vault/general/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - App Service
+        - Container Apps
+        - AKS
+        - Kubernetes
+        - Azure Functions
+        - Virtual Machine
+        - API Management
+      companions:
+        - Key Vault
+        - Managed Identity
+        - Workload Identity
+        - Microsoft Entra
+        - Entra
+        - Secret Store
+    tags: [secrets, keyvault, managed-identity]
+
+  - id: observability-anchor-missing-warning
+    title: Production workloads need an observability anchor
+    severity: warning
+    category: operations
+    message: |
+      Production workload services were detected without a visible telemetry,
+      logging, alerting, or tracing anchor. Without a declared observability
+      path, incident response depends on ad-hoc portal checks and post-failure
+      instrumentation.
+    remediation: |
+      Add Application Insights, Azure Monitor, Log Analytics, OpenTelemetry,
+      managed Prometheus/Grafana, or an approved third-party telemetry stack.
+      Include alerts for availability, saturation, errors, and dependency
+      failures before production cutover.
+    docs_url: https://learn.microsoft.com/azure/azure-monitor/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - App Service
+        - Container Apps
+        - AKS
+        - Kubernetes
+        - Azure Functions
+        - API Management
+        - SQL Database
+        - Service Bus
+        - Event Hubs
+      companions:
+        - Application Insights
+        - Azure Monitor
+        - Log Analytics
+        - OpenTelemetry
+        - Grafana
+        - Prometheus
+        - Alert
+        - Workbook
+        - Datadog
+        - Splunk
+    tags: [observability, monitoring, alerts]
+
+  - id: observability-stack-overlap-info
+    title: Multiple observability stacks need clear ownership boundaries
+    severity: info
+    category: operations
+    message: |
+      Several observability tools were detected. Multiple telemetry stacks can
+      be valid, but without ownership boundaries they commonly duplicate
+      ingestion cost, split incident response, and create competing alert rules.
+    remediation: |
+      Document the system of record for metrics, logs, traces, dashboards, and
+      paging. Route shared signals through one primary workspace or event path
+      and define which team owns each alert policy.
+    docs_url: https://learn.microsoft.com/azure/azure-monitor/best-practices
+    predicate: service_count_at_least
+    predicate_args:
+      keywords:
+        - Application Insights
+        - Azure Monitor
+        - Log Analytics
+        - Sentinel
+        - Grafana
+        - Prometheus
+        - Datadog
+        - Splunk
+      threshold: 3
+    tags: [observability, cost, operations]
+
+  - id: regulated-workload-without-policy-anchor-warning
+    title: Regulated workloads need compliance and audit anchors
+    severity: warning
+    category: governance
+    message: |
+      Regulated workload signals were detected without clear Azure Policy,
+      Defender, Purview, Sentinel, Key Vault, private endpoint, or immutable
+      audit evidence. Regulated migrations need controls visible in the target
+      architecture, not only in deployment runbooks.
+    remediation: |
+      Add compliance boundaries such as Azure Policy initiatives, Defender for
+      Cloud recommendations, Purview data governance, Sentinel audit routing,
+      Key Vault, Private Link, and immutable log or storage retention.
+    docs_url: https://learn.microsoft.com/azure/governance/policy/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - HIPAA
+        - PCI
+        - FedRAMP
+        - PHI
+        - PII
+        - Government
+        - Confidential
+        - Healthcare
+        - Financial
+      companions:
+        - Azure Policy
+        - Defender
+        - Purview
+        - Sentinel
+        - Key Vault
+        - Private Endpoint
+        - Immutable
+        - Audit
+    tags: [regulated, compliance, audit]
+
+  - id: multi-domain-edge-validation-info
+    title: Multi-domain edge designs need DNS and certificate validation ownership
+    severity: info
+    category: network-topology
+    message: |
+      Domain, DNS, certificate, and edge-service signals were detected without
+      explicit validation or certificate-rotation ownership. Multi-domain edge
+      migrations often stall on DNS proof, SAN/wildcard constraints, or manual
+      certificate renewal paths.
+    remediation: |
+      Document DNS ownership validation, managed certificate eligibility,
+      wildcard/SAN limits, Key Vault-backed certificate rotation, and the team
+      responsible for domain cutover approvals.
+    docs_url: https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-add-custom-domain
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Custom Domain
+        - DNS Zone
+        - Certificate
+        - Front Door
+        - Application Gateway
+      companions:
+        - DNS Validation
+        - Managed Certificate
+        - Certificate Rotation
+        - Key Vault
+      threshold: 3
+    tags: [dns, certificate, edge]
+
+  - id: multi-tenant-app-without-tenant-isolation-warning
+    title: Multi-tenant apps need an explicit tenant-isolation model
+    severity: warning
+    category: identity-auth
+    message: |
+      Multi-tenant or SaaS workload signals were detected without tenant
+      isolation, external identity, partitioning, or per-tenant boundary
+      evidence. Missing tenant boundaries make data leakage, noisy-neighbor
+      behavior, and support escalations much harder to contain.
+    remediation: |
+      Define the tenancy model explicitly: pooled, siloed, or hybrid. Add
+      Entra External ID/B2C where appropriate, tenant-aware partition keys,
+      row-level security, per-tenant encryption or resource boundaries, and
+      tenant-scoped observability dimensions.
+    docs_url: https://learn.microsoft.com/azure/architecture/guide/multitenant/overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Multi-tenant
+        - SaaS
+        - Tenant
+        - Customer Portal
+      companions:
+        - Tenant Isolation
+        - Entra External ID
+        - B2C
+        - Partition Key
+        - Row-level Security
+        - Elastic Pool
+        - Per-tenant
+    tags: [multitenant, saas, isolation]
+
+  - id: service-bus-without-dead-letter-operations-warning
+    title: Service Bus workloads need dead-letter operations
+    severity: warning
+    category: data-plane
+    message: |
+      Service Bus queues, topics, or subscriptions were detected without a
+      dead-letter handling signal. Dead-letter queues are only useful when the
+      architecture includes monitoring, triage ownership, replay, and poison
+      message handling.
+    remediation: |
+      Configure dead-letter monitoring and alerts, define replay/runbook
+      ownership, track max delivery count, and make poison-message handling a
+      first-class operational workflow before cutover.
+    docs_url: https://learn.microsoft.com/azure/service-bus-messaging/service-bus-dead-letter-queues
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Service Bus
+        - Queue
+        - Topic
+        - Subscription
+      companions:
+        - Dead Letter
+        - DLQ
+        - Poison Queue
+        - Replay
+      exclude_keywords:
+        - Storage Queue
+    tags: [servicebus, dlq, operations]
+
+  - id: event-hubs-without-checkpoint-storage-warning
+    title: Event Hubs consumers need durable checkpointing
+    severity: warning
+    category: data-plane
+    message: |
+      Event Hubs was detected without a checkpoint, consumer-group, or offset
+      store signal. Event Processor clients need durable checkpointing to resume
+      consumption predictably after restarts, scale-out, or failover.
+    remediation: |
+      Add Blob Storage-backed checkpointing, define consumer groups per
+      application boundary, monitor lag, and document replay behavior for
+      poison or out-of-order event handling.
+    docs_url: https://learn.microsoft.com/azure/event-hubs/event-processor-balance-partition-load
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Event Hubs
+        - Event Hub
+      companions:
+        - Checkpoint
+        - Consumer Group
+        - Offset Store
+        - Blob Lease
+    tags: [eventhubs, checkpoint, streaming]
+
+  - id: public-api-without-rate-limiting-warning
+    title: Public APIs need rate limiting or request controls
+    severity: warning
+    category: security
+    message: |
+      Public API entry points were detected without rate limiting, quota,
+      throttling, WAF policy, or cache-based request control evidence. Public
+      endpoints without request controls are vulnerable to abuse, cost spikes,
+      and noisy-neighbor traffic.
+    remediation: |
+      Add API Management rate-limit/quota policies, Front Door or Application
+      Gateway WAF controls, application throttling, or Redis-backed request
+      counters. Document expected burst, sustained RPS, and client quotas.
+    docs_url: https://learn.microsoft.com/azure/api-management/rate-limit-policy
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - API Management
+        - API Gateway
+        - Public API
+        - Front Door
+        - Application Gateway
+        - App Service
+        - Azure Functions
+      companions:
+        - Rate Limit
+        - Throttling
+        - Quota
+        - WAF
+        - APIM Policy
+        - Redis
+    tags: [api, rate-limit, security]
+
+  - id: zone-redundancy-posture-missing-warning
+    title: Zone-capable production services need zone redundancy decisions
+    severity: warning
+    category: resilience
+    message: |
+      Zone-capable production services were detected without availability zone,
+      zone-redundant, or ZRS evidence. Region-local resilience depends on an
+      explicit zone posture; default single-zone or non-zonal deployments can
+      become hidden availability risks.
+    remediation: |
+      Decide per service whether to use zone redundancy, zonal pinning, or a
+      documented exception. Capture ZRS storage, zone-redundant gateways,
+      zone-balanced AKS/node pools, and database HA tier choices in the design.
+    docs_url: https://learn.microsoft.com/azure/reliability/availability-zones-overview
+    predicate: service_keywords_without_companion
+    predicate_args:
+      keywords:
+        - Application Gateway
+        - Azure Firewall
+        - AKS
+        - Kubernetes
+        - App Service
+        - Container Apps
+        - SQL Database
+        - PostgreSQL
+        - Storage
+        - Redis
+        - Cosmos DB
+      companions:
+        - Availability Zone
+        - Availability Zones
+        - Zone Redundant
+        - Zone-redundant
+        - ZRS
+        - AZ
+    tags: [zones, resilience, ha]
+
+  - id: premium-edge-cost-acknowledgement-info
+    title: Private-origin Front Door designs should acknowledge Premium edge cost
+    severity: info
+    category: cost
+    message: |
+      Front Door with private endpoint or Private Link origin evidence was
+      detected. That architecture normally requires Front Door Premium, which
+      can be the right choice but should be an explicit cost and capability
+      decision rather than an incidental dependency.
+    remediation: |
+      Confirm traffic volume, WAF requirements, private-origin value, and
+      monthly edge cost before committing. If private origin is not required,
+      compare Standard Front Door with origin hardening using service tags,
+      FDID headers, and application-level access controls.
+    docs_url: https://learn.microsoft.com/azure/frontdoor/private-link
+    predicate: services_all_present
+    predicate_args:
+      names:
+        - Front Door
+        - Private Endpoint
+    tags: [frontdoor, cost, premium]

--- a/backend/tests/test_architecture_rules.py
+++ b/backend/tests/test_architecture_rules.py
@@ -162,6 +162,103 @@ def private_backend_analysis():
     }
 
 
+@pytest.fixture
+def phase3_missing_controls_analysis():
+    return {
+        "identified_services": [
+            {"name": "Browser", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Custom Domain", "category": "Networking"},
+            {"name": "DNS Zone", "category": "Networking"},
+            {"name": "API Management", "category": "API"},
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "Azure Storage Account", "category": "Storage"},
+            {"name": "Service Bus Queue", "category": "Messaging"},
+            {"name": "Event Hubs Namespace", "category": "Streaming"},
+            {"name": "HIPAA Workload", "category": "Compliance"},
+            {"name": "Multi-tenant SaaS Portal", "category": "Application"},
+        ],
+        "service_connections": [
+            {"from": "Browser", "to": "Azure Front Door", "type": "HTTPS"},
+            {"from": "Azure Front Door", "to": "API Management", "type": "HTTPS"},
+            {"from": "API Management", "to": "Azure App Service", "type": "HTTPS"},
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+            {"from": "Azure App Service", "to": "Service Bus Queue", "type": "AMQP"},
+            {"from": "Azure App Service", "to": "Event Hubs Namespace", "type": "AMQP"},
+        ],
+    }
+
+
+@pytest.fixture
+def phase3_complete_controls_analysis():
+    return {
+        "identified_services": [
+            {"name": "Browser", "category": "Client"},
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Custom Domain", "category": "Networking"},
+            {"name": "DNS Zone", "category": "Networking"},
+            {"name": "DNS Validation", "category": "Networking"},
+            {"name": "Managed Certificate", "category": "Security"},
+            {"name": "API Management", "category": "API"},
+            {"name": "Rate Limit Policy", "category": "Security"},
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Managed Identity", "category": "Identity"},
+            {"name": "Azure Key Vault", "category": "Security"},
+            {"name": "Application Insights", "category": "Operations"},
+            {"name": "Azure Policy", "category": "Governance"},
+            {"name": "Defender for Cloud", "category": "Governance"},
+            {"name": "Private Endpoint", "category": "Networking"},
+            {"name": "Availability Zones", "category": "Resilience"},
+            {"name": "Azure SQL Database", "category": "Database"},
+            {"name": "Azure Storage Account", "category": "Storage"},
+            {"name": "Service Bus Queue", "category": "Messaging"},
+            {"name": "Service Bus DLQ", "category": "Messaging"},
+            {"name": "Event Hubs Namespace", "category": "Streaming"},
+            {"name": "Event Hubs Checkpoint Blob", "category": "Storage"},
+            {"name": "HIPAA Workload", "category": "Compliance"},
+            {"name": "Tenant Isolation", "category": "Architecture"},
+            {"name": "Partition Key", "category": "Data"},
+            {"name": "Multi-tenant SaaS Portal", "category": "Application"},
+        ],
+        "service_connections": [
+            {"from": "Browser", "to": "Azure Front Door", "type": "HTTPS"},
+            {"from": "Azure Front Door", "to": "API Management", "type": "HTTPS"},
+            {"from": "API Management", "to": "Azure App Service", "type": "HTTPS"},
+            {"from": "Azure App Service", "to": "Azure SQL Database", "type": "TDS"},
+            {"from": "Azure App Service", "to": "Service Bus Queue", "type": "AMQP"},
+            {"from": "Azure App Service", "to": "Event Hubs Namespace", "type": "AMQP"},
+        ],
+    }
+
+
+@pytest.fixture
+def observability_overlap_analysis():
+    return {
+        "identified_services": [
+            {"name": "Azure App Service", "category": "Compute"},
+            {"name": "Application Insights", "category": "Operations"},
+            {"name": "Log Analytics Workspace", "category": "Operations"},
+            {"name": "Datadog", "category": "Operations"},
+        ],
+        "service_connections": [],
+    }
+
+
+@pytest.fixture
+def frontdoor_private_origin_analysis():
+    return {
+        "identified_services": [
+            {"name": "Azure Front Door", "category": "Networking"},
+            {"name": "Private Endpoint", "category": "Networking"},
+            {"name": "Azure App Service", "category": "Compute"},
+        ],
+        "service_connections": [
+            {"from": "Azure Front Door", "to": "Private Endpoint", "type": "HTTPS"},
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -421,7 +518,7 @@ rules:
 class TestYAMLLoaderFromDisk:
     def test_default_rules_load(self):
         rules = list_rules()
-        assert len(rules) >= 25
+        assert len(rules) >= 40
 
     def test_default_rules_have_unique_ids(self):
         rules = list_rules()
@@ -543,6 +640,60 @@ class TestPhase2RulePack:
     def test_edge_rule_does_not_fire_on_private_backend(self, private_backend_analysis):
         ids = _rule_ids(private_backend_analysis)
         assert "edge-security-waf-ddos-warning" not in ids
+
+
+class TestPhase3RulePack:
+    def test_phase3_rules_fire_when_controls_missing(
+        self, phase3_missing_controls_analysis
+    ):
+        ids = _rule_ids(phase3_missing_controls_analysis)
+        assert {
+            "public-data-service-without-private-link-warning",
+            "workload-secrets-without-key-vault-warning",
+            "observability-anchor-missing-warning",
+            "regulated-workload-without-policy-anchor-warning",
+            "multi-domain-edge-validation-info",
+            "multi-tenant-app-without-tenant-isolation-warning",
+            "service-bus-without-dead-letter-operations-warning",
+            "event-hubs-without-checkpoint-storage-warning",
+            "public-api-without-rate-limiting-warning",
+            "zone-redundancy-posture-missing-warning",
+        }.issubset(ids)
+
+    def test_phase3_rules_do_not_fire_when_controls_present(
+        self, phase3_complete_controls_analysis
+    ):
+        ids = _rule_ids(phase3_complete_controls_analysis)
+        assert "public-data-service-without-private-link-warning" not in ids
+        assert "workload-secrets-without-key-vault-warning" not in ids
+        assert "observability-anchor-missing-warning" not in ids
+        assert "regulated-workload-without-policy-anchor-warning" not in ids
+        assert "multi-domain-edge-validation-info" not in ids
+        assert "multi-tenant-app-without-tenant-isolation-warning" not in ids
+        assert "service-bus-without-dead-letter-operations-warning" not in ids
+        assert "event-hubs-without-checkpoint-storage-warning" not in ids
+        assert "public-api-without-rate-limiting-warning" not in ids
+        assert "zone-redundancy-posture-missing-warning" not in ids
+
+    def test_observability_overlap_rule_fires_on_multiple_stacks(
+        self, observability_overlap_analysis, phase3_complete_controls_analysis
+    ):
+        assert "observability-stack-overlap-info" in _rule_ids(
+            observability_overlap_analysis
+        )
+        assert "observability-stack-overlap-info" not in _rule_ids(
+            phase3_complete_controls_analysis
+        )
+
+    def test_premium_edge_cost_rule_requires_private_origin(
+        self, frontdoor_private_origin_analysis, sane_web_analysis
+    ):
+        assert "premium-edge-cost-acknowledgement-info" in _rule_ids(
+            frontdoor_private_origin_analysis
+        )
+        assert "premium-edge-cost-acknowledgement-info" not in _rule_ids(
+            sane_web_analysis
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -1,6 +1,6 @@
 # Architecture Limitations Engine
 
-> Status: Phase 1 (curated rules + IaC blocker gate) — landed in PR [#615](https://github.com/idokatz86/Archmorph/pull/615). Rule-library expansion [#662](https://github.com/idokatz86/Archmorph/issues/662) has started, bringing the curated library to 30 rules. Subsequent engine phases tracked at [#616](https://github.com/idokatz86/Archmorph/issues/616) (AI fallback), [#617](https://github.com/idokatz86/Archmorph/issues/617) (admin review queue), [#618](https://github.com/idokatz86/Archmorph/issues/618) (frontend panel), [#619](https://github.com/idokatz86/Archmorph/issues/619) (rule-library expansion).
+> Status: Phase 1 (curated rules + IaC blocker gate) — landed in PR [#615](https://github.com/idokatz86/Archmorph/pull/615). Rule-library expansion [#662](https://github.com/idokatz86/Archmorph/issues/662) has brought the curated library to 42 rules. Subsequent engine phases tracked at [#616](https://github.com/idokatz86/Archmorph/issues/616) (AI fallback), [#617](https://github.com/idokatz86/Archmorph/issues/617) (admin review queue), [#618](https://github.com/idokatz86/Archmorph/issues/618) (frontend panel), [#619](https://github.com/idokatz86/Archmorph/issues/619) (rule-library expansion).
 
 ## Why this exists
 
@@ -31,7 +31,7 @@ on POST /generate: if any severity == "blocker" → 409 unless ?force=true
 | [backend/architecture_rules/models.py](../backend/architecture_rules/models.py) | `Severity`, `Rule`, `ArchitectureIssue` dataclasses. |
 | [backend/architecture_rules/predicates.py](../backend/architecture_rules/predicates.py) | 9 reusable predicates + decorator-based registry. |
 | [backend/architecture_rules/engine.py](../backend/architecture_rules/engine.py) | YAML loader, schema validation, lazy thread-safe singleton, `evaluate()`. |
-| [backend/data/architecture_rules.yaml](../backend/data/architecture_rules.yaml) | 30 curated rules. |
+| [backend/data/architecture_rules.yaml](../backend/data/architecture_rules.yaml) | 42 curated rules. |
 | [backend/routers/diagrams.py](../backend/routers/diagrams.py) | Wires `evaluate()` into the analysis enrichment pipeline. |
 | [backend/routers/iac_routes.py](../backend/routers/iac_routes.py) | 409 gate on blockers; `?force=true` override. |
 | [backend/tests/test_architecture_rules.py](../backend/tests/test_architecture_rules.py) | Engine + golden scenario tests. |


### PR DESCRIPTION
## Summary
- Expand `backend/data/architecture_rules.yaml` from 30 to 42 curated architecture rules for #662
- Add Phase 3 fixture coverage for missing/present controls plus dedicated overlap and premium-edge checks
- Update rule authoring docs, roadmap, README, and architecture-rules docs with the 42-rule count

## Validation
- `cd backend && ./.venv/bin/python -m pytest tests/test_architecture_rules.py tests/test_iac_blocker_gate.py -q`
- `cd backend && ./.venv/bin/python -m pytest tests -q`
- `git diff --check`

Notes: backend pytest still emits the known usage_metrics shutdown logging warning and existing OpenAPI duplicate-operation warnings after passing.

Closes #662