### PR TITLE
chore: document OpenAI West Europe cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,7 @@ jobs:
 
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:8}"
+          REVISION_SUFFIX="sha-${SHORT_SHA}-run-${{ github.run_attempt }}"
           az containerapp update \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
@@ -633,7 +634,7 @@ jobs:
               AZURE_OPENAI_API_VERSION="2025-04-01-preview" \
               ACS_CONNECTION_STRING="${{ secrets.ACS_CONNECTION_STRING }}" \
               ACS_SENDER_EMAIL="${{ secrets.ACS_SENDER_EMAIL }}" \
-            --revision-suffix "sha-${SHORT_SHA}" \
+            --revision-suffix "$REVISION_SUFFIX" \
             --no-wait
 
           echo "Waiting for green revision to provision..."
@@ -642,7 +643,7 @@ jobs:
           GREEN_REV=$(az containerapp revision list \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[?contains(name, 'sha-${SHORT_SHA}')].name" -o tsv | head -1)
+            --query "[?contains(name, '$REVISION_SUFFIX')].name" -o tsv | head -1)
 
           echo "green_revision=$GREEN_REV" >> $GITHUB_OUTPUT
           echo "Green revision: $GREEN_REV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Infrastructure and security maintenance
+
+- **#607 Azure OpenAI West Europe cutover** — provisioned the parallel West Europe OpenAI account `archmorph-openai-we-acm7pd`, deployed `gpt-4.1` primary and `gpt-4o` fallback with matching runtime names, granted the Container App managed identity `Cognitive Services OpenAI User`, updated the deployment secret, and routed `archmorph-api` traffic to a healthy West Europe revision while leaving the East US account online for rollback and 24-hour zero-traffic verification.
+- **#608 Terraform OpenAI target sync** — updated checked-in Terraform defaults and deployment resources to target the live West Europe `gpt-4.1` / `gpt-4o` shape. Live import/state adoption remains operator-controlled before any Terraform apply.
+- **Backend deploy reruns** — made Azure Container App revision suffixes include the GitHub run attempt so rerunning a failed deploy does not collide with an existing `sha-*` revision.
+- **Dependabot alert #33** — bumped root `ip-address` from 10.1.0 to 10.2.0, resolving GHSA-v2v4-37r5-5v8g / CVE-2026-42338.
+
 #### CI and release maintenance
 
 - **GitHub Actions Node.js 24 readiness** — audited workflow action runtimes, moved deprecated Node.js 20 action pins to Node.js 24-compatible majors, pinned Trivy to a release tag, and documented the workflow runtime inventory for release maintenance.
@@ -123,7 +130,7 @@ Resource-group hygiene pass on `archmorph-rg-dev` (West Europe). Three orphaned 
 - **Container Registry `cafd43cfd4deacr`** (East US, Basic) — deleted. The `archmorph-mcp-gateway` Container App image (`archmorph-mcp-gateway:20260309101659330272`, plus the `:20260309103959778879` companion tag for safety) was imported server-side into the primary `archmorphacm7pd` registry (West Europe) using `az acr import`, the Container App was reconfigured with the new registry credentials and image, the new revision (`archmorph-mcp-gateway--0000004`) was verified `Healthy` at 100% traffic with `/health` returning HTTP 200, and only then was the legacy registry binding removed and the registry deleted. Cuts cross-region image pulls and the second-registry monthly line item.
 - **Cognitive Services `secondnature-openai-whisper`** (originally in `archmorph-rg-dev`) — moved to its actual project resource group `rg-secondnature`. Note: `az resource move` returned a misleading `ResourceMoveFailed` referencing an unrelated linked-notification provider error, but the move itself completed — verification (presence in `rg-secondnature`, absence from `archmorph-rg-dev`) confirmed success.
 
-Net effect: roughly $18/mo in idle resource spend eliminated, IaC footprint matches reality except for the OpenAI account region. Follow-ups: [#607](https://github.com/idokatz86/Archmorph/issues/607) tracks the West Europe OpenAI cutover, [#608](https://github.com/idokatz86/Archmorph/issues/608) tracks the Terraform `var.openai_location` sync once the live account has been moved.
+Net effect: roughly $18/mo in idle resource spend eliminated. The later #607 cutover moved production OpenAI traffic to West Europe; [#608](https://github.com/idokatz86/Archmorph/issues/608) remains the follow-up for importing the live account/deployments into Terraform state before apply.
 
 #### Other changes
 

--- a/README.md
+++ b/README.md
@@ -813,14 +813,14 @@ Production hardening switches:
 | Container Apps (`archmorph-api`, `archmorph-mcp-gateway`) | Consumption | West Europe |
 | Static Web Apps | Free | West Europe |
 | Container Registry (`archmorphacm7pd`) | Basic | West Europe |
-| Azure OpenAI | S0 | East US [^1] |
+| Azure OpenAI | S0 | West Europe [^1] |
 | PostgreSQL Flexible Server | Burstable B1ms | West Europe |
 | Azure Cache for Redis | Basic C0 | West Europe |
 | Application Insights | — | West Europe |
 
-[^1]: Tracked for consolidation into West Europe — see [#607](https://github.com/idokatz86/Archmorph/issues/607). The April 2026 hub used to also run an `archmorph-backend` App Service (Canada Central), a duplicate `cafd43cfd4deacr` registry (East US), and a stray `secondnature-openai-whisper` cognitive account. All three were retired during the May 2026 infra consolidation; the dev RG now hosts only the active Container Apps stack and supporting data services.
+[^1]: #607 cut production traffic over to the West Europe account `archmorph-openai-we-acm7pd` with `gpt-4.1` primary and `gpt-4o` fallback. The prior East US account remains online during the rollback/zero-traffic verification window. The April 2026 hub used to also run an `archmorph-backend` App Service (Canada Central), a duplicate `cafd43cfd4deacr` registry (East US), and a stray `secondnature-openai-whisper` cognitive account. All three were retired during the May 2026 infra consolidation; the dev RG now hosts only the active Container Apps stack and supporting data services.
 
-Terraform topology and no-break state-sync guardrails are documented in [infra/README.md](infra/README.md). Do not run Terraform import, state removal, or apply steps for the OpenAI region sync until #607 is complete and an operator change window is approved.
+Terraform topology and no-break state-sync guardrails are documented in [infra/README.md](infra/README.md). Do not run Terraform state removal or apply steps for the OpenAI region sync until the live West Europe account and deployments have been imported and an operator change window is approved.
 
 ### CI/CD Pipeline
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,10 +1,10 @@
 # Archmorph — Cloud Architecture Translator to Azure
 ## Product Requirements Document (PRD)
 **Version:** 4.3.0-main
-**Date:** May 3, 2026
+**Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Off-spine Agent PaaS proof and RAG API surfaces retired from the active backend contract.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; Terraform state adoption remains an operator-controlled follow-up.
 
 ---
 
@@ -50,7 +50,7 @@ The PRD distinguishes three maturity levels. **Live** features are usable in the
 - **Analysis time:** ≤30 seconds for diagrams ≤50 services
 
 ### 3.2 Service Detection
-- AI-powered identification using Azure OpenAI GPT-4o Vision
+- AI-powered identification using Azure OpenAI `gpt-4.1` with `gpt-4o` fallback in West Europe
 - Detects: Services, connections/data flows, annotations
 - **Multi-pass analysis:** Diagrams with >30 services trigger 2-pass analysis (quadrant split + merge)
 - **405+ service catalog:** 145 AWS, 143 Azure, 117 GCP services with 122 cross-cloud mappings (grows automatically via auto-discovery)
@@ -708,7 +708,7 @@ Only when 1–7 all green does the README/PRD Capability Status table flip ALZ r
 |-------|------------|
 | Frontend | React 19.2, Vite 8.0, TailwindCSS 4.2, Lucide React (icons), Prism.js (syntax highlighting), react-i18next (i18n) |
 | Backend | Python 3.12, FastAPI, Gunicorn (UvicornWorker) |
-| AI | Azure OpenAI GPT-4.1 (deployment `gpt-4.1`, model 2025-04-14) with GPT-4o fallback |
+| AI | Azure OpenAI GPT-4.1 (deployment `gpt-4.1`, model 2025-04-14) with GPT-4o fallback, served from West Europe |
 | Database | PostgreSQL (Azure Flexible Server) |
 | Storage | Azure Blob Storage |
 | Hosting | Azure Container Apps (API + MCP gateway), Static Web Apps (frontend) |

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,13 +7,13 @@ This directory contains the checked-in Terraform configuration for the Azure-hos
 | Component | Terraform owner | Region note |
 | --- | --- | --- |
 | Resource group, Container Apps, Container Registry, PostgreSQL, Redis, Application Insights, Log Analytics, and primary Blob Storage | `infra/main.tf` | `var.location`, default `westeurope` |
-| Azure OpenAI account and model deployments | `infra/main.tf` | `var.openai_location`, currently `eastus` until #607 cutover and #608 state sync finish |
+| Azure OpenAI account and model deployments | `infra/main.tf` | Live traffic uses West Europe account `archmorph-openai-we-acm7pd` with `gpt-4.1` primary and `gpt-4o` fallback; Terraform now targets `var.openai_location = westeurope`, but #608 import/state sync must run before apply |
 | Metrics storage account `archmorphmetrics` | `.github/workflows/ci.yml` | Workflow-owned for current deployment smoke/runtime metrics path; do not alter inline region or SKU without a Terraform import or replacement plan |
 | Terraform remote state storage | Bootstrap command comments in `infra/main.tf` | `archmorph-tfstate-rg` / `archmorphtfstate`, `westeurope` |
 
 ## No-Break State Sync Guardrails
 
-Issue #608 tracks bringing Terraform state back in line with the consolidated Azure estate. The safe repo-only work is validation and documentation. The following operations must stay manual and change-window controlled:
+Issue #608 tracks bringing Terraform state back in line with the consolidated Azure estate. The #607 live traffic cutover to West Europe is complete, but the East US account remains online for rollback and the live West Europe account still needs to be adopted into Terraform state. The following operations must stay manual and change-window controlled:
 
 - `terraform plan` against the live dev workspace
 - `terraform import`
@@ -23,11 +23,12 @@ Issue #608 tracks bringing Terraform state back in line with the consolidated Az
 
 Before any state-changing operation:
 
-1. Confirm #607 has completed and traffic is using the West Europe OpenAI account.
+1. Confirm production traffic is still using the West Europe OpenAI account and App Insights shows no East US dependency traffic in the verification window.
 2. Run `terraform state pull > backup.tfstate` and keep the backup outside the repository.
 3. Capture `terraform plan -lock=false` output and verify there is no unrelated drift.
-4. Prefer importing the existing West Europe OpenAI account into state and removing the retired East US state entry over destroy/recreate.
-5. Apply only from an approved operator session with rollback notes and smoke checks ready.
+4. Import `archmorph-openai-we-acm7pd` and its `gpt-4.1` / `gpt-4o` deployments into the Terraform resources before changing or removing the East US state entry.
+5. Keep the East US account alive until at least 24 hours of zero traffic is verified.
+6. Apply only from an approved operator session with rollback notes and smoke checks ready.
 
 ## Local Validation
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -304,12 +304,28 @@ resource "azurerm_key_vault_secret" "redis_connection" {
 resource "azurerm_cognitive_account" "openai" {
   name                  = "archmorph-openai-${local.name_suffix}"
   resource_group_name   = azurerm_resource_group.main.name
-  location              = var.openai_location # OpenAI has limited regions
+  location              = var.openai_location
   kind                  = "OpenAI"
   sku_name              = "S0"
   custom_subdomain_name = "archmorph-openai-${local.name_suffix}"
 
   tags = local.tags
+}
+
+resource "azurerm_cognitive_deployment" "gpt41_primary" {
+  name                 = "gpt-4.1"
+  cognitive_account_id = azurerm_cognitive_account.openai.id
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4.1"
+    version = "2025-04-14"
+  }
+
+  sku {
+    name     = "GlobalStandard"
+    capacity = var.openai_capacity
+  }
 }
 
 resource "azurerm_cognitive_deployment" "gpt4_vision" {
@@ -319,12 +335,12 @@ resource "azurerm_cognitive_deployment" "gpt4_vision" {
   model {
     format  = "OpenAI"
     name    = "gpt-4o"
-    version = "2024-05-13"
+    version = "2024-11-20"
   }
 
   sku {
-    name     = "Standard"
-    capacity = var.openai_capacity # Issue #296 — was hardcoded to 10 (≈1 concurrent call)
+    name     = "GlobalStandard"
+    capacity = var.openai_capacity
   }
 }
 
@@ -472,7 +488,17 @@ resource "azurerm_container_app" "backend" {
 
       env {
         name  = "AZURE_OPENAI_DEPLOYMENT"
+        value = azurerm_cognitive_deployment.gpt41_primary.name
+      }
+
+      env {
+        name  = "AZURE_OPENAI_FALLBACK_DEPLOYMENT"
         value = azurerm_cognitive_deployment.gpt4_vision.name
+      }
+
+      env {
+        name  = "AZURE_OPENAI_API_VERSION"
+        value = "2025-04-01-preview"
       }
 
       env {

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -55,7 +55,12 @@ output "openai_endpoint" {
 }
 
 output "openai_deployment_name" {
-  description = "GPT-4 Vision deployment name"
+  description = "Primary Azure OpenAI deployment name"
+  value       = azurerm_cognitive_deployment.gpt41_primary.name
+}
+
+output "openai_fallback_deployment_name" {
+  description = "Fallback Azure OpenAI deployment name"
   value       = azurerm_cognitive_deployment.gpt4_vision.name
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -12,14 +12,14 @@ variable "location" {
 variable "openai_location" {
   description = "Azure region for OpenAI (limited availability)"
   type        = string
-  default     = "eastus"
-  # Keep East US until #607 completes and the existing West Europe account is imported into Terraform state.
+  default     = "westeurope"
+  # #607 cutover is live in West Europe. Import the live account before applying #608 Terraform state sync.
 }
 
 variable "openai_capacity" {
-  description = "Azure OpenAI deployment capacity in thousands of tokens per minute (TPM). 10 = ~1 concurrent call; 80+ recommended for production (Issue #296)."
+  description = "Azure OpenAI deployment capacity in thousands of tokens per minute (TPM). 10 matches the live West Europe cutover; raise only after quota validation."
   type        = number
-  default     = 80
+  default     = 10
 
   validation {
     condition     = var.openai_capacity >= 10 && var.openai_capacity <= 1000


### PR DESCRIPTION
## Summary
- document the #607 West Europe Azure OpenAI cutover across README, changelog, PRD, and infra runbook
- update Terraform's intended OpenAI target to West Europe with gpt-4.1 primary and gpt-4o fallback
- make backend deploy reruns use unique Container App revision suffixes by including github.run_attempt

## Validation
- terraform fmt check over checked-in .tf files
- terraform init -backend=false and validate for infra roots: ., staging, dr, observability

## Notes
- East US OpenAI remains online for rollback and 24-hour zero-traffic verification
- Terraform live import/state adoption is still operator-controlled before any apply