### PR TITLE
chore: add Terraform no-break validation guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,40 @@ jobs:
           ARCHMORPH_ENABLE_TERRAFORM_CLI_VALIDATION: "1"
 
   # ============================================
+  # CHECKED-IN TERRAFORM VALIDATION
+  # ============================================
+  terraform-config-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.x"
+
+      - name: Configure Terraform plugin cache
+        run: |
+          mkdir -p "$RUNNER_TEMP/terraform-plugin-cache"
+          echo "TF_PLUGIN_CACHE_DIR=$RUNNER_TEMP/terraform-plugin-cache" >> "$GITHUB_ENV"
+
+      - name: Check Terraform formatting
+        run: find . -path './.terraform' -prune -o -name '*.tf' -print0 | xargs -0 terraform fmt -check
+
+      - name: Validate checked-in Terraform roots without remote backends
+        run: |
+          for dir in . staging dr observability; do
+            echo "::group::terraform validate infra/$dir"
+            terraform -chdir="$dir" init -backend=false -input=false
+            terraform -chdir="$dir" validate -no-color
+            echo "::endgroup::"
+          done
+
+  # ============================================
   # CLI FULL-SPINE ARTIFACT CONTRACT
   # ============================================
   cli-full-spine-smoke:
@@ -442,6 +476,9 @@ jobs:
 
       - name: Provision metrics storage
         run: |
+          # #608: This workflow-owned storage account is intentionally kept here until
+          # it is imported into Terraform state or replaced by azurerm_storage_account.main
+          # through a separate no-break state plan. Do not change region/SKU inline.
           STORAGE_NAME="archmorphmetrics"
           STORAGE_ACCOUNT_URL="https://${STORAGE_NAME}.blob.core.windows.net"
           echo "STORAGE_NAME=$STORAGE_NAME" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -820,15 +820,18 @@ Production hardening switches:
 
 [^1]: Tracked for consolidation into West Europe — see [#607](https://github.com/idokatz86/Archmorph/issues/607). The April 2026 hub used to also run an `archmorph-backend` App Service (Canada Central), a duplicate `cafd43cfd4deacr` registry (East US), and a stray `secondnature-openai-whisper` cognitive account. All three were retired during the May 2026 infra consolidation; the dev RG now hosts only the active Container Apps stack and supporting data services.
 
+Terraform topology and no-break state-sync guardrails are documented in [infra/README.md](infra/README.md). Do not run Terraform import, state removal, or apply steps for the OpenAI region sync until #607 is complete and an operator change window is approved.
+
 ### CI/CD Pipeline
 
 The CI/CD workflow (`.github/workflows/ci.yml`) runs the main quality gates:
 
 1. **backend-tests** — installs with `uv`, runs Ruff, executes pytest with coverage threshold, exports OpenAPI, generates backend SBOM, and runs Grype
 2. **frontend-build** — installs npm dependencies, runs ESLint, runs Vitest, builds Vite output, generates frontend SBOM, and runs Grype
-3. **upload-sarif** — uploads Grype SARIF when available without blocking successful builds on upload rate limits
-4. **deploy-backend / deploy-frontend** — production Azure Container Apps and Static Web Apps deployment from `main` using GitHub Secrets and OIDC
-5. **post-deploy-smoke** — deployed frontend/API smoke checks for root, sample routes, health, and OpenAPI schema
+3. **iac-validate / terraform-config-validate** — validates generated IaC artifacts and the checked-in Terraform configuration without initializing the live remote backend
+4. **upload-sarif** — uploads Grype SARIF when available without blocking successful builds on upload rate limits
+5. **deploy-backend / deploy-frontend** — production Azure Container Apps and Static Web Apps deployment from `main` using GitHub Secrets and OIDC
+6. **post-deploy-smoke** — deployed frontend/API smoke checks for root, sample routes, health, and OpenAPI schema
 
 Additional workflows:
 - **security.yml** — SAST/DAST/SCA security pipeline (Semgrep, Bandit, CodeQL, Trivy, Gitleaks)

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,45 @@
+# Archmorph Infrastructure
+
+This directory contains the checked-in Terraform configuration for the Azure-hosted Archmorph stack. It is validated in CI with `terraform init -backend=false`, `terraform fmt -check`, and `terraform validate`; live plans and state operations remain operator-run tasks.
+
+## Current Topology
+
+| Component | Terraform owner | Region note |
+| --- | --- | --- |
+| Resource group, Container Apps, Container Registry, PostgreSQL, Redis, Application Insights, Log Analytics, and primary Blob Storage | `infra/main.tf` | `var.location`, default `westeurope` |
+| Azure OpenAI account and model deployments | `infra/main.tf` | `var.openai_location`, currently `eastus` until #607 cutover and #608 state sync finish |
+| Metrics storage account `archmorphmetrics` | `.github/workflows/ci.yml` | Workflow-owned for current deployment smoke/runtime metrics path; do not alter inline region or SKU without a Terraform import or replacement plan |
+| Terraform remote state storage | Bootstrap command comments in `infra/main.tf` | `archmorph-tfstate-rg` / `archmorphtfstate`, `westeurope` |
+
+## No-Break State Sync Guardrails
+
+Issue #608 tracks bringing Terraform state back in line with the consolidated Azure estate. The safe repo-only work is validation and documentation. The following operations must stay manual and change-window controlled:
+
+- `terraform plan` against the live dev workspace
+- `terraform import`
+- `terraform state rm`
+- `terraform apply`
+- Any Azure CLI command that creates, updates, deletes, or moves resources
+
+Before any state-changing operation:
+
+1. Confirm #607 has completed and traffic is using the West Europe OpenAI account.
+2. Run `terraform state pull > backup.tfstate` and keep the backup outside the repository.
+3. Capture `terraform plan -lock=false` output and verify there is no unrelated drift.
+4. Prefer importing the existing West Europe OpenAI account into state and removing the retired East US state entry over destroy/recreate.
+5. Apply only from an approved operator session with rollback notes and smoke checks ready.
+
+## Local Validation
+
+Run these commands when editing files under `infra/`:
+
+```bash
+cd infra
+find . -path './.terraform' -prune -o -name '*.tf' -print0 | xargs -0 terraform fmt -check
+for dir in . staging dr observability; do
+	terraform -chdir="$dir" init -backend=false -input=false
+	terraform -chdir="$dir" validate -no-color
+done
+```
+
+These commands do not connect to the configured remote backend and do not mutate Azure resources.

--- a/infra/dr/main.tf
+++ b/infra/dr/main.tf
@@ -127,10 +127,10 @@ resource "azurerm_container_app" "dr_backend" {
     }
 
     cors {
-      allowed_origins   = [var.frontend_url]
-      allowed_methods   = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
-      allowed_headers   = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
-      exposed_headers = ["X-Correlation-ID", "X-Response-Time"]
+      allowed_origins    = [var.frontend_url]
+      allowed_methods    = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+      allowed_headers    = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
+      exposed_headers    = ["X-Correlation-ID", "X-Response-Time"]
       max_age_in_seconds = 3600
     }
   }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -214,15 +214,15 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure" {
 # Azure Cache for Redis — session store & caching layer
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_redis_cache" "main" {
-  name                               = "archmorph-redis-${local.name_suffix}"
-  resource_group_name                = azurerm_resource_group.main.name
-  location                           = azurerm_resource_group.main.location
-  capacity                           = var.redis_capacity
-  family                             = var.environment == "prod" ? "C" : "C"
-  sku_name                           = var.environment == "prod" ? "Standard" : "Basic"
-  non_ssl_port_enabled               = false # TLS-only (port 6380)
-  minimum_tls_version                = "1.2"
-  public_network_access_enabled      = var.environment == "prod" ? false : true
+  name                          = "archmorph-redis-${local.name_suffix}"
+  resource_group_name           = azurerm_resource_group.main.name
+  location                      = azurerm_resource_group.main.location
+  capacity                      = var.redis_capacity
+  family                        = var.environment == "prod" ? "C" : "C"
+  sku_name                      = var.environment == "prod" ? "Standard" : "Basic"
+  non_ssl_port_enabled          = false # TLS-only (port 6380)
+  minimum_tls_version           = "1.2"
+  public_network_access_enabled = var.environment == "prod" ? false : true
   # access_key_authentication_disabled = false # Required for REDIS_URL access key auth (#320)
 
   redis_configuration {
@@ -409,10 +409,10 @@ resource "azurerm_container_app" "backend" {
     # app itself 502s/503s or times out (Container Apps returns its own
     # error page which would otherwise strip application-level CORS).
     cors {
-      allowed_origins   = [var.frontend_url, "https://www.archmorphai.com"]
-      allowed_methods   = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
-      allowed_headers   = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
-      exposed_headers = ["X-Correlation-ID", "X-Response-Time"]
+      allowed_origins    = [var.frontend_url, "https://www.archmorphai.com"]
+      allowed_methods    = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+      allowed_headers    = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
+      exposed_headers    = ["X-Correlation-ID", "X-Response-Time"]
       max_age_in_seconds = 3600
     }
   }

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -149,10 +149,10 @@ resource "azurerm_container_app" "staging_backend" {
     }
 
     cors {
-      allowed_origins   = [var.staging_frontend_url]
-      allowed_methods   = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
-      allowed_headers   = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
-      exposed_headers = ["X-Correlation-ID", "X-Response-Time"]
+      allowed_origins    = [var.staging_frontend_url]
+      allowed_methods    = ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+      allowed_headers    = ["Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID"]
+      exposed_headers    = ["X-Correlation-ID", "X-Response-Time"]
       max_age_in_seconds = 3600
     }
   }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -12,7 +12,8 @@ variable "location" {
 variable "openai_location" {
   description = "Azure region for OpenAI (limited availability)"
   type        = string
-  default     = "eastus" # GPT-4 Vision available, Sweden blocked by policy
+  default     = "eastus"
+  # Keep East US until #607 completes and the existing West Europe account is imported into Terraform state.
 }
 
 variable "openai_capacity" {


### PR DESCRIPTION
## Summary
- add a checked-in Terraform validation job that runs formatting, backend-disabled init, and terraform validate
- document the current infra topology and #608 no-break state-sync guardrails in infra/README.md
- remove the stale OpenAI region rationale while keeping eastus until #607 and explicit state import are complete
- document that archmorphmetrics remains workflow-owned until a separate import/replacement plan

Refs #608

## Validation
- find . -name '*.tf' -print0 | xargs -0 terraform fmt -check
- terraform init -backend=false -input=false
- terraform validate -no-color

## Safety
This PR deliberately does not run terraform plan against live state, terraform import, terraform state rm, terraform apply, or any Azure resource mutation.