### PR TITLE
feat: surface IaC GitHub PR workflow

### DIFF
--- a/backend/tests/test_github_integration.py
+++ b/backend/tests/test_github_integration.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+
+def test_push_iac_pr_route_delegates_to_pr_service(test_client):
+    with patch("routers.github_integration.push_iac_as_pr") as push:
+        push.return_value = {
+            "success": True,
+            "pr_url": "https://github.com/acme/infra/pull/1",
+            "branch_name": "archmorph/iac-terraform-20260506-181000",
+        }
+
+        response = test_client.post(
+            "/api/integrations/github/push-pr",
+            json={
+                "repo": "acme/infra",
+                "iac_code": "resource \"azurerm_resource_group\" \"main\" {}",
+                "iac_format": "terraform",
+                "base_branch": "develop",
+                "target_path": "deploy/main.tf",
+                "analysis_summary": {"source_provider": "aws"},
+                "cost_estimate": {"currency": "USD"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["pr_url"] == "https://github.com/acme/infra/pull/1"
+    push.assert_called_once_with(
+        repo_full_name="acme/infra",
+        iac_code="resource \"azurerm_resource_group\" \"main\" {}",
+        iac_format="terraform",
+        base_branch="develop",
+        target_path="deploy/main.tf",
+        github_token=None,
+        analysis_summary={"source_provider": "aws"},
+        cost_estimate={"currency": "USD"},
+    )
+
+
+def test_push_iac_pr_route_returns_readable_failure(test_client):
+    with patch("routers.github_integration.push_iac_as_pr") as push:
+        push.return_value = {"success": False, "error": "GitHub token not configured. Set GITHUB_TOKEN."}
+
+        response = test_client.post(
+            "/api/integrations/github/push-pr",
+            json={
+                "repo": "acme/infra",
+                "iac_code": "targetScope = 'resourceGroup'",
+                "iac_format": "bicep",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "GitHub token not configured. Set GITHUB_TOKEN."

--- a/cli/archmorph_cli.py
+++ b/cli/archmorph_cli.py
@@ -219,6 +219,8 @@ class ArchmorphClient:
         repo: str,
         iac_code: str,
         iac_format: str,
+        base_branch: str = "main",
+        target_path: Optional[str] = None,
         analysis_summary: Optional[dict] = None,
         cost_estimate: Optional[dict] = None,
     ) -> dict:
@@ -229,7 +231,8 @@ class ArchmorphClient:
                 "repo": repo,
                 "iac_code": iac_code,
                 "iac_format": iac_format,
-                "target_path": f"infra/main.{ext_map.get(iac_format, 'txt')}",
+                "base_branch": base_branch,
+                "target_path": target_path or f"infra/main.{ext_map.get(iac_format, 'txt')}",
                 "analysis_summary": analysis_summary or {},
                 "cost_estimate": cost_estimate or {},
             },
@@ -543,6 +546,8 @@ def analyze(ctx, image_path, project_id):
     metavar="OWNER/REPO",
     help="Optional GitHub repo to open a PR with the first generated IaC artifact.",
 )
+@click.option("--pr-base", default="main", show_default=True, help="Base branch for --push-pr.")
+@click.option("--pr-path", default=None, help="Target path for --push-pr, for example infra/main.tf.")
 @click.option("--force-iac", is_flag=True, help="Pass force=true to IaC generation when architecture blockers exist.")
 @click.pass_context
 def run_full_spine(
@@ -554,6 +559,8 @@ def run_full_spine(
     project_id,
     baseline,
     push_pr,
+    pr_base,
+    pr_path,
     force_iac,
 ):
     """Run the full engineer spine from diagram upload to artifacts on disk.
@@ -628,10 +635,15 @@ def run_full_spine(
             push_pr,
             iac_outputs[preferred_format],
             preferred_format,
+            base_branch=pr_base,
+            target_path=pr_path,
             analysis_summary=_summarize_analysis(analysis, diagram_id, target_rg),
             cost_estimate=cost_estimate,
         )
         artifact_paths["github-pr"] = str(_write_json_artifact(out_root / "github-pr.json", pr_result))
+        pr_url = pr_result.get("pr_url") or pr_result.get("pull_request_url")
+        if pr_url:
+            click.echo(click.style(f"GitHub PR created: {pr_url}", fg="green"))
 
     summary = {
         "diagram_id": diagram_id,

--- a/cli/tests/test_archmorph_cli_run.py
+++ b/cli/tests/test_archmorph_cli_run.py
@@ -68,15 +68,26 @@ class FakeArchmorphClient:
             "services": [{"service": "Azure Blob Storage", "monthly_low": 10, "monthly_high": 20}],
         }
 
-    def push_iac_pr(self, repo, iac_code, iac_format, analysis_summary=None, cost_estimate=None):
+    def push_iac_pr(
+        self,
+        repo,
+        iac_code,
+        iac_format,
+        base_branch="main",
+        target_path=None,
+        analysis_summary=None,
+        cost_estimate=None,
+    ):
         self.pushed = {
             "repo": repo,
             "iac_code": iac_code,
             "iac_format": iac_format,
+            "base_branch": base_branch,
+            "target_path": target_path,
             "analysis_summary": analysis_summary,
             "cost_estimate": cost_estimate,
         }
-        return {"success": True, "pull_request_url": "https://github.com/acme/infra/pull/1"}
+        return {"success": True, "pr_url": "https://github.com/acme/infra/pull/1"}
 
 
 def test_run_emits_full_spine_artifacts(monkeypatch, tmp_path):
@@ -150,15 +161,22 @@ def test_run_push_pr_uses_first_generated_iac(monkeypatch, tmp_path):
             str(tmp_path / "out"),
             "--push-pr",
             "acme/infra",
+            "--pr-base",
+            "develop",
+            "--pr-path",
+            "deploy/main.bicep",
         ],
     )
 
     assert result.exit_code == 0, result.output
     assert client.pushed["repo"] == "acme/infra"
     assert client.pushed["iac_format"] == "bicep"
+    assert client.pushed["base_branch"] == "develop"
+    assert client.pushed["target_path"] == "deploy/main.bicep"
     assert client.pushed["analysis_summary"]["diagram_id"] == "diag-test-660"
     pr = json.loads((tmp_path / "out" / "github-pr.json").read_text())
     assert pr["success"] is True
+    assert "GitHub PR created: https://github.com/acme/infra/pull/1" in result.output
 
 
 def test_run_rejects_unknown_emit_target(tmp_path):

--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -68,6 +68,8 @@ archmorph run \
   --diagram ./fixtures/aws.png \
   --emit terraform,cost \
   --push-pr owner/repo \
+  --pr-base main \
+  --pr-path infra/main.tf \
   --out ./infra
 ```
 
@@ -78,6 +80,8 @@ The CLI sends the first generated IaC artifact to `/api/integrations/github/push
 ```
 
 When Terraform is emitted, Terraform is preferred for the PR. Otherwise the first requested IaC format is used.
+
+Authentication is handled by the API server. For local development, run the backend with `GITHUB_TOKEN` set to a PAT that can create branches, write files, and open pull requests in the target repository. For shared environments, prefer a GitHub App credential managed by the server rather than sending personal tokens from clients.
 
 ## Existing Focused Commands
 

--- a/frontend/src/components/DiagramTranslator/IaCViewer.jsx
+++ b/frontend/src/components/DiagramTranslator/IaCViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import Prism from '../../lib/prism';
 import DOMPurify from 'dompurify';
 import {
@@ -34,8 +34,17 @@ export default function IaCViewer({
   iacChatEndRef, iacChatInputRef,
   onCopyWithFeedback, onToggleChat, onOpenChatWithMessage,
   onResetChat, onSendChat, onSetChatInput, onDownload,
+  onPushPr,
 }) {
   const safeIacFormat = iacFormat === 'bicep' ? 'bicep' : 'terraform';
+  const [pushOpen, setPushOpen] = useState(false);
+  const [repo, setRepo] = useState('');
+  const [baseBranch, setBaseBranch] = useState('main');
+  const [targetPath, setTargetPath] = useState('');
+  const [githubToken, setGithubToken] = useState('');
+  const [pushLoading, setPushLoading] = useState(false);
+  const [pushError, setPushError] = useState('');
+  const [pushResult, setPushResult] = useState(null);
 
   // Compute which lines are new/changed compared to previous version
   const changedLineSet = useMemo(() => {
@@ -59,6 +68,29 @@ export default function IaCViewer({
       return DOMPurify.sanitize(rawHighlighted, { ALLOWED_TAGS: ['span'], ALLOWED_ATTR: ['class'] });
     });
   }, [iacCode, safeIacFormat]);
+
+  const handlePushSubmit = async (event) => {
+    event.preventDefault();
+    if (!onPushPr || !repo.trim()) return;
+    setPushLoading(true);
+    setPushError('');
+    setPushResult(null);
+    try {
+      const result = await onPushPr({
+        repo: repo.trim(),
+        baseBranch: baseBranch.trim() || 'main',
+        targetPath: targetPath.trim() || undefined,
+        githubToken: githubToken.trim() || undefined,
+      });
+      setPushResult(result || null);
+    } catch (err) {
+      setPushError(err?.message || 'Failed to create GitHub PR');
+    } finally {
+      setPushLoading(false);
+    }
+  };
+
+  const prUrl = pushResult?.pr_url || pushResult?.pull_request_url;
 
   return (
     <>
@@ -86,25 +118,68 @@ export default function IaCViewer({
               URL.revokeObjectURL(url);
               onDownload?.();
             }} variant="secondary" size="sm" icon={Download}>Download</Button>
-            <Button onClick={() => {
-              const repo = prompt('Enter GitHub repo (owner/repo):');
-              if (!repo) return;
-              const token = prompt('Enter GitHub Personal Access Token:');
-              if (!token) return;
-              fetch('/api/integrations/github/push-pr', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ repo, iac_code: iacCode, iac_format: safeIacFormat, github_token: token }),
-              })
-                .then(r => r.json())
-                .then(data => {
-                  if (data.pr_url) { window.open(data.pr_url, '_blank'); }
-                  else { alert(data.detail || data.error || 'Failed to create PR'); }
-                })
-                .catch(() => alert('Failed to push to GitHub'));
-            }} variant="secondary" size="sm" icon={GitPullRequest}>Push to GitHub</Button>
+            <Button onClick={() => setPushOpen(value => !value)} variant={pushOpen ? 'primary' : 'secondary'} size="sm" icon={GitPullRequest}>
+              Push PR
+            </Button>
           </div>
         </div>
+        {pushOpen && (
+          <form onSubmit={handlePushSubmit} className="mb-4 rounded-lg border border-border bg-secondary/40 p-3">
+            <div className="grid gap-2 sm:grid-cols-[minmax(0,1.4fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
+              <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
+                Repository
+                <input
+                  value={repo}
+                  onChange={event => setRepo(event.target.value)}
+                  placeholder="owner/repo"
+                  className="h-9 rounded-lg border border-border bg-primary px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-cta focus:outline-none focus:ring-2 focus:ring-cta/50"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
+                Base
+                <input
+                  value={baseBranch}
+                  onChange={event => setBaseBranch(event.target.value)}
+                  placeholder="main"
+                  className="h-9 rounded-lg border border-border bg-primary px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-cta focus:outline-none focus:ring-2 focus:ring-cta/50"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
+                Path
+                <input
+                  value={targetPath}
+                  onChange={event => setTargetPath(event.target.value)}
+                  placeholder={safeIacFormat === 'terraform' ? 'infra/main.tf' : 'infra/main.bicep'}
+                  className="h-9 rounded-lg border border-border bg-primary px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-cta focus:outline-none focus:ring-2 focus:ring-cta/50"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
+                Token
+                <input
+                  type="password"
+                  value={githubToken}
+                  onChange={event => setGithubToken(event.target.value)}
+                  placeholder="server default"
+                  className="h-9 rounded-lg border border-border bg-primary px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-cta focus:outline-none focus:ring-2 focus:ring-cta/50"
+                />
+              </label>
+              <Button type="submit" variant="primary" size="sm" loading={pushLoading} disabled={!repo.trim()}>
+                Create PR
+              </Button>
+            </div>
+            {(pushError || prUrl) && (
+              <div className="mt-3 text-xs">
+                {pushError && <p className="text-danger">{pushError}</p>}
+                {prUrl && (
+                  <a href={prUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 font-medium text-cta hover:text-cta-hover">
+                    <GitPullRequest className="h-3.5 w-3.5" aria-hidden="true" />
+                    Open pull request
+                  </a>
+                )}
+              </div>
+            )}
+          </form>
+        )}
         <div className="bg-surface rounded-lg border border-border overflow-auto max-h-[600px]">
           <pre className="p-4 text-xs leading-relaxed">
             <code>

--- a/frontend/src/components/DiagramTranslator/__tests__/IaCViewer.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/IaCViewer.test.jsx
@@ -31,6 +31,7 @@ describe('IaCViewer', () => {
     onResetChat: vi.fn(),
     onSendChat: vi.fn(),
     onSetChatInput: vi.fn(),
+    onPushPr: vi.fn(),
   }
 
   it('renders Terraform Code title', () => {
@@ -58,6 +59,28 @@ describe('IaCViewer', () => {
     render(<IaCViewer {...defaultProps} />)
     expect(screen.getByText('Copy')).toBeInTheDocument()
     expect(screen.getByText('Download')).toBeInTheDocument()
+    expect(screen.getByText('Push PR')).toBeInTheDocument()
+  })
+
+  it('creates a GitHub PR from the inline publish panel', async () => {
+    const user = userEvent.setup()
+    const onPushPr = vi.fn().mockResolvedValue({ pr_url: 'https://github.com/acme/infra/pull/7' })
+    render(<IaCViewer {...defaultProps} onPushPr={onPushPr} />)
+
+    await user.click(screen.getByText('Push PR'))
+    await user.type(screen.getByLabelText('Repository'), 'acme/infra')
+    await user.clear(screen.getByLabelText('Base'))
+    await user.type(screen.getByLabelText('Base'), 'develop')
+    await user.type(screen.getByLabelText('Path'), 'deploy/main.tf')
+    await user.click(screen.getByText('Create PR'))
+
+    expect(onPushPr).toHaveBeenCalledWith({
+      repo: 'acme/infra',
+      baseBranch: 'develop',
+      targetPath: 'deploy/main.tf',
+      githubToken: undefined,
+    })
+    expect(await screen.findByText('Open pull request')).toHaveAttribute('href', 'https://github.com/acme/infra/pull/7')
   })
 
   it('renders IaC Assistant section', () => {

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -793,6 +793,20 @@ export default function DiagramTranslator() {
     setTimeout(() => iacChatEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 100);
   };
 
+  const handlePushPr = async ({ repo, baseBranch, targetPath, githubToken }) => {
+    const payload = {
+      repo,
+      iac_code: state.iacCode,
+      iac_format: normalizeIacFormat(state.iacFormat),
+      base_branch: baseBranch || 'main',
+      target_path: targetPath || undefined,
+      github_token: githubToken || undefined,
+      analysis_summary: state.analysis || {},
+      cost_estimate: state.costEstimate || state.costBreakdown || {},
+    };
+    return api.post('/integrations/github/push-pr', payload, undefined, 120_000);
+  };
+
   const handleNotifyEmail = async (email) => {
     try {
       await api.post(`/diagrams/${state.diagramId}/notify-email`, {
@@ -894,6 +908,7 @@ export default function DiagramTranslator() {
           onResetChat={handleResetChat}
           onSendChat={handleIacChat}
           onSetChatInput={(v) => set({ iacChatInput: v })}
+          onPushPr={handlePushPr}
         />
       ) : tab.id === 'hld' ? (
         <HLDTab


### PR DESCRIPTION
## Summary
- promote the existing IaC-to-GitHub PR path with CLI `--pr-base` and `--pr-path` controls plus PR URL output
- replace the IaC viewer's prompt-based GitHub action with an inline publish panel for repo, base branch, target path, optional token, loading/error states, and PR link
- add mocked backend, CLI, and frontend tests for the PR push path
- document GitHub auth expectations for local and shared API environments

Closes #654.

## Validation
- `uv run --with tabulate --with pytest --with click --with requests python -m pytest cli/tests/test_archmorph_cli_run.py -q`
- `uv run --with-requirements backend/requirements.txt python -m pytest backend/tests/test_github_integration.py -q`
- `cd frontend && npm test -- --run src/components/DiagramTranslator/__tests__/IaCViewer.test.jsx src/components/DiagramTranslator/__tests__/useWorkflow.test.js`
- `cd frontend && npm run build`
- `git diff --check`