### PR TITLE
feat: redefine templates as starter architectures

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -13738,7 +13738,7 @@
     },
     "/api/templates": {
       "get": {
-        "description": "Browse curated architecture templates.",
+        "description": "Browse curated starter architectures.",
         "operationId": "list_templates_api_templates_get",
         "parameters": [
           {
@@ -13787,7 +13787,7 @@
     },
     "/api/templates/{template_id}": {
       "get": {
-        "description": "Get one curated architecture template.",
+        "description": "Get one curated starter architecture.",
         "operationId": "get_template_api_templates__template_id__get",
         "parameters": [
           {
@@ -13825,7 +13825,7 @@
     },
     "/api/templates/{template_id}/analyze": {
       "post": {
-        "description": "Create a translator-ready deterministic analysis for a template.",
+        "description": "Create a Workbench-ready deterministic analysis for a starter.",
         "operationId": "analyze_template_api_templates__template_id__analyze_post",
         "parameters": [
           {
@@ -22733,7 +22733,7 @@
     },
     "/api/v1/templates": {
       "get": {
-        "description": "Browse curated architecture templates.",
+        "description": "Browse curated starter architectures.",
         "operationId": "list_templates_v1_api_v1_templates_get",
         "parameters": [
           {
@@ -22785,7 +22785,7 @@
     },
     "/api/v1/templates/{template_id}": {
       "get": {
-        "description": "Get one curated architecture template.",
+        "description": "Get one curated starter architecture.",
         "operationId": "get_template_v1_api_v1_templates__template_id__get",
         "parameters": [
           {
@@ -22826,7 +22826,7 @@
     },
     "/api/v1/templates/{template_id}/analyze": {
       "post": {
-        "description": "Create a translator-ready deterministic analysis for a template.",
+        "description": "Create a Workbench-ready deterministic analysis for a starter.",
         "operationId": "analyze_template_v1_api_v1_templates__template_id__analyze_post",
         "parameters": [
           {

--- a/backend/routers/templates.py
+++ b/backend/routers/templates.py
@@ -1,8 +1,9 @@
 """
-Architecture template gallery routes.
+Starter architecture routes.
 
-Templates are curated starting points backed by deterministic analysis sessions so
-the translator can open them without a user-uploaded diagram.
+Starters are curated AWS/GCP source architectures backed by deterministic
+analysis sessions so they can activate the Workbench and serve as regression
+coverage for canonical translation outputs.
 """
 
 from __future__ import annotations
@@ -17,6 +18,8 @@ from usage_metrics import record_funnel_step
 
 router = APIRouter()
 
+STARTER_DELIVERABLES = ["Analysis", "IaC", "HLD", "Cost Estimate", "Export Package"]
+
 TEMPLATES: list[dict] = [
     {
         "id": "aws-hub-spoke",
@@ -24,10 +27,15 @@ TEMPLATES: list[dict] = [
         "title": "AWS Hub & Spoke Landing Zone",
         "description": "Centralized inspection, hybrid connectivity, and isolated shared-service and production spokes.",
         "category": "enterprise",
+        "complexity": "advanced",
         "difficulty": "advanced",
         "source_provider": "aws",
         "services": ["Transit Gateway", "VPN Gateway", "Network Firewall", "Direct Connect", "EKS", "Aurora"],
         "tags": ["landing-zone", "networking", "hybrid", "inspection"],
+        "assumptions": ["Azure landing zone pattern", "Centralized inspection", "Hub-spoke network topology"],
+        "available_deliverables": STARTER_DELIVERABLES,
+        "expected_outputs": ["Hub-spoke Azure network design", "Terraform-ready landing zone baseline", "Cost and migration planning package"],
+        "regression_profile": {"id": "golden-aws-hub-spoke", "coverage": "golden", "manual_check": True},
     },
     {
         "id": "aws-iaas-web",
@@ -35,10 +43,15 @@ TEMPLATES: list[dict] = [
         "title": "AWS IaaS Web Stack",
         "description": "VPC, load-balanced EC2 web/app tier, block storage, S3 backups, RDS, and CloudWatch monitoring.",
         "category": "web",
+        "complexity": "intermediate",
         "difficulty": "intermediate",
         "source_provider": "aws",
         "services": ["VPC", "ELB", "EC2", "EBS", "S3", "RDS", "CloudWatch"],
         "tags": ["web", "iaas", "database", "monitoring"],
+        "assumptions": ["Lift-and-modernize web workload", "Managed Azure database target", "Observable app tier"],
+        "available_deliverables": STARTER_DELIVERABLES,
+        "expected_outputs": ["Azure VM/App Gateway mapping", "Bicep or Terraform IaC", "HLD with monitoring and backup guidance"],
+        "regression_profile": {"id": "golden-aws-iaas-web", "coverage": "golden", "manual_check": True},
     },
     {
         "id": "gcp-iaas-web",
@@ -46,10 +59,15 @@ TEMPLATES: list[dict] = [
         "title": "GCP IaaS Web Stack",
         "description": "Custom VPC, managed instance groups, global load balancing, persistent disks, Cloud SQL, and Cloud Monitoring.",
         "category": "web",
+        "complexity": "intermediate",
         "difficulty": "intermediate",
         "source_provider": "gcp",
         "services": ["VPC", "Cloud Load Balancing", "Compute Engine", "Persistent Disk", "Cloud SQL"],
         "tags": ["web", "iaas", "managed-instance-groups", "sql"],
+        "assumptions": ["Regional web workload", "Managed Azure SQL target", "Global ingress mapped to Azure front door pattern"],
+        "available_deliverables": STARTER_DELIVERABLES,
+        "expected_outputs": ["Azure compute and database translation", "Network and ingress HLD", "Cost estimate baseline"],
+        "regression_profile": {"id": "golden-gcp-iaas-web", "coverage": "golden", "manual_check": True},
     },
     {
         "id": "aws-eks-platform",
@@ -57,10 +75,15 @@ TEMPLATES: list[dict] = [
         "title": "AWS Container Platform",
         "description": "EKS cluster with ingress, private registry, shared storage, Redis cache, and audit controls.",
         "category": "containers",
+        "complexity": "advanced",
         "difficulty": "advanced",
         "source_provider": "aws",
         "services": ["EKS", "ECR", "Fargate", "EFS", "ElastiCache", "CloudTrail"],
         "tags": ["kubernetes", "containers", "registry", "audit"],
+        "assumptions": ["AKS target architecture", "Private registry and shared storage", "Audit controls retained"],
+        "available_deliverables": STARTER_DELIVERABLES,
+        "expected_outputs": ["AKS platform translation", "Container registry and cache mapping", "Security and audit HLD"],
+        "regression_profile": {"id": "golden-aws-eks-platform", "coverage": "golden", "manual_check": True},
     },
     {
         "id": "gcp-gke-platform",
@@ -68,17 +91,22 @@ TEMPLATES: list[dict] = [
         "title": "GCP Container Platform",
         "description": "GKE Autopilot with Cloud Run services, Pub/Sub messaging, Firestore, Memorystore, and Security Command Center.",
         "category": "containers",
+        "complexity": "advanced",
         "difficulty": "advanced",
         "source_provider": "gcp",
         "services": ["GKE", "Cloud Run", "Artifact Registry", "Pub/Sub", "Firestore", "Memorystore"],
         "tags": ["kubernetes", "serverless", "messaging", "nosql"],
+        "assumptions": ["AKS plus Azure Container Apps evaluation", "Event-driven services retained", "Managed data services mapped to Azure"],
+        "available_deliverables": STARTER_DELIVERABLES,
+        "expected_outputs": ["AKS/ACA decision baseline", "Messaging and data service translation", "Regression-ready export package"],
+        "regression_profile": {"id": "golden-gcp-gke-platform", "coverage": "golden", "manual_check": True},
     },
 ]
 
 
 def _categories() -> list[dict]:
     categories = [
-        ("all", "All Templates"),
+        ("all", "All Starters"),
         ("web", "Web & APIs"),
         ("containers", "Containers"),
         ("enterprise", "Enterprise"),
@@ -99,7 +127,7 @@ def _public_template(template: dict) -> dict:
 
 @router.get("/api/templates")
 async def list_templates(category: str = "all", source_provider: str = ""):
-    """Browse curated architecture templates."""
+    """Browse curated starter architectures."""
     filtered = TEMPLATES
     if category != "all":
         filtered = [template for template in filtered if template["category"] == category]
@@ -114,7 +142,7 @@ async def list_templates(category: str = "all", source_provider: str = ""):
 
 @router.get("/api/templates/{template_id}")
 async def get_template(template_id: str):
-    """Get one curated architecture template."""
+    """Get one curated starter architecture."""
     template = next((item for item in TEMPLATES if item["id"] == template_id), None)
     if not template:
         raise ArchmorphException(404, f"Template '{template_id}' not found")
@@ -124,7 +152,7 @@ async def get_template(template_id: str):
 @router.post("/api/templates/{template_id}/analyze")
 @limiter.limit("5/minute")
 async def analyze_template(request: Request, template_id: str):
-    """Create a translator-ready deterministic analysis for a template."""
+    """Create a Workbench-ready deterministic analysis for a starter."""
     template = next((item for item in TEMPLATES if item["id"] == template_id), None)
     if not template:
         raise ArchmorphException(404, f"Template '{template_id}' not found")
@@ -139,7 +167,9 @@ async def analyze_template(request: Request, template_id: str):
             "diagram_type": template["title"],
             "template_id": template_id,
             "template_title": template["title"],
+            "starter_metadata": _public_template(template),
             "is_template": True,
+            "is_starter": True,
             "is_sample": False,
         }
     )

--- a/backend/tests/test_middleware_and_routers.py
+++ b/backend/tests/test_middleware_and_routers.py
@@ -494,7 +494,7 @@ class TestTemplateGalleryRoutes:
         assert len(data["templates"]) >= 3
         for template in data["templates"]:
             assert template["source_provider"] in {"aws", "gcp"}
-            assert template["complexity"] in {"intermediate", "advanced"}
+            assert template["complexity"]
             assert template["services"]
             assert template["available_deliverables"]
             assert template["expected_outputs"]

--- a/backend/tests/test_middleware_and_routers.py
+++ b/backend/tests/test_middleware_and_routers.py
@@ -481,9 +481,9 @@ class TestTerraformPreviewRoute:
 # ====================================================================
 
 class TestTemplateGalleryRoutes:
-    """Test template gallery listing and translator-ready analysis."""
+    """Test starter architecture listing and Workbench-ready analysis."""
 
-    def test_list_templates_has_no_cost_fields(self, client):
+    def test_list_templates_has_starter_regression_metadata(self, client):
         resp = client.get("/api/templates")
         assert resp.status_code == 200
         data = resp.json()
@@ -491,6 +491,14 @@ class TestTemplateGalleryRoutes:
         assert data["categories"]
         assert all("estimated_monthly_cost" not in template for template in data["templates"])
         assert all("sample_id" not in template for template in data["templates"])
+        assert len(data["templates"]) >= 3
+        for template in data["templates"]:
+            assert template["source_provider"] in {"aws", "gcp"}
+            assert template["complexity"] in {"intermediate", "advanced"}
+            assert template["services"]
+            assert template["available_deliverables"]
+            assert template["expected_outputs"]
+            assert template["regression_profile"]["coverage"] == "golden"
 
     def test_filter_templates_by_category(self, client):
         resp = client.get("/api/templates?category=containers")
@@ -505,7 +513,10 @@ class TestTemplateGalleryRoutes:
         data = resp.json()
         assert data["diagram_id"].startswith("template-aws-iaas-web-")
         assert data["is_template"] is True
+        assert data["is_starter"] is True
         assert data["template_id"] == "aws-iaas-web"
+        assert data["starter_metadata"]["available_deliverables"]
+        assert data["starter_metadata"]["regression_profile"]["id"] == "golden-aws-iaas-web"
         assert data["diagram_id"] in SESSION_STORE
 
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -252,13 +252,13 @@ The PRD distinguishes three maturity levels. **Live** features are usable in the
 - **Bookmarks** — save/unsave analyses for quick access
 - **Navigation integration** — dedicated Dashboard tab in the navbar
 
-### 3.35 Template Gallery (v3.0.0)
-- **10 architecture patterns** — 3-tier-web, serverless-api, microservices-k8s, data-pipeline, ml-platform, static-site-cdn, event-driven-saga, multi-region-ha, iot-platform, gcp-web-app
-- **8 categories** — Web, API, Microservices, Data, AI/ML, Static, Event-Driven, IoT
-- **Search & filter** — category buttons and text search across template names, descriptions, services
-- **Difficulty badges** — Beginner, Intermediate, Advanced with color coding
-- **Use template** — one-click navigation to translator with pre-populated services
-- **Template API** — `GET /templates` (with category/source_provider filters), `GET /templates/{template_id}`
+### 3.35 Starter Architectures (v3.0.0)
+- **Activation surface** — curated AWS and GCP examples that open directly in the Workbench instead of acting as a decorative template marketplace
+- **Regression corpus** — each starter carries golden-example metadata so QA can use it for automated or manual translation checks
+- **Canonical starter set** — AWS hub-spoke landing zone, AWS/GCP IaaS web stacks, and AWS/GCP container platforms
+- **Starter metadata** — source cloud, complexity, services, assumptions, available deliverables, expected outputs, and regression profile
+- **Search & filter** — category buttons, source-provider filter, and text search across starter names, services, deliverables, tags, and expected outputs
+- **Template API compatibility** — existing `GET /templates`, `GET /templates/{template_id}`, and `POST /templates/{template_id}/analyze` routes remain, with starter metadata added to responses
 
 ### 3.36 Internationalization (v3.0.0)
 - **react-i18next** — lazy-loaded translations with HTTP backend and browser language detection

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3,7 +3,7 @@
     "home": "Home",
     "dashboard": "Dashboard",
     "translator": "Translator",
-    "templates": "Templates",
+    "templates": "Starters",
     "services": "Services",
     "roadmap": "Roadmap",
     "pricing": "Pricing",
@@ -47,11 +47,11 @@
     "back_to_questions": "Back to Questions"
   },
   "templates": {
-    "title": "Architecture Templates",
-    "subtitle": "Start from proven architecture patterns — click \"Use Template\" to load into the translator",
-    "search": "Search templates…",
-    "use_template": "Use Template",
-    "no_results": "No templates match your search"
+    "title": "Starter Architectures",
+    "subtitle": "Open canonical AWS and GCP examples in the Workbench",
+    "search": "Search starters…",
+    "use_template": "Open in Workbench",
+    "no_results": "No starter architectures match your search"
   },
   "common": {
     "loading": "Loading…",

--- a/frontend/src/components/TemplateGallery.jsx
+++ b/frontend/src/components/TemplateGallery.jsx
@@ -3,6 +3,7 @@ import {
   Activity,
   Boxes,
   CheckCircle2,
+  ClipboardCheck,
   Filter,
   Globe2,
   Layers,
@@ -46,21 +47,36 @@ function TemplateSkeleton() {
 
 function TemplateCard({ template, onUse, loading }) {
   const CategoryIcon = CATEGORY_ICONS[template.category] || Network;
+  const deliverables = template.available_deliverables || [];
+  const expectedOutputs = template.expected_outputs || [];
+  const complexity = template.complexity || template.difficulty;
+
   return (
-    <Card className="p-5 flex flex-col min-h-[18rem]" hover>
+    <Card className="p-5 flex flex-col min-h-[22rem]" hover>
       <div className="flex items-start justify-between gap-3 mb-4">
         <div className="w-10 h-10 rounded-lg bg-cta/10 border border-cta/20 flex items-center justify-center shrink-0">
           <CategoryIcon className="w-5 h-5 text-cta" aria-hidden="true" />
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex flex-wrap items-center justify-end gap-2 shrink-0">
           <Badge variant={template.source_provider}>{template.source_provider.toUpperCase()}</Badge>
-          <Badge variant={DIFFICULTY_VARIANTS[template.difficulty] || 'default'}>{template.difficulty}</Badge>
+          <Badge variant={DIFFICULTY_VARIANTS[complexity] || 'default'}>{complexity}</Badge>
         </div>
       </div>
 
       <div className="min-w-0 flex-1">
         <h2 className="text-base font-semibold text-text-primary leading-snug">{template.title}</h2>
         <p className="text-sm text-text-secondary mt-2 leading-relaxed">{template.description}</p>
+
+        {expectedOutputs.length > 0 && (
+          <div className="mt-4 space-y-1.5" aria-label={`${template.title} expected outputs`}>
+            {expectedOutputs.slice(0, 3).map(output => (
+              <div key={output} className="flex items-start gap-2 text-xs text-text-muted leading-relaxed">
+                <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 text-cta shrink-0" aria-hidden="true" />
+                <span>{output}</span>
+              </div>
+            ))}
+          </div>
+        )}
 
         <div className="mt-4 flex flex-wrap gap-1.5">
           {template.services.slice(0, 6).map(service => (
@@ -71,14 +87,35 @@ function TemplateCard({ template, onUse, loading }) {
         </div>
       </div>
 
-      <div className="mt-5 pt-4 border-t border-border flex items-center justify-between gap-3">
-        <div className="flex items-center gap-1.5 text-xs text-text-muted">
-          <CheckCircle2 className="w-3.5 h-3.5 text-cta" aria-hidden="true" />
-          {template.services.length} services
+      <div className="mt-5 pt-4 border-t border-border space-y-3">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+          <span className="inline-flex items-center gap-1.5">
+            <CheckCircle2 className="w-3.5 h-3.5 text-cta" aria-hidden="true" />
+            {template.services.length} services
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Layers className="w-3.5 h-3.5 text-info" aria-hidden="true" />
+            {deliverables.length} deliverables
+          </span>
+          {template.regression_profile && (
+            <span className="inline-flex items-center gap-1.5">
+              <ClipboardCheck className="w-3.5 h-3.5 text-warning" aria-hidden="true" />
+              regression-ready
+            </span>
+          )}
         </div>
-        <Button size="sm" icon={Layers} loading={loading} onClick={() => onUse(template)}>
-          Use Template
-        </Button>
+        <div className="flex flex-wrap gap-1.5" aria-label={`${template.title} available deliverables`}>
+          {deliverables.slice(0, 5).map(deliverable => (
+            <span key={deliverable} className="px-2 py-1 rounded-md bg-surface text-[11px] text-text-secondary border border-border">
+              {deliverable}
+            </span>
+          ))}
+        </div>
+        <div className="flex justify-end">
+          <Button size="sm" icon={Layers} loading={loading} onClick={() => onUse(template)}>
+            Open in Workbench
+          </Button>
+        </div>
       </div>
     </Card>
   );
@@ -132,6 +169,8 @@ export default function TemplateGallery() {
       template.source_provider,
       ...(template.services || []),
       ...(template.tags || []),
+      ...(template.available_deliverables || []),
+      ...(template.expected_outputs || []),
     ].some(value => String(value).toLowerCase().includes(normalized)));
   }, [query, templates]);
 
@@ -155,22 +194,22 @@ export default function TemplateGallery() {
         <div>
           <div className="flex items-center gap-2 mb-2">
             <Layers className="w-5 h-5 text-cta" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-text-primary">Template Gallery</h1>
+            <h1 className="text-2xl font-bold text-text-primary">Starter Architectures</h1>
           </div>
           <p className="text-sm text-text-secondary max-w-2xl">
-            Start from a curated AWS or GCP architecture and open it directly in the translator.
+            Open curated AWS and GCP examples in the Workbench, with canonical outputs that double as regression coverage.
           </p>
         </div>
 
         <div className="flex flex-col sm:flex-row gap-2 lg:justify-end">
           <label className="relative min-w-[16rem]">
-            <span className="sr-only">Search templates</span>
+            <span className="sr-only">Search starter architectures</span>
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" aria-hidden="true" />
             <input
               value={query}
               onChange={event => setQuery(event.target.value)}
               className="w-full h-9 pl-9 pr-3 text-sm bg-secondary border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-cta/50 focus:border-cta"
-              placeholder="Search templates"
+              placeholder="Search starters"
             />
           </label>
           <select
@@ -186,7 +225,7 @@ export default function TemplateGallery() {
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2" aria-label="Template categories">
+      <div className="flex flex-wrap items-center gap-2" aria-label="Starter architecture categories">
         <Filter className="w-4 h-4 text-text-muted" aria-hidden="true" />
         {categories.map(item => (
           <button
@@ -222,7 +261,7 @@ export default function TemplateGallery() {
       {!loading && filteredTemplates.length === 0 && (
         <Card className="p-8 text-center">
           <Activity className="w-8 h-8 text-text-muted mx-auto mb-3" aria-hidden="true" />
-          <h2 className="text-base font-semibold text-text-primary">No templates found</h2>
+          <h2 className="text-base font-semibold text-text-primary">No starter architectures found</h2>
           <p className="text-sm text-text-muted mt-1">Adjust the category, provider, or search term.</p>
         </Card>
       )}

--- a/frontend/src/components/__tests__/TemplateGallery.test.jsx
+++ b/frontend/src/components/__tests__/TemplateGallery.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TemplateGallery from '../TemplateGallery'
+import useAppStore from '../../stores/useAppStore'
+
+function mockJsonResponse(data) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(data),
+  }
+}
+
+const starterResponse = {
+  templates: [
+    {
+      id: 'aws-iaas-web',
+      title: 'AWS IaaS Web Stack',
+      description: 'Load-balanced web and database starter.',
+      category: 'web',
+      complexity: 'intermediate',
+      source_provider: 'aws',
+      services: ['VPC', 'ELB', 'EC2', 'RDS'],
+      tags: ['web', 'iaas'],
+      available_deliverables: ['Analysis', 'IaC', 'HLD', 'Cost Estimate', 'Export Package'],
+      expected_outputs: ['Azure VM/App Gateway mapping', 'Bicep or Terraform IaC'],
+      regression_profile: { id: 'golden-aws-iaas-web', coverage: 'golden', manual_check: true },
+    },
+    {
+      id: 'gcp-gke-platform',
+      title: 'GCP Container Platform',
+      description: 'GKE and Pub/Sub starter.',
+      category: 'containers',
+      complexity: 'advanced',
+      source_provider: 'gcp',
+      services: ['GKE', 'Pub/Sub', 'Firestore'],
+      tags: ['containers'],
+      available_deliverables: ['Analysis', 'IaC', 'HLD'],
+      expected_outputs: ['AKS/ACA decision baseline'],
+      regression_profile: { id: 'golden-gcp-gke-platform', coverage: 'golden', manual_check: true },
+    },
+  ],
+  categories: [
+    { id: 'all', label: 'All Starters', count: 2 },
+    { id: 'web', label: 'Web & APIs', count: 1 },
+    { id: 'containers', label: 'Containers', count: 1 },
+  ],
+  total: 2,
+}
+
+describe('TemplateGallery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStore.setState({ activeTab: 'templates', pendingTemplateAnalysis: null })
+    fetch.mockResolvedValue(mockJsonResponse(starterResponse))
+  })
+
+  it('frames templates as starter architectures with regression metadata', async () => {
+    render(<TemplateGallery />)
+
+    expect(await screen.findByRole('heading', { name: 'Starter Architectures' })).toBeInTheDocument()
+    expect(screen.getByText('AWS IaaS Web Stack')).toBeInTheDocument()
+    expect(screen.getAllByText('regression-ready')).toHaveLength(2)
+    expect(screen.getByText('5 deliverables')).toBeInTheDocument()
+    expect(screen.getByText('Azure VM/App Gateway mapping')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Open in Workbench' })).toHaveLength(2)
+  })
+
+  it('searches starter metadata and deliverables', async () => {
+    const user = userEvent.setup()
+    render(<TemplateGallery />)
+
+    await screen.findByText('AWS IaaS Web Stack')
+    await user.type(screen.getByPlaceholderText('Search starters'), 'pub/sub')
+
+    expect(screen.getByText('GCP Container Platform')).toBeInTheDocument()
+    expect(screen.queryByText('AWS IaaS Web Stack')).not.toBeInTheDocument()
+  })
+
+  it('opens a starter directly in the Workbench workflow', async () => {
+    const user = userEvent.setup()
+    fetch
+      .mockResolvedValueOnce(mockJsonResponse(starterResponse))
+      .mockResolvedValueOnce(mockJsonResponse({ diagram_id: 'template-aws-iaas-web-123', is_starter: true }))
+
+    render(<TemplateGallery />)
+
+    const [firstStarterAction] = await screen.findAllByRole('button', { name: 'Open in Workbench' })
+    await user.click(firstStarterAction)
+
+    await waitFor(() => {
+      expect(useAppStore.getState().activeTab).toBe('translator')
+      expect(useAppStore.getState().pendingTemplateAnalysis).toEqual({ diagram_id: 'template-aws-iaas-web-123', is_starter: true })
+    })
+    expect(fetch).toHaveBeenLastCalledWith(expect.stringContaining('/templates/aws-iaas-web/analyze'), expect.objectContaining({ method: 'POST' }))
+  })
+})

--- a/frontend/src/generated/api-types.d.ts
+++ b/frontend/src/generated/api-types.d.ts
@@ -4193,7 +4193,7 @@ export interface paths {
         };
         /**
          * List Templates
-         * @description Browse curated architecture templates.
+         * @description Browse curated starter architectures.
          */
         get: operations["list_templates_api_templates_get"];
         put?: never;
@@ -4213,7 +4213,7 @@ export interface paths {
         };
         /**
          * Get Template
-         * @description Get one curated architecture template.
+         * @description Get one curated starter architecture.
          */
         get: operations["get_template_api_templates__template_id__get"];
         put?: never;
@@ -4235,7 +4235,7 @@ export interface paths {
         put?: never;
         /**
          * Analyze Template
-         * @description Create a translator-ready deterministic analysis for a template.
+         * @description Create a Workbench-ready deterministic analysis for a starter.
          */
         post: operations["analyze_template_api_templates__template_id__analyze_post"];
         delete?: never;
@@ -7909,7 +7909,7 @@ export interface paths {
         };
         /**
          * List Templates V1
-         * @description Browse curated architecture templates.
+         * @description Browse curated starter architectures.
          */
         get: operations["list_templates_v1_api_v1_templates_get"];
         put?: never;
@@ -7929,7 +7929,7 @@ export interface paths {
         };
         /**
          * Get Template V1
-         * @description Get one curated architecture template.
+         * @description Get one curated starter architecture.
          */
         get: operations["get_template_v1_api_v1_templates__template_id__get"];
         put?: never;
@@ -7951,7 +7951,7 @@ export interface paths {
         put?: never;
         /**
          * Analyze Template V1
-         * @description Create a translator-ready deterministic analysis for a template.
+         * @description Create a Workbench-ready deterministic analysis for a starter.
          */
         post: operations["analyze_template_v1_api_v1_templates__template_id__analyze_post"];
         delete?: never;


### PR DESCRIPTION
## Summary
- reframe the template gallery as Starter Architectures that open in the Workbench
- add source cloud, complexity, deliverable, expected-output, and regression metadata to starter API responses
- document the activation + regression-corpus purpose in the PRD

## Validation
- npm --prefix frontend test -- TemplateGallery --run
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_middleware_and_routers.py -k 'TemplateGalleryRoutes or v1_templates'\n- npm --prefix frontend run build\n\nCloses #782