### PR TITLE
chore: govern azure skills upstream dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  azure-skills-governance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check azure-skills upstream pin and collisions
+        run: python scripts/check_azure_skills_upstream.py --check-telemetry-env
+        env:
+          AZURE_MCP_COLLECT_TELEMETRY: "false"
+
   mappings-freshness:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "infra/skills-upstream/azure-skills"]
+	path = infra/skills-upstream/azure-skills
+	url = https://github.com/microsoft/azure-skills.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,46 @@ Run linters before submitting:
 cd backend && ruff check . && bandit -r . -x ./tests --skip B101
 ```
 
+## Managed Azure Skills Upstream
+
+Archmorph consumes `microsoft/azure-skills` as a managed upstream dependency.
+The upstream repository is pinned as a git submodule at
+`infra/skills-upstream/azure-skills`, with the expected commit and skill list
+recorded in `infra/skills-upstream/azure-skills.lock.json`.
+
+Custom local skills must use the `archmorph-*` namespace so VS Code extension
+auto-sync cannot shadow them if Microsoft later adds a similarly named Azure
+skill:
+
+| Legacy local name | Protected name |
+| --- | --- |
+| `azure-observability` | `archmorph-observability` |
+| `azure-postgres` | `archmorph-postgres` |
+| `ui-ux-pro-max` | `archmorph-ui-ux` |
+
+Before adopting an upstream update:
+
+1. Fetch the new upstream commit in `infra/skills-upstream/azure-skills`.
+2. Review the diff manually because skill content is authoritative agent
+	instruction text.
+3. Update `azure-skills.lock.json` with the new SHA and expected skill list.
+4. Run:
+	```bash
+	AZURE_MCP_COLLECT_TELEMETRY=false python scripts/check_azure_skills_upstream.py --check-telemetry-env
+	```
+5. On a machine with VS Code Azure MCP skills installed, also compare local
+	installed upstream skills against the pinned submodule before applying any
+	sync:
+	```bash
+	AZURE_MCP_COLLECT_TELEMETRY=false python scripts/check_azure_skills_upstream.py --check-telemetry-env --require-local-skills --diff-local-upstream
+	```
+6. Include the upstream SHA and review notes in the PR description.
+
+The checker is dry-run safe: it reports SHA drift, upstream skill-list drift,
+protected-name collisions, legacy local skill names, local-vs-pinned content
+drift, and telemetry default misconfiguration. It never overwrites
+`~/.agents/skills`.
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch from `main`.

--- a/backend/tests/test_azure_skills_upstream.py
+++ b/backend/tests/test_azure_skills_upstream.py
@@ -1,0 +1,139 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_azure_skills_upstream.py"
+SPEC = spec_from_file_location("check_azure_skills_upstream", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+check_azure_skills_upstream = module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_azure_skills_upstream
+SPEC.loader.exec_module(check_azure_skills_upstream)
+
+
+def _lock():
+    return {
+        "upstream": {
+            "pinned_sha": "27c9afeabd7912543d9a9041b9210b69adfd13f9",
+            "expected_skill_count": 2,
+            "expected_skill_names": ["azure-compute", "azure-storage"],
+        },
+        "custom_skills": [
+            {
+                "legacy_name": "azure-postgres",
+                "protected_name": "archmorph-postgres",
+            }
+        ],
+        "telemetry": {
+            "env": "AZURE_MCP_COLLECT_TELEMETRY",
+            "default": "false",
+        },
+    }
+
+
+def _codes(findings):
+    return {finding.code for finding in findings}
+
+
+def test_governance_passes_when_pin_skill_names_and_customs_match():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-storage"},
+        local_skill_names={"archmorph-postgres"},
+        submodule_sha="27c9afeabd7912543d9a9041b9210b69adfd13f9",
+        telemetry_env="false",
+        check_telemetry_env=True,
+    )
+
+    assert findings == []
+
+
+def test_detects_submodule_sha_drift():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-storage"},
+        local_skill_names={"archmorph-postgres"},
+        submodule_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+
+    assert "submodule-drift" in _codes(findings)
+
+
+def test_detects_upstream_skill_list_drift():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-networking"},
+        local_skill_names={"archmorph-postgres"},
+        submodule_sha="27c9afeabd7912543d9a9041b9210b69adfd13f9",
+    )
+
+    assert "upstream-skill-drift" in _codes(findings)
+
+
+def test_detects_legacy_local_skill_name():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-storage"},
+        local_skill_names={"azure-postgres"},
+        submodule_sha="27c9afeabd7912543d9a9041b9210b69adfd13f9",
+    )
+
+    assert "legacy-local-skill" in _codes(findings)
+
+
+def test_detects_protected_name_collision_with_upstream():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-storage", "archmorph-postgres"},
+        local_skill_names={"archmorph-postgres"},
+        submodule_sha="27c9afeabd7912543d9a9041b9210b69adfd13f9",
+    )
+
+    assert "protected-name-collision" in _codes(findings)
+
+
+def test_detects_telemetry_default_when_requested():
+    findings = check_azure_skills_upstream.evaluate_config(
+        _lock(),
+        upstream_skill_names={"azure-compute", "azure-storage"},
+        local_skill_names={"archmorph-postgres"},
+        submodule_sha="27c9afeabd7912543d9a9041b9210b69adfd13f9",
+        telemetry_env=None,
+        check_telemetry_env=True,
+    )
+
+    assert "telemetry-default" in _codes(findings)
+
+
+def test_local_upstream_diff_detects_content_drift(tmp_path):
+    upstream = tmp_path / "upstream" / "azure-compute"
+    local = tmp_path / "local" / "azure-compute"
+    upstream.mkdir(parents=True)
+    local.mkdir(parents=True)
+    (upstream / "SKILL.md").write_text("pinned\n", encoding="utf-8")
+    (local / "SKILL.md").write_text("local drift\n", encoding="utf-8")
+
+    findings = check_azure_skills_upstream.diff_local_upstream(
+        tmp_path / "upstream",
+        tmp_path / "local",
+        expected_skill_names={"azure-compute"},
+    )
+
+    assert "local-upstream-content-drift" in _codes(findings)
+
+
+def test_local_upstream_diff_passes_for_identical_skill(tmp_path):
+    upstream = tmp_path / "upstream" / "azure-compute"
+    local = tmp_path / "local" / "azure-compute"
+    upstream.mkdir(parents=True)
+    local.mkdir(parents=True)
+    (upstream / "SKILL.md").write_text("same\n", encoding="utf-8")
+    (local / "SKILL.md").write_text("same\n", encoding="utf-8")
+
+    findings = check_azure_skills_upstream.diff_local_upstream(
+        tmp_path / "upstream",
+        tmp_path / "local",
+        expected_skill_names={"azure-compute"},
+    )
+
+    assert findings == []

--- a/infra/skills-upstream/azure-skills.lock.json
+++ b/infra/skills-upstream/azure-skills.lock.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "upstream": {
+    "repo": "https://github.com/microsoft/azure-skills.git",
+    "owner_repo": "microsoft/azure-skills",
+    "path": "infra/skills-upstream/azure-skills",
+    "skills_path": "skills",
+    "pinned_sha": "27c9afeabd7912543d9a9041b9210b69adfd13f9",
+    "expected_skill_count": 26,
+    "expected_skill_names": [
+      "airunway-aks-setup",
+      "appinsights-instrumentation",
+      "azure-ai",
+      "azure-aigateway",
+      "azure-cloud-migrate",
+      "azure-compliance",
+      "azure-compute",
+      "azure-cost",
+      "azure-deploy",
+      "azure-diagnostics",
+      "azure-enterprise-infra-planner",
+      "azure-hosted-copilot-sdk",
+      "azure-kubernetes",
+      "azure-kusto",
+      "azure-messaging",
+      "azure-prepare",
+      "azure-quotas",
+      "azure-rbac",
+      "azure-resource-lookup",
+      "azure-resource-visualizer",
+      "azure-storage",
+      "azure-upgrade",
+      "azure-validate",
+      "entra-agent-id",
+      "entra-app-registration",
+      "microsoft-foundry"
+    ]
+  },
+  "custom_skills": [
+    {
+      "legacy_name": "azure-observability",
+      "protected_name": "archmorph-observability",
+      "owner": "Archmorph"
+    },
+    {
+      "legacy_name": "azure-postgres",
+      "protected_name": "archmorph-postgres",
+      "owner": "Archmorph"
+    },
+    {
+      "legacy_name": "ui-ux-pro-max",
+      "protected_name": "archmorph-ui-ux",
+      "owner": "Archmorph"
+    }
+  ],
+  "telemetry": {
+    "env": "AZURE_MCP_COLLECT_TELEMETRY",
+    "default": "false"
+  }
+}

--- a/scripts/check_azure_skills_upstream.py
+++ b/scripts/check_azure_skills_upstream.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Validate the managed microsoft/azure-skills upstream dependency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOCKFILE = REPO_ROOT / "infra" / "skills-upstream" / "azure-skills.lock.json"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    level: str
+    code: str
+    message: str
+
+
+def main() -> int:
+    args = _parse_args()
+    lock = _load_lock(args.lockfile)
+    upstream_dir = _resolve_path(args.upstream_dir or lock["upstream"]["path"])
+    upstream_skills_dir = upstream_dir / lock["upstream"].get("skills_path", "skills")
+    local_skills_dir = Path(args.local_skills_dir).expanduser()
+
+    findings = evaluate_config(
+        lock,
+        upstream_skill_names=_list_skill_dirs(upstream_skills_dir),
+        local_skill_names=_list_skill_dirs(local_skills_dir),
+        submodule_sha=_git_head(upstream_dir),
+        telemetry_env=os.environ.get(lock["telemetry"]["env"]),
+        require_local_skills=args.require_local_skills,
+        check_telemetry_env=args.check_telemetry_env,
+    )
+    if args.diff_local_upstream:
+        findings.extend(
+            diff_local_upstream(
+                upstream_skills_dir,
+                local_skills_dir,
+                expected_skill_names=set(lock["upstream"].get("expected_skill_names") or []),
+            )
+        )
+    _print_findings(findings)
+    return 1 if any(f.level == "error" for f in findings) else 0
+
+
+def evaluate_config(
+    lock: dict[str, Any],
+    *,
+    upstream_skill_names: set[str] | None,
+    local_skill_names: set[str] | None,
+    submodule_sha: str | None,
+    telemetry_env: str | None = None,
+    require_local_skills: bool = False,
+    check_telemetry_env: bool = False,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    upstream = lock.get("upstream") or {}
+    pinned_sha = str(upstream.get("pinned_sha", "")).strip()
+    expected_names = set(upstream.get("expected_skill_names") or [])
+    expected_count = upstream.get("expected_skill_count")
+
+    if not SHA_RE.fullmatch(pinned_sha):
+        findings.append(Finding("error", "invalid-pin", "Pinned azure-skills SHA must be a 40-character lowercase git SHA."))
+
+    if submodule_sha is None:
+        findings.append(Finding("error", "missing-submodule", "azure-skills submodule is not checked out or is not a git worktree."))
+    elif submodule_sha != pinned_sha:
+        findings.append(
+            Finding(
+                "error",
+                "submodule-drift",
+                f"azure-skills submodule HEAD {submodule_sha} does not match pinned SHA {pinned_sha}.",
+            )
+        )
+
+    if upstream_skill_names is None:
+        findings.append(Finding("error", "missing-upstream-skills", "Upstream azure-skills/skills directory is unavailable."))
+    else:
+        if expected_count is not None and len(upstream_skill_names) != int(expected_count):
+            findings.append(
+                Finding(
+                    "error",
+                    "upstream-count-drift",
+                    f"Expected {expected_count} upstream skills, found {len(upstream_skill_names)}.",
+                )
+            )
+        missing = sorted(expected_names - upstream_skill_names)
+        added = sorted(upstream_skill_names - expected_names)
+        if missing or added:
+            findings.append(
+                Finding(
+                    "error",
+                    "upstream-skill-drift",
+                    "Upstream skill list differs from lock file; review diff before updating. "
+                    f"missing={missing}; added={added}",
+                )
+            )
+
+    local_names = local_skill_names or set()
+    if require_local_skills and local_skill_names is None:
+        findings.append(Finding("error", "missing-local-skills", "Local ~/.agents/skills directory is unavailable."))
+
+    for custom in lock.get("custom_skills") or []:
+        legacy_name = custom["legacy_name"]
+        protected_name = custom["protected_name"]
+        if upstream_skill_names and protected_name in upstream_skill_names:
+            findings.append(
+                Finding(
+                    "error",
+                    "protected-name-collision",
+                    f"Upstream now contains protected custom skill name {protected_name!r}; choose a new Archmorph namespace.",
+                )
+            )
+        if local_skill_names is not None:
+            if legacy_name in local_names:
+                findings.append(
+                    Finding(
+                        "error",
+                        "legacy-local-skill",
+                        f"Local custom skill {legacy_name!r} must be renamed to {protected_name!r}.",
+                    )
+                )
+            if protected_name not in local_names:
+                findings.append(
+                    Finding(
+                        "warning",
+                        "missing-protected-local-skill",
+                        f"Protected custom skill {protected_name!r} is not installed locally.",
+                    )
+                )
+
+    if check_telemetry_env:
+        telemetry = lock.get("telemetry") or {}
+        env_name = telemetry.get("env", "AZURE_MCP_COLLECT_TELEMETRY")
+        expected = str(telemetry.get("default", "false")).lower()
+        if (telemetry_env or "").lower() != expected:
+            findings.append(
+                Finding(
+                    "error",
+                    "telemetry-default",
+                    f"{env_name} must be set to {expected!r} for azure-skills governance checks.",
+                )
+            )
+
+    return findings
+
+
+def diff_local_upstream(
+    upstream_skills_dir: Path,
+    local_skills_dir: Path,
+    *,
+    expected_skill_names: set[str],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    if not upstream_skills_dir.exists():
+        return [Finding("error", "missing-upstream-skills", "Upstream skills directory is unavailable for diff.")]
+    if not local_skills_dir.exists():
+        return [Finding("error", "missing-local-skills", "Local skills directory is unavailable for diff.")]
+
+    for skill_name in sorted(expected_skill_names):
+        upstream_path = upstream_skills_dir / skill_name
+        local_path = local_skills_dir / skill_name
+        if not upstream_path.exists():
+            findings.append(Finding("error", "missing-upstream-skill", f"Pinned upstream skill {skill_name!r} is missing."))
+            continue
+        if not local_path.exists():
+            findings.append(Finding("warning", "missing-local-upstream-skill", f"Local upstream skill {skill_name!r} is not installed."))
+            continue
+
+        result = subprocess.run(
+            ["diff", "-qr", str(upstream_path), str(local_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0:
+            continue
+        if result.returncode == 1:
+            findings.append(
+                Finding(
+                    "error",
+                    "local-upstream-content-drift",
+                    f"Local installed upstream skill {skill_name!r} differs from pinned submodule. "
+                    f"Review with: diff -ru {upstream_path} {local_path}",
+                )
+            )
+            continue
+        findings.append(
+            Finding(
+                "error",
+                "local-upstream-diff-failed",
+                f"Unable to diff local upstream skill {skill_name!r}: {result.stderr.strip()}",
+            )
+        )
+
+    return findings
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lockfile", type=Path, default=DEFAULT_LOCKFILE)
+    parser.add_argument("--upstream-dir", type=Path)
+    parser.add_argument("--local-skills-dir", default="~/.agents/skills")
+    parser.add_argument("--require-local-skills", action="store_true")
+    parser.add_argument("--check-telemetry-env", action="store_true")
+    parser.add_argument("--diff-local-upstream", action="store_true")
+    return parser.parse_args()
+
+
+def _load_lock(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _resolve_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return REPO_ROOT / candidate
+
+
+def _list_skill_dirs(path: Path) -> set[str] | None:
+    if not path.exists() or not path.is_dir():
+        return None
+    return {child.name for child in path.iterdir() if child.is_dir()}
+
+
+def _git_head(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip()
+
+
+def _print_findings(findings: list[Finding]) -> None:
+    if not findings:
+        print("azure-skills upstream governance passed")
+        return
+    for finding in findings:
+        stream = sys.stderr if finding.level == "error" else sys.stdout
+        print(f"{finding.level.upper()}: {finding.code}: {finding.message}", file=stream)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Pin `microsoft/azure-skills` as a submodule at `27c9afeabd7912543d9a9041b9210b69adfd13f9` under `infra/skills-upstream/azure-skills`
- Add lock metadata and a dry-run governance checker for SHA drift, upstream skill-list drift, protected-name collisions, local legacy names, telemetry defaults, and optional local-vs-pinned content drift
- Add CI coverage for the pin/collision check and backend tests for checker failure modes
- Document the review/sync ritual and protected `archmorph-*` custom skill namespace in `CONTRIBUTING.md`

## Local operational change
Renamed local custom skills under `~/.agents/skills`:
- `azure-observability` -> `archmorph-observability`
- `azure-postgres` -> `archmorph-postgres`
- `ui-ux-pro-max` -> `archmorph-ui-ux`

## Validation
- `AZURE_MCP_COLLECT_TELEMETRY=false python3 scripts/check_azure_skills_upstream.py --check-telemetry-env --require-local-skills`
- `AZURE_MCP_COLLECT_TELEMETRY=false python3 scripts/check_azure_skills_upstream.py --check-telemetry-env`
- `cd backend && ./.venv/bin/python -m pytest tests/test_azure_skills_upstream.py -q`
- `cd backend && ./.venv/bin/python -m pytest tests -q`
- `cd backend && ./.venv/bin/ruff check tests/test_azure_skills_upstream.py`
- `python3 -m py_compile scripts/check_azure_skills_upstream.py`
- `git diff --check`

## Drift evidence
`--diff-local-upstream` correctly detected local installed upstream drift for five Microsoft skills: `appinsights-instrumentation`, `azure-cloud-migrate`, `azure-compute`, `azure-prepare`, and `azure-upgrade`. No files were auto-overwritten; those diffs require manual review before any sync.

Closes #696