### PR TITLE
feat: frame translator as spine-first workbench

### DIFF
--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -24,8 +24,8 @@ function fuzzyMatch(query, text) {
 function buildCommands(setActiveTab, toggleTheme, theme) {
   return [
     // Navigation
-    { id: 'nav-upload', label: 'Go to Upload', section: 'Navigation', shortcut: '1', icon: Upload, action: () => setActiveTab('translator') },
-    { id: 'nav-results', label: 'Go to Results', section: 'Navigation', shortcut: '2', icon: BarChart3, action: () => setActiveTab('translator') },
+    { id: 'nav-upload', label: 'Go to Workbench Input', section: 'Navigation', shortcut: '1', icon: Upload, action: () => setActiveTab('translator') },
+    { id: 'nav-results', label: 'Go to Workbench Analysis', section: 'Navigation', shortcut: '2', icon: BarChart3, action: () => setActiveTab('translator') },
     { id: 'nav-iac', label: 'Go to IaC', section: 'Navigation', shortcut: '3', icon: Code, action: () => setActiveTab('translator') },
     { id: 'nav-hld', label: 'Go to HLD', section: 'Navigation', shortcut: '4', icon: FileText, action: () => setActiveTab('translator') },
     { id: 'nav-cost', label: 'Go to Cost', section: 'Navigation', shortcut: '5', icon: DollarSign, action: () => setActiveTab('translator') },

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
-  Upload, BarChart3, Code, FileText, DollarSign,
+  Upload, Code, FileText, DollarSign,
   Download, Image, FileDown, MessageSquare, Moon, Sun,
   Copy, ExternalLink, Trash2, Search, Command,
 } from 'lucide-react';
@@ -24,8 +24,7 @@ function fuzzyMatch(query, text) {
 function buildCommands(setActiveTab, toggleTheme, theme) {
   return [
     // Navigation
-    { id: 'nav-upload', label: 'Go to Workbench Input', section: 'Navigation', shortcut: '1', icon: Upload, action: () => setActiveTab('translator') },
-    { id: 'nav-results', label: 'Go to Workbench Analysis', section: 'Navigation', shortcut: '2', icon: BarChart3, action: () => setActiveTab('translator') },
+    { id: 'nav-workbench', label: 'Go to Workbench', section: 'Navigation', shortcut: '1', icon: Upload, action: () => setActiveTab('translator') },
     { id: 'nav-iac', label: 'Go to IaC', section: 'Navigation', shortcut: '3', icon: Code, action: () => setActiveTab('translator') },
     { id: 'nav-hld', label: 'Go to HLD', section: 'Navigation', shortcut: '4', icon: FileText, action: () => setActiveTab('translator') },
     { id: 'nav-cost', label: 'Go to Cost', section: 'Navigation', shortcut: '5', icon: DollarSign, action: () => setActiveTab('translator') },

--- a/frontend/src/components/DiagramTranslator/__tests__/index.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/index.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import DiagramTranslator from '../../DiagramTranslator'
 
 // Mock Prism to avoid require issues
@@ -21,17 +21,18 @@ describe('DiagramTranslator', () => {
 
   it('renders without crashing', async () => {
     render(<DiagramTranslator />)
-    expect(await screen.findByText('Translation Workbench')).toBeInTheDocument()
-    expect(await screen.findAllByText('Input')).toHaveLength(2)
+    expect(await screen.findByRole('heading', { name: 'Translation Workbench' })).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Translation Workbench' })).toBeInTheDocument()
   })
 
   it('shows the step progress bar', async () => {
     render(<DiagramTranslator />)
-    expect(await screen.findAllByText('Input')).toHaveLength(2)
-    expect(await screen.findAllByText('Analysis')).toHaveLength(2)
-    expect(await screen.findByText('Decisions')).toBeInTheDocument()
-    expect(await screen.findAllByText('Deliverables')).toHaveLength(2)
-    expect(await screen.findByText('Share/Export')).toBeInTheDocument()
+    const spine = await screen.findByRole('group', { name: 'Translation Workbench' })
+    expect(within(spine).getByText('Input')).toBeInTheDocument()
+    expect(within(spine).getByText('Analysis')).toBeInTheDocument()
+    expect(within(spine).getByText('Decisions')).toBeInTheDocument()
+    expect(within(spine).getByText('Deliverables')).toBeInTheDocument()
+    expect(within(spine).getByText('Share/Export')).toBeInTheDocument()
   })
 
   it('shows upload step by default', async () => {

--- a/frontend/src/components/DiagramTranslator/__tests__/index.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/index.test.jsx
@@ -21,14 +21,17 @@ describe('DiagramTranslator', () => {
 
   it('renders without crashing', async () => {
     render(<DiagramTranslator />)
-    expect(await screen.findByText('Input')).toBeInTheDocument()
+    expect(await screen.findByText('Translation Workbench')).toBeInTheDocument()
+    expect(await screen.findAllByText('Input')).toHaveLength(2)
   })
 
   it('shows the step progress bar', async () => {
     render(<DiagramTranslator />)
-    expect(await screen.findByText('Input')).toBeInTheDocument()
-    expect(await screen.findByText('Analysis')).toBeInTheDocument()
-    expect(await screen.findByText('Deliverables')).toBeInTheDocument()
+    expect(await screen.findAllByText('Input')).toHaveLength(2)
+    expect(await screen.findAllByText('Analysis')).toHaveLength(2)
+    expect(await screen.findByText('Decisions')).toBeInTheDocument()
+    expect(await screen.findAllByText('Deliverables')).toHaveLength(2)
+    expect(await screen.findByText('Share/Export')).toBeInTheDocument()
   })
 
   it('shows upload step by default', async () => {

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -75,14 +75,17 @@ function StatusPill({ status, label }) {
   );
 }
 
-function getWorkbenchSpine(state, currentPhase) {
+function getWorkbenchSpine(state) {
   const hasQuestions = (state.questions || []).length > 0 || (state.questionAssumptions || []).length > 0;
-  const isGenerating = state.step === 'analyzing' || state.generatingIac || state.hldLoading || state.costBreakdownLoading;
+  const inputFailed = state.step === 'upload' && !!state.error;
+  const analysisFailed = ['analyzing', 'results'].includes(state.step) && !!state.error;
+  const deliverablesGenerating = state.generatingIac || state.hldLoading || state.costBreakdownLoading;
+  const deliverablesFailed = ['iac', 'hld', 'pricing', 'deploy'].includes(state.step) && !!state.error;
   return [
-    { id: 'input', status: state.selectedFile || state.analysis ? 'ready' : 'notGenerated', label: state.analysis ? 'Ready' : state.selectedFile ? 'Selected' : 'Awaiting input' },
-    { id: 'analysis', status: state.error && currentPhase === 'input' ? 'failed' : state.step === 'analyzing' ? 'generating' : state.analysis ? 'ready' : 'notGenerated', label: state.step === 'analyzing' ? 'Analyzing' : state.analysis ? 'Ready' : 'Not started' },
+    { id: 'input', status: inputFailed ? 'failed' : state.selectedFile || state.analysis ? 'ready' : 'notGenerated', label: inputFailed ? 'Failed' : state.analysis ? 'Ready' : state.selectedFile ? 'Selected' : 'Awaiting input' },
+    { id: 'analysis', status: analysisFailed ? 'failed' : state.step === 'analyzing' ? 'generating' : state.analysis ? 'ready' : 'notGenerated', label: analysisFailed ? 'Failed' : state.step === 'analyzing' ? 'Analyzing' : state.analysis ? 'Ready' : 'Not started' },
     { id: 'decisions', status: hasQuestions && state.step === 'questions' ? 'needsReview' : hasQuestions ? 'ready' : state.analysis ? 'notGenerated' : 'notGenerated', label: hasQuestions && state.step === 'questions' ? 'Needs review' : hasQuestions ? 'Captured' : 'Not started' },
-    { id: 'deliverables', status: isGenerating && currentPhase === 'deliverables' ? 'generating' : state.iacCode ? 'ready' : 'notGenerated', label: isGenerating && currentPhase === 'deliverables' ? 'Generating' : state.iacCode ? 'Ready' : 'Not generated' },
+    { id: 'deliverables', status: deliverablesFailed ? 'failed' : deliverablesGenerating ? 'generating' : state.iacCode ? 'ready' : 'notGenerated', label: deliverablesFailed ? 'Failed' : deliverablesGenerating ? 'Generating' : state.iacCode ? 'Ready' : 'Not generated' },
     { id: 'share', status: state.exportCapability ? 'ready' : state.iacCode ? 'needsReview' : 'notGenerated', label: state.exportCapability ? 'Ready' : state.iacCode ? 'Needs review' : 'Not generated' },
   ];
 }
@@ -96,15 +99,15 @@ function getDeliverableStatuses(state) {
   ];
 }
 
-function WorkbenchSpineHeader({ state, currentPhase }) {
-  const statusByStep = new Map(getWorkbenchSpine(state, currentPhase).map(item => [item.id, item]));
+function WorkbenchSpineHeader({ state }) {
+  const statusByStep = new Map(getWorkbenchSpine(state).map(item => [item.id, item]));
   return (
     <Card className="p-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h1 className="text-xl font-bold text-text-primary">Translation Workbench</h1>
+          <h1 id="workbench-spine-title" className="text-xl font-bold text-text-primary">Translation Workbench</h1>
         </div>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-5 lg:min-w-[42rem]" aria-label="Workbench spine status">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-5 lg:min-w-[42rem]" role="group" aria-labelledby="workbench-spine-title">
           {SPINE_STEPS.map(step => {
             const stateForStep = statusByStep.get(step.id);
             return (
@@ -127,9 +130,9 @@ function DeliverablesHubHeader({ state }) {
     <Card className="p-4">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-base font-semibold text-text-primary">Deliverables Hub</h2>
+          <h2 id="deliverables-hub-title" className="text-base font-semibold text-text-primary">Deliverables Hub</h2>
         </div>
-        <div className="flex flex-wrap gap-2" aria-label="Deliverable status summary">
+        <div className="flex flex-wrap gap-2" role="group" aria-labelledby="deliverables-hub-title">
           {getDeliverableStatuses(state).map(item => (
             <StatusPill key={item.id} status={item.status} label={`${item.label}: ${item.text}`} />
           ))}
@@ -1063,7 +1066,7 @@ export default function DiagramTranslator() {
 
   return (
     <div className="space-y-6">
-      <WorkbenchSpineHeader state={state} currentPhase={currentPhase} />
+      <WorkbenchSpineHeader state={state} />
 
       {/* Phase Bar (#512 — 3-phase progress) */}
       <div className="flex items-center justify-center gap-3 text-sm font-medium">

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -49,6 +49,96 @@ const DELIVERABLE_TABS = [
   { id: 'deploy', label: 'Deploy', icon: Rocket, feature: 'deployEngine' },
 ].filter(tab => !tab.feature || isFeatureEnabled(tab.feature));
 
+const SPINE_STEPS = [
+  { id: 'input', label: 'Input' },
+  { id: 'analysis', label: 'Analysis' },
+  { id: 'decisions', label: 'Decisions' },
+  { id: 'deliverables', label: 'Deliverables' },
+  { id: 'share', label: 'Share/Export' },
+];
+
+const STATUS_STYLES = {
+  ready: 'border-cta/30 bg-cta/10 text-cta',
+  generating: 'border-info/30 bg-info/10 text-info',
+  failed: 'border-danger/30 bg-danger/10 text-danger',
+  stale: 'border-warning/30 bg-warning/10 text-warning',
+  needsReview: 'border-warning/30 bg-warning/10 text-warning',
+  notGenerated: 'border-border bg-secondary text-text-muted',
+};
+
+function StatusPill({ status, label }) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium ${STATUS_STYLES[status] || STATUS_STYLES.notGenerated}`}>
+      <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function getWorkbenchSpine(state, currentPhase) {
+  const hasQuestions = (state.questions || []).length > 0 || (state.questionAssumptions || []).length > 0;
+  const isGenerating = state.step === 'analyzing' || state.generatingIac || state.hldLoading || state.costBreakdownLoading;
+  return [
+    { id: 'input', status: state.selectedFile || state.analysis ? 'ready' : 'notGenerated', label: state.analysis ? 'Ready' : state.selectedFile ? 'Selected' : 'Awaiting input' },
+    { id: 'analysis', status: state.error && currentPhase === 'input' ? 'failed' : state.step === 'analyzing' ? 'generating' : state.analysis ? 'ready' : 'notGenerated', label: state.step === 'analyzing' ? 'Analyzing' : state.analysis ? 'Ready' : 'Not started' },
+    { id: 'decisions', status: hasQuestions && state.step === 'questions' ? 'needsReview' : hasQuestions ? 'ready' : state.analysis ? 'notGenerated' : 'notGenerated', label: hasQuestions && state.step === 'questions' ? 'Needs review' : hasQuestions ? 'Captured' : 'Not started' },
+    { id: 'deliverables', status: isGenerating && currentPhase === 'deliverables' ? 'generating' : state.iacCode ? 'ready' : 'notGenerated', label: isGenerating && currentPhase === 'deliverables' ? 'Generating' : state.iacCode ? 'Ready' : 'Not generated' },
+    { id: 'share', status: state.exportCapability ? 'ready' : state.iacCode ? 'needsReview' : 'notGenerated', label: state.exportCapability ? 'Ready' : state.iacCode ? 'Needs review' : 'Not generated' },
+  ];
+}
+
+function getDeliverableStatuses(state) {
+  return [
+    { id: 'iac', label: 'IaC', status: state.generatingIac ? 'generating' : state.iacCode ? 'ready' : state.error && state.step === 'iac' ? 'failed' : 'notGenerated', text: state.generatingIac ? 'Generating' : state.iacCode ? 'Ready' : state.error && state.step === 'iac' ? 'Failed' : 'Not generated' },
+    { id: 'hld', label: 'HLD', status: state.hldLoading ? 'generating' : state.hldData ? 'ready' : state.error && state.step === 'hld' ? 'failed' : 'notGenerated', text: state.hldLoading ? 'Generating' : state.hldData ? 'Ready' : state.error && state.step === 'hld' ? 'Failed' : 'Not generated' },
+    { id: 'pricing', label: 'Cost', status: state.costBreakdownLoading ? 'generating' : state.costBreakdown ? 'ready' : 'notGenerated', text: state.costBreakdownLoading ? 'Generating' : state.costBreakdown ? 'Ready' : 'Not generated' },
+    { id: 'package', label: 'Package', status: state.exportCapability ? 'ready' : state.iacCode ? 'needsReview' : 'notGenerated', text: state.exportCapability ? 'Ready' : state.iacCode ? 'Needs review' : 'Not generated' },
+  ];
+}
+
+function WorkbenchSpineHeader({ state, currentPhase }) {
+  const statusByStep = new Map(getWorkbenchSpine(state, currentPhase).map(item => [item.id, item]));
+  return (
+    <Card className="p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-text-primary">Translation Workbench</h1>
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-5 lg:min-w-[42rem]" aria-label="Workbench spine status">
+          {SPINE_STEPS.map(step => {
+            const stateForStep = statusByStep.get(step.id);
+            return (
+              <div key={step.id} className="min-w-0 rounded-lg border border-border bg-secondary/40 p-2">
+                <div className="truncate text-xs font-semibold text-text-secondary">{step.label}</div>
+                <div className="mt-1">
+                  <StatusPill status={stateForStep.status} label={stateForStep.label} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function DeliverablesHubHeader({ state }) {
+  return (
+    <Card className="p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-text-primary">Deliverables Hub</h2>
+        </div>
+        <div className="flex flex-wrap gap-2" aria-label="Deliverable status summary">
+          {getDeliverableStatuses(state).map(item => (
+            <StatusPill key={item.id} status={item.status} label={`${item.label}: ${item.text}`} />
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 function buildQuestionState(qData = {}) {
   const questions = qData.questions || [];
   const allQuestions = qData.all_questions || questions;
@@ -973,6 +1063,8 @@ export default function DiagramTranslator() {
 
   return (
     <div className="space-y-6">
+      <WorkbenchSpineHeader state={state} currentPhase={currentPhase} />
+
       {/* Phase Bar (#512 — 3-phase progress) */}
       <div className="flex items-center justify-center gap-3 text-sm font-medium">
         {PHASES.map((phase, i) => {
@@ -1149,6 +1241,7 @@ export default function DiagramTranslator() {
       {/* ═══ Phase 3: Deliverables (Tabbed — IaC | HLD | Pricing | Deploy) ═══ */}
       {PHASES[2].steps.includes(state.step) && state.iacCode && (
         <div className="space-y-4">
+          <DeliverablesHubHeader state={state} />
           <div className="flex items-center justify-between">
             <Button onClick={() => set({ step: 'results' })} variant="ghost" size="sm" icon={Eye}>Back to Analysis</Button>
           </div>

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -22,10 +22,10 @@ function useTheme() {
 }
 
 const PRIMARY_ITEMS = [
-  { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { id: 'translator', label: 'Translator', icon: Layers },
-  { id: 'templates', label: 'Templates', icon: LayoutTemplate },
-  { id: 'services', label: 'Services', icon: Server },
+  { id: 'translator', label: 'Workbench', icon: Layers },
+  { id: 'templates', label: 'Starters', icon: LayoutTemplate },
+  { id: 'dashboard', label: 'History', icon: LayoutDashboard },
+  { id: 'services', label: 'Reference', icon: Server },
 ];
 
 const MORE_ITEMS = [

--- a/frontend/src/components/__tests__/Nav.test.jsx
+++ b/frontend/src/components/__tests__/Nav.test.jsx
@@ -45,21 +45,21 @@ describe('Nav', () => {
 
   it('renders navigation tabs', () => {
     render(<Nav {...defaultProps} />)
-    expect(screen.getByText('Translator')).toBeInTheDocument()
-    expect(screen.getByText('Services')).toBeInTheDocument()
+    expect(screen.getByText('Workbench')).toBeInTheDocument()
+    expect(screen.getByText('Reference')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument()
   })
 
   it('highlights the active tab', () => {
     render(<Nav {...defaultProps} activeTab="services" />)
-    const servicesBtn = screen.getByText('Services').closest('button')
+    const servicesBtn = screen.getByText('Reference').closest('button')
     expect(servicesBtn).toHaveAttribute('aria-current', 'page')
   })
 
   it('calls setActiveTab when a tab is clicked', async () => {
     const user = userEvent.setup()
     render(<Nav {...defaultProps} />)
-    await user.click(screen.getByText('Services'))
+    await user.click(screen.getByText('Reference'))
     expect(defaultProps.setActiveTab).toHaveBeenCalledWith('services')
   })
 


### PR DESCRIPTION
## Summary
- rename the primary shell around the product spine: Workbench, Starters, History, Reference
- add a five-step workbench status header for Input, Analysis, Decisions, Deliverables, and Share/Export
- add a Deliverables Hub readiness summary with explicit generated/generating/ready/failed/needs-review states
- update command palette and focused tests for the new information architecture

Refs #780.

## Validation
- npm --prefix frontend test -- Nav DiagramTranslator --run
- npm --prefix frontend run build
- local Vite browser smoke at http://127.0.0.1:5173/