### PR TITLE
docs(eval): add Foundry benchmark spike plan

### DIFF
--- a/backend/eval/model_bench.py
+++ b/backend/eval/model_bench.py
@@ -1,9 +1,15 @@
-"""Foundry model evaluation harness (#602).
+"""Foundry model evaluation harness (#602, refreshed for #781).
 
 Bench candidate Azure Foundry models against the six Archmorph workloads,
 collect accuracy / latency / cost / refusal metrics, and emit a JSON report
 that the human-readable analysis at `docs/eval/model_bench_2026_05.md`
 references.
+
+Issue #781 extends the original spike with a deployment-aware benchmark plan:
+compare the current West Europe `gpt-4.1` primary and `gpt-4o` fallback
+against deployable Foundry candidates, record regional availability, and keep
+production routing unchanged until live evidence clears quality, cost,
+latency, throttling, safety, structured-output, and rollback gates.
 
 Design constraints
 ------------------
@@ -99,6 +105,180 @@ PRICING_PER_1M_TOKENS_USD: Dict[str, Tuple[float, float]] = {
 }
 
 JUDGE_MODEL = "gpt-5-pro"
+
+
+# ───────────────────────────────────────────────────────────────────
+# #781 deployment-aware benchmark plan metadata
+# ───────────────────────────────────────────────────────────────────
+
+CURRENT_FOUNDRY_ACCOUNT = {
+    "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
+    "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3",
+    "resource_group": "archmorph-rg-dev",
+    "account_name": "archmorph-openai-we-acm7pd",
+    "region": "westeurope",
+    "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
+}
+
+CURRENT_DEPLOYMENTS = {
+    "primary": {
+        "deployment": "gpt-4.1",
+        "model": "gpt-4.1",
+        "version": "2025-04-14",
+        "sku": "GlobalStandard",
+        "capacity": 10,
+        "rai_policy": "Microsoft.DefaultV2",
+    },
+    "fallback": {
+        "deployment": "gpt-4o",
+        "model": "gpt-4o",
+        "version": "2024-11-20",
+        "sku": "GlobalStandard",
+        "capacity": 10,
+        "rai_policy": "Microsoft.DefaultV2",
+    },
+}
+
+AUTH_REQUIREMENTS = {
+    "local_auth_enabled": False,
+    "runtime_identity": "Container App user-assigned managed identity with system-assigned fallback",
+    "required_role": "Cognitive Services OpenAI User",
+    "forbidden": ["API-key based benchmark routing", "committing secrets", "production deployment mutation"],
+}
+
+REGIONAL_AVAILABILITY = {
+    "westeurope": {
+        "source": "az cognitiveservices account list-models on archmorph-openai-we-acm7pd, 2026-05-07",
+        "current_deployments": ["gpt-4.1", "gpt-4o"],
+        "deployable_candidates": {
+            "gpt-4.1": "baseline primary, GlobalStandard, version 2025-04-14",
+            "gpt-4o": "baseline fallback, GlobalStandard deployable versions include 2024-05-13/2024-08-06 and current deployment 2024-11-20",
+            "gpt-4o-mini": "GlobalStandard, version 2024-07-18",
+            "gpt-4.1-mini": "Standard, version 2025-04-14",
+            "gpt-4.1-nano": "GlobalStandard, version 2025-04-14",
+            "o4-mini": "GlobalStandard, version 2025-04-16",
+            "gpt-5": "GlobalStandard, version 2025-08-07",
+            "gpt-5-mini": "GlobalStandard, version 2025-08-07",
+            "gpt-5-nano": "GlobalStandard, version 2025-08-07",
+            "gpt-5-codex": "GlobalStandard, version 2025-09-15",
+            "gpt-5-pro": "GlobalStandard, version 2025-10-06",
+            "gpt-5.3-codex": "GlobalStandard, version 2026-02-24",
+            "gpt-5.4": "GlobalStandard, version 2026-03-05",
+            "gpt-5.4-mini": "GlobalStandard, version 2026-03-17",
+            "gpt-5.4-nano": "GlobalStandard, version 2026-03-17",
+            "gpt-5.5": "GlobalProvisionedManaged, version 2026-04-24; benchmark only after capacity approval",
+        },
+        "quota_notes": "Usage CLI returned no rows in this environment; live run must capture TPM/RPM and throttling before any routed deployment.",
+    },
+    "swedencentral": {
+        "source": "subscription resource inventory found AIServices account agentsecysbz; list-models query was interrupted after hanging, 2026-05-07",
+        "current_deployments": [],
+        "deployable_candidates": {},
+        "quota_notes": "Treat as migration-region validation pending. Do not route Archmorph traffic here until account model list, quota, RBAC, and rollback drills are captured.",
+    },
+}
+
+BENCHMARK_LANES = {
+    "diagram_image_understanding": {
+        "workload": "vision_analyzer",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-5.4", "gpt-5.5"],
+        "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
+        "quality_gates": ["service inventory F1", "relationship edge F1", "JSON schema validity", "image/PDF refusal rate"],
+    },
+    "cloud_service_mapping": {
+        "workload": "mapping_suggester",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-4.1-mini", "gpt-4o-mini", "gpt-5.4-mini"],
+        "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
+        "quality_gates": ["primary mapping accuracy", "confidence calibration", "rationale safety", "JSON schema validity"],
+    },
+    "iac_generation_repair": {
+        "workload": "iac_generator",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-5.3-codex", "gpt-5-codex", "gpt-5.4"],
+        "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
+        "quality_gates": ["terraform fmt/validate", "bicep diagnostics", "least-privilege defaults", "no secret leakage"],
+    },
+    "hld_architecture_narrative": {
+        "workload": "hld_generator",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-5.4", "gpt-5", "gpt-5-mini"],
+        "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
+        "quality_gates": ["required section coverage", "migration-risk accuracy", "concise executive narrative", "policy-safe recommendations"],
+    },
+    "cost_explanation": {
+        "workload": "cost_explainer",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-4.1-mini", "gpt-4o-mini", "gpt-5.4-mini"],
+        "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
+        "quality_gates": ["numeric consistency", "SKU caveat accuracy", "unit-cost clarity", "no fabricated prices"],
+    },
+    "regression_judge": {
+        "workload": "eval_judge",
+        "baseline": ["gpt-4o", "gpt-4.1"],
+        "candidates": ["gpt-5-pro", "gpt-5.4", "o4-mini"],
+        "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
+        "quality_gates": ["grader agreement", "false-pass rate", "false-fail rate", "stable JSON scores"],
+    },
+    "chat_refinement_assistant": {
+        "workload": "agent_paas_react",
+        "baseline": ["gpt-4.1", "gpt-4o"],
+        "candidates": ["gpt-5.4-mini", "gpt-5-mini", "o4-mini"],
+        "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",
+        "quality_gates": ["tool-call accuracy", "constraint retention", "latency p95", "safe refusal behavior"],
+    },
+}
+
+RECOMMENDATION_MATRIX = [
+    {
+        "lane": "diagram_image_understanding",
+        "candidate": "gpt-5.4",
+        "decision": "defer",
+        "reason": "Potential quality candidate, but requires live image/PDF benchmark and quota proof before routed model deployment.",
+    },
+    {
+        "lane": "cloud_service_mapping",
+        "candidate": "gpt-5.4-mini",
+        "decision": "add_routed_model_candidate",
+        "reason": "Low-risk structured mapping lane; benchmark for cost and p95 latency savings before any feature-flagged route.",
+    },
+    {
+        "lane": "iac_generation_repair",
+        "candidate": "gpt-5.3-codex",
+        "decision": "add_routed_model_candidate",
+        "reason": "Codex-specialized deployable candidate; must pass IaC validation and security gates before canary.",
+    },
+    {
+        "lane": "hld_architecture_narrative",
+        "candidate": "gpt-5.4",
+        "decision": "defer",
+        "reason": "Narrative quality may improve, but current baseline remains until live report shows better section coverage without verbosity regressions.",
+    },
+    {
+        "lane": "cost_explanation",
+        "candidate": "gpt-5.4-mini",
+        "decision": "add_routed_model_candidate",
+        "reason": "Candidate for cheaper explanation prompts if numeric consistency and no fabricated pricing hold in the benchmark.",
+    },
+    {
+        "lane": "regression_judge",
+        "candidate": "gpt-5-pro",
+        "decision": "defer",
+        "reason": "Use only as an offline judge candidate until cost and evaluator agreement justify continuous use.",
+    },
+    {
+        "lane": "chat_refinement_assistant",
+        "candidate": "gpt-5.4-mini",
+        "decision": "defer",
+        "reason": "Multi-turn tool use needs stronger evidence on tool-call accuracy and constraint retention before routing.",
+    },
+]
+
+DECISION_RULE = (
+    "Keep current gpt-4.1/gpt-4o unless a candidate improves quality or cost "
+    "without breaking structured output, export artifacts, safety gates, quota headroom, or SLA."
+)
 
 
 # ───────────────────────────────────────────────────────────────────
@@ -541,6 +721,29 @@ def _percentile(values: List[float], p: float) -> float:
     return s[lo] + (s[hi] - s[lo]) * (k - lo)
 
 
+def build_benchmark_plan() -> Dict[str, Any]:
+    """Return the #781 deployment-aware benchmark plan.
+
+    This is intentionally static and offline-friendly. The live benchmark can
+    attach measured result files later, but the candidate set, auth posture,
+    regional evidence, and decision rule should be reviewable in CI without
+    touching Azure resources.
+    """
+    return {
+        "issue": 781,
+        "generated_for_date": "2026-05-07",
+        "current_account": CURRENT_FOUNDRY_ACCOUNT,
+        "current_deployments": CURRENT_DEPLOYMENTS,
+        "auth_requirements": AUTH_REQUIREMENTS,
+        "regional_availability": REGIONAL_AVAILABILITY,
+        "benchmark_lanes": BENCHMARK_LANES,
+        "recommendation_matrix": RECOMMENDATION_MATRIX,
+        "decision_rule": DECISION_RULE,
+        "production_routing_change": False,
+        "minimum_required_lanes": 5,
+    }
+
+
 def run_bench(
     workloads: Optional[List[str]] = None,
     models_filter: Optional[List[str]] = None,
@@ -588,6 +791,7 @@ def _report_to_json(report: BenchReport) -> str:
         "started_at":     report.started_at,
         "finished_at":    report.finished_at,
         "dry_run":        report.dry_run,
+        "benchmark_plan": build_benchmark_plan(),
         "workloads_run":  report.workloads_run,
         "models_seen":    report.models_seen,
         "judge_model":    report.judge_model,
@@ -602,6 +806,7 @@ def _parse_cli(argv: Optional[List[str]] = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="model_bench", description=__doc__.split("\n", 1)[0])
     p.add_argument("--dry-run", action="store_true", help="Use synthetic responses; no Foundry calls.")
     p.add_argument("--full", action="store_true", help="Run the full matrix in #602 acceptance criteria.")
+    p.add_argument("--plan", action="store_true", help="Emit the #781 benchmark plan only; no model calls.")
     p.add_argument("--workloads", default=None,
                    help=f"Comma-separated subset of: {','.join(WORKLOAD_CANDIDATES)}")
     p.add_argument("--models", default=None,
@@ -621,6 +826,17 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.full and (args.workloads or args.models):
         logger.error("--full is incompatible with --workloads / --models")
         return 2
+
+    if args.plan:
+        payload = json.dumps(build_benchmark_plan(), indent=2, sort_keys=True)
+        if args.output == "-":
+            print(payload)
+        else:
+            out = Path(args.output)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(payload, encoding="utf-8")
+            logger.info("wrote benchmark plan: %s", out)
+        return 0
 
     workloads = list(WORKLOAD_CANDIDATES) if args.full else (
         [w.strip() for w in args.workloads.split(",")] if args.workloads else None

--- a/backend/eval/model_bench.py
+++ b/backend/eval/model_bench.py
@@ -112,12 +112,12 @@ JUDGE_MODEL = "gpt-5-pro"
 # ───────────────────────────────────────────────────────────────────
 
 CURRENT_FOUNDRY_ACCOUNT = {
-    "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
-    "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3",
+    "subscription_id": "<redacted-subscription-id>",
+    "tenant_id": "<redacted-tenant-id>",
     "resource_group": "archmorph-rg-dev",
     "account_name": "archmorph-openai-we-acm7pd",
     "region": "westeurope",
-    "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
+    "resource_id": "<redacted-foundry-account-resource-id>",
 }
 
 CURRENT_DEPLOYMENTS = {
@@ -180,49 +180,56 @@ REGIONAL_AVAILABILITY = {
 
 BENCHMARK_LANES = {
     "diagram_image_understanding": {
-        "workload": "vision_analyzer",
+        "lane_id": "vision_analyzer",
+        "harness_workload": "vision_analyzer",
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-5.4", "gpt-5.5"],
         "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
         "quality_gates": ["service inventory F1", "relationship edge F1", "JSON schema validity", "image/PDF refusal rate"],
     },
     "cloud_service_mapping": {
-        "workload": "mapping_suggester",
+        "lane_id": "mapping_suggester",
+        "harness_workload": "mapping_suggester",
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-4.1-mini", "gpt-4o-mini", "gpt-5.4-mini"],
         "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
         "quality_gates": ["primary mapping accuracy", "confidence calibration", "rationale safety", "JSON schema validity"],
     },
     "iac_generation_repair": {
-        "workload": "iac_generator",
+        "lane_id": "iac_generator",
+        "harness_workload": "iac_generator",
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-5.3-codex", "gpt-5-codex", "gpt-5.4"],
         "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
         "quality_gates": ["terraform fmt/validate", "bicep diagnostics", "least-privilege defaults", "no secret leakage"],
     },
     "hld_architecture_narrative": {
-        "workload": "hld_generator",
+        "lane_id": "hld_generator",
+        "harness_workload": "hld_generator",
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-5.4", "gpt-5", "gpt-5-mini"],
         "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
         "quality_gates": ["required section coverage", "migration-risk accuracy", "concise executive narrative", "policy-safe recommendations"],
     },
     "cost_explanation": {
-        "workload": "cost_explainer",
+        "lane_id": "cost_explainer",
+        "harness_workload": None,
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-4.1-mini", "gpt-4o-mini", "gpt-5.4-mini"],
         "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
         "quality_gates": ["numeric consistency", "SKU caveat accuracy", "unit-cost clarity", "no fabricated prices"],
     },
     "regression_judge": {
-        "workload": "eval_judge",
+        "lane_id": "eval_judge",
+        "harness_workload": None,
         "baseline": ["gpt-4o", "gpt-4.1"],
         "candidates": ["gpt-5-pro", "gpt-5.4", "o4-mini"],
         "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
         "quality_gates": ["grader agreement", "false-pass rate", "false-fail rate", "stable JSON scores"],
     },
     "chat_refinement_assistant": {
-        "workload": "agent_paas_react",
+        "lane_id": "agent_paas_react",
+        "harness_workload": "agent_paas_react",
         "baseline": ["gpt-4.1", "gpt-4o"],
         "candidates": ["gpt-5.4-mini", "gpt-5-mini", "o4-mini"],
         "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",

--- a/backend/tests/test_model_bench.py
+++ b/backend/tests/test_model_bench.py
@@ -1,10 +1,12 @@
-"""Tests for the #602 model evaluation harness.
+"""Tests for the #602/#781 model evaluation harness.
 
 Three concerns:
 1. Bench harness is structurally correct in dry-run mode (offline,
    deterministic, no Foundry calls).
 2. The CLI is wired up.
-3. The cache-key versioning AC from #602 is satisfied —
+3. The #781 benchmark plan captures regional availability, workload lanes,
+   managed-identity auth posture, and the no-production-routing guardrail.
+4. The cache-key versioning AC from #602 is satisfied —
    `_compute_cache_key` already includes `model`, so swapping models
    automatically invalidates cache entries. Lock that with an explicit
    test against the production code path.
@@ -121,6 +123,49 @@ class TestCorpusIntegrity:
                 )
 
 
+class TestBenchmarkPlan781:
+    def test_plan_has_at_least_five_archmorph_lanes(self) -> None:
+        plan = model_bench.build_benchmark_plan()
+        assert len(plan["benchmark_lanes"]) >= plan["minimum_required_lanes"] >= 5
+        for required in (
+            "diagram_image_understanding",
+            "cloud_service_mapping",
+            "iac_generation_repair",
+            "hld_architecture_narrative",
+            "cost_explanation",
+        ):
+            assert required in plan["benchmark_lanes"]
+
+    def test_plan_keeps_current_baseline_and_no_routing_change(self) -> None:
+        plan = model_bench.build_benchmark_plan()
+        assert plan["production_routing_change"] is False
+        assert plan["current_deployments"]["primary"]["deployment"] == "gpt-4.1"
+        assert plan["current_deployments"]["fallback"]["deployment"] == "gpt-4o"
+        assert "Keep current gpt-4.1/gpt-4o" in plan["decision_rule"]
+
+    def test_plan_requires_managed_identity_not_keys(self) -> None:
+        plan = model_bench.build_benchmark_plan()
+        auth = plan["auth_requirements"]
+        assert auth["local_auth_enabled"] is False
+        assert auth["required_role"] == "Cognitive Services OpenAI User"
+        assert any("API-key" in item for item in auth["forbidden"])
+
+    def test_plan_records_west_europe_and_sweden_central_status(self) -> None:
+        plan = model_bench.build_benchmark_plan()
+        regional = plan["regional_availability"]
+        assert "westeurope" in regional
+        assert "swedencentral" in regional
+        assert "gpt-5.4" in regional["westeurope"]["deployable_candidates"]
+        assert regional["swedencentral"]["deployable_candidates"] == {}
+
+    def test_recommendation_matrix_uses_allowed_decisions(self) -> None:
+        plan = model_bench.build_benchmark_plan()
+        allowed = {"keep_current", "add_routed_model_candidate", "defer"}
+        assert plan["recommendation_matrix"]
+        for row in plan["recommendation_matrix"]:
+            assert row["decision"] in allowed
+
+
 class TestCacheKeyVersioning:
     """Lock the AC: 'cached_chat_completion cache invalidates cleanly when
     model changes'.
@@ -170,6 +215,15 @@ class TestCli:
         assert payload["dry_run"] is True
         # Full run touches every workload
         assert set(payload["workloads_run"]) == set(model_bench.WORKLOAD_CANDIDATES)
+        assert payload["benchmark_plan"]["issue"] == 781
+
+    def test_cli_plan_to_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = model_bench.main(["--plan"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["issue"] == 781
+        assert payload["production_routing_change"] is False
 
     def test_cli_full_with_workloads_is_error(self) -> None:
         # Mutually exclusive flags

--- a/backend/tests/test_model_bench.py
+++ b/backend/tests/test_model_bench.py
@@ -1,6 +1,6 @@
 """Tests for the #602/#781 model evaluation harness.
 
-Three concerns:
+The suite covers:
 1. Bench harness is structurally correct in dry-run mode (offline,
    deterministic, no Foundry calls).
 2. The CLI is wired up.

--- a/docs/eval/data/foundry_benchmark_plan_781_2026_05_07.json
+++ b/docs/eval/data/foundry_benchmark_plan_781_2026_05_07.json
@@ -21,13 +21,14 @@
         "o4-mini"
       ],
       "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",
+      "harness_workload": "agent_paas_react",
+      "lane_id": "agent_paas_react",
       "quality_gates": [
         "tool-call accuracy",
         "constraint retention",
         "latency p95",
         "safe refusal behavior"
-      ],
-      "workload": "agent_paas_react"
+      ]
     },
     "cloud_service_mapping": {
       "baseline": [
@@ -40,13 +41,14 @@
         "gpt-5.4-mini"
       ],
       "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
+      "harness_workload": "mapping_suggester",
+      "lane_id": "mapping_suggester",
       "quality_gates": [
         "primary mapping accuracy",
         "confidence calibration",
         "rationale safety",
         "JSON schema validity"
-      ],
-      "workload": "mapping_suggester"
+      ]
     },
     "cost_explanation": {
       "baseline": [
@@ -59,13 +61,14 @@
         "gpt-5.4-mini"
       ],
       "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
+      "harness_workload": null,
+      "lane_id": "cost_explainer",
       "quality_gates": [
         "numeric consistency",
         "SKU caveat accuracy",
         "unit-cost clarity",
         "no fabricated prices"
-      ],
-      "workload": "cost_explainer"
+      ]
     },
     "diagram_image_understanding": {
       "baseline": [
@@ -77,13 +80,14 @@
         "gpt-5.5"
       ],
       "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
+      "harness_workload": "vision_analyzer",
+      "lane_id": "vision_analyzer",
       "quality_gates": [
         "service inventory F1",
         "relationship edge F1",
         "JSON schema validity",
         "image/PDF refusal rate"
-      ],
-      "workload": "vision_analyzer"
+      ]
     },
     "hld_architecture_narrative": {
       "baseline": [
@@ -96,13 +100,14 @@
         "gpt-5-mini"
       ],
       "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
+      "harness_workload": "hld_generator",
+      "lane_id": "hld_generator",
       "quality_gates": [
         "required section coverage",
         "migration-risk accuracy",
         "concise executive narrative",
         "policy-safe recommendations"
-      ],
-      "workload": "hld_generator"
+      ]
     },
     "iac_generation_repair": {
       "baseline": [
@@ -115,13 +120,14 @@
         "gpt-5.4"
       ],
       "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
+      "harness_workload": "iac_generator",
+      "lane_id": "iac_generator",
       "quality_gates": [
         "terraform fmt/validate",
         "bicep diagnostics",
         "least-privilege defaults",
         "no secret leakage"
-      ],
-      "workload": "iac_generator"
+      ]
     },
     "regression_judge": {
       "baseline": [
@@ -134,22 +140,23 @@
         "o4-mini"
       ],
       "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
+      "harness_workload": null,
+      "lane_id": "eval_judge",
       "quality_gates": [
         "grader agreement",
         "false-pass rate",
         "false-fail rate",
         "stable JSON scores"
-      ],
-      "workload": "eval_judge"
+      ]
     }
   },
   "current_account": {
     "account_name": "archmorph-openai-we-acm7pd",
     "region": "westeurope",
     "resource_group": "archmorph-rg-dev",
-    "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
-    "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
-    "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3"
+    "resource_id": "<redacted-foundry-account-resource-id>",
+    "subscription_id": "<redacted-subscription-id>",
+    "tenant_id": "<redacted-tenant-id>"
   },
   "current_deployments": {
     "fallback": {

--- a/docs/eval/data/foundry_benchmark_plan_781_2026_05_07.json
+++ b/docs/eval/data/foundry_benchmark_plan_781_2026_05_07.json
@@ -1,0 +1,255 @@
+{
+  "auth_requirements": {
+    "forbidden": [
+      "API-key based benchmark routing",
+      "committing secrets",
+      "production deployment mutation"
+    ],
+    "local_auth_enabled": false,
+    "required_role": "Cognitive Services OpenAI User",
+    "runtime_identity": "Container App user-assigned managed identity with system-assigned fallback"
+  },
+  "benchmark_lanes": {
+    "chat_refinement_assistant": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-5.4-mini",
+        "gpt-5-mini",
+        "o4-mini"
+      ],
+      "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",
+      "quality_gates": [
+        "tool-call accuracy",
+        "constraint retention",
+        "latency p95",
+        "safe refusal behavior"
+      ],
+      "workload": "agent_paas_react"
+    },
+    "cloud_service_mapping": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-4.1-mini",
+        "gpt-4o-mini",
+        "gpt-5.4-mini"
+      ],
+      "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
+      "quality_gates": [
+        "primary mapping accuracy",
+        "confidence calibration",
+        "rationale safety",
+        "JSON schema validity"
+      ],
+      "workload": "mapping_suggester"
+    },
+    "cost_explanation": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-4.1-mini",
+        "gpt-4o-mini",
+        "gpt-5.4-mini"
+      ],
+      "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
+      "quality_gates": [
+        "numeric consistency",
+        "SKU caveat accuracy",
+        "unit-cost clarity",
+        "no fabricated prices"
+      ],
+      "workload": "cost_explainer"
+    },
+    "diagram_image_understanding": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-5.4",
+        "gpt-5.5"
+      ],
+      "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
+      "quality_gates": [
+        "service inventory F1",
+        "relationship edge F1",
+        "JSON schema validity",
+        "image/PDF refusal rate"
+      ],
+      "workload": "vision_analyzer"
+    },
+    "hld_architecture_narrative": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-5.4",
+        "gpt-5",
+        "gpt-5-mini"
+      ],
+      "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
+      "quality_gates": [
+        "required section coverage",
+        "migration-risk accuracy",
+        "concise executive narrative",
+        "policy-safe recommendations"
+      ],
+      "workload": "hld_generator"
+    },
+    "iac_generation_repair": {
+      "baseline": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "candidates": [
+        "gpt-5.3-codex",
+        "gpt-5-codex",
+        "gpt-5.4"
+      ],
+      "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
+      "quality_gates": [
+        "terraform fmt/validate",
+        "bicep diagnostics",
+        "least-privilege defaults",
+        "no secret leakage"
+      ],
+      "workload": "iac_generator"
+    },
+    "regression_judge": {
+      "baseline": [
+        "gpt-4o",
+        "gpt-4.1"
+      ],
+      "candidates": [
+        "gpt-5-pro",
+        "gpt-5.4",
+        "o4-mini"
+      ],
+      "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
+      "quality_gates": [
+        "grader agreement",
+        "false-pass rate",
+        "false-fail rate",
+        "stable JSON scores"
+      ],
+      "workload": "eval_judge"
+    }
+  },
+  "current_account": {
+    "account_name": "archmorph-openai-we-acm7pd",
+    "region": "westeurope",
+    "resource_group": "archmorph-rg-dev",
+    "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
+    "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
+    "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3"
+  },
+  "current_deployments": {
+    "fallback": {
+      "capacity": 10,
+      "deployment": "gpt-4o",
+      "model": "gpt-4o",
+      "rai_policy": "Microsoft.DefaultV2",
+      "sku": "GlobalStandard",
+      "version": "2024-11-20"
+    },
+    "primary": {
+      "capacity": 10,
+      "deployment": "gpt-4.1",
+      "model": "gpt-4.1",
+      "rai_policy": "Microsoft.DefaultV2",
+      "sku": "GlobalStandard",
+      "version": "2025-04-14"
+    }
+  },
+  "decision_rule": "Keep current gpt-4.1/gpt-4o unless a candidate improves quality or cost without breaking structured output, export artifacts, safety gates, quota headroom, or SLA.",
+  "generated_for_date": "2026-05-07",
+  "issue": 781,
+  "minimum_required_lanes": 5,
+  "production_routing_change": false,
+  "recommendation_matrix": [
+    {
+      "candidate": "gpt-5.4",
+      "decision": "defer",
+      "lane": "diagram_image_understanding",
+      "reason": "Potential quality candidate, but requires live image/PDF benchmark and quota proof before routed model deployment."
+    },
+    {
+      "candidate": "gpt-5.4-mini",
+      "decision": "add_routed_model_candidate",
+      "lane": "cloud_service_mapping",
+      "reason": "Low-risk structured mapping lane; benchmark for cost and p95 latency savings before any feature-flagged route."
+    },
+    {
+      "candidate": "gpt-5.3-codex",
+      "decision": "add_routed_model_candidate",
+      "lane": "iac_generation_repair",
+      "reason": "Codex-specialized deployable candidate; must pass IaC validation and security gates before canary."
+    },
+    {
+      "candidate": "gpt-5.4",
+      "decision": "defer",
+      "lane": "hld_architecture_narrative",
+      "reason": "Narrative quality may improve, but current baseline remains until live report shows better section coverage without verbosity regressions."
+    },
+    {
+      "candidate": "gpt-5.4-mini",
+      "decision": "add_routed_model_candidate",
+      "lane": "cost_explanation",
+      "reason": "Candidate for cheaper explanation prompts if numeric consistency and no fabricated pricing hold in the benchmark."
+    },
+    {
+      "candidate": "gpt-5-pro",
+      "decision": "defer",
+      "lane": "regression_judge",
+      "reason": "Use only as an offline judge candidate until cost and evaluator agreement justify continuous use."
+    },
+    {
+      "candidate": "gpt-5.4-mini",
+      "decision": "defer",
+      "lane": "chat_refinement_assistant",
+      "reason": "Multi-turn tool use needs stronger evidence on tool-call accuracy and constraint retention before routing."
+    }
+  ],
+  "regional_availability": {
+    "swedencentral": {
+      "current_deployments": [],
+      "deployable_candidates": {},
+      "quota_notes": "Treat as migration-region validation pending. Do not route Archmorph traffic here until account model list, quota, RBAC, and rollback drills are captured.",
+      "source": "subscription resource inventory found AIServices account agentsecysbz; list-models query was interrupted after hanging, 2026-05-07"
+    },
+    "westeurope": {
+      "current_deployments": [
+        "gpt-4.1",
+        "gpt-4o"
+      ],
+      "deployable_candidates": {
+        "gpt-4.1": "baseline primary, GlobalStandard, version 2025-04-14",
+        "gpt-4.1-mini": "Standard, version 2025-04-14",
+        "gpt-4.1-nano": "GlobalStandard, version 2025-04-14",
+        "gpt-4o": "baseline fallback, GlobalStandard deployable versions include 2024-05-13/2024-08-06 and current deployment 2024-11-20",
+        "gpt-4o-mini": "GlobalStandard, version 2024-07-18",
+        "gpt-5": "GlobalStandard, version 2025-08-07",
+        "gpt-5-codex": "GlobalStandard, version 2025-09-15",
+        "gpt-5-mini": "GlobalStandard, version 2025-08-07",
+        "gpt-5-nano": "GlobalStandard, version 2025-08-07",
+        "gpt-5-pro": "GlobalStandard, version 2025-10-06",
+        "gpt-5.3-codex": "GlobalStandard, version 2026-02-24",
+        "gpt-5.4": "GlobalStandard, version 2026-03-05",
+        "gpt-5.4-mini": "GlobalStandard, version 2026-03-17",
+        "gpt-5.4-nano": "GlobalStandard, version 2026-03-17",
+        "gpt-5.5": "GlobalProvisionedManaged, version 2026-04-24; benchmark only after capacity approval",
+        "o4-mini": "GlobalStandard, version 2025-04-16"
+      },
+      "quota_notes": "Usage CLI returned no rows in this environment; live run must capture TPM/RPM and throttling before any routed deployment.",
+      "source": "az cognitiveservices account list-models on archmorph-openai-we-acm7pd, 2026-05-07"
+    }
+  }
+}

--- a/docs/eval/data/model_bench_2026_05.json
+++ b/docs/eval/data/model_bench_2026_05.json
@@ -1,6 +1,261 @@
 {
+  "benchmark_plan": {
+    "auth_requirements": {
+      "forbidden": [
+        "API-key based benchmark routing",
+        "committing secrets",
+        "production deployment mutation"
+      ],
+      "local_auth_enabled": false,
+      "required_role": "Cognitive Services OpenAI User",
+      "runtime_identity": "Container App user-assigned managed identity with system-assigned fallback"
+    },
+    "benchmark_lanes": {
+      "chat_refinement_assistant": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-5.4-mini",
+          "gpt-5-mini",
+          "o4-mini"
+        ],
+        "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",
+        "quality_gates": [
+          "tool-call accuracy",
+          "constraint retention",
+          "latency p95",
+          "safe refusal behavior"
+        ],
+        "workload": "agent_paas_react"
+      },
+      "cloud_service_mapping": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-4.1-mini",
+          "gpt-4o-mini",
+          "gpt-5.4-mini"
+        ],
+        "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
+        "quality_gates": [
+          "primary mapping accuracy",
+          "confidence calibration",
+          "rationale safety",
+          "JSON schema validity"
+        ],
+        "workload": "mapping_suggester"
+      },
+      "cost_explanation": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-4.1-mini",
+          "gpt-4o-mini",
+          "gpt-5.4-mini"
+        ],
+        "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
+        "quality_gates": [
+          "numeric consistency",
+          "SKU caveat accuracy",
+          "unit-cost clarity",
+          "no fabricated prices"
+        ],
+        "workload": "cost_explainer"
+      },
+      "diagram_image_understanding": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-5.4",
+          "gpt-5.5"
+        ],
+        "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
+        "quality_gates": [
+          "service inventory F1",
+          "relationship edge F1",
+          "JSON schema validity",
+          "image/PDF refusal rate"
+        ],
+        "workload": "vision_analyzer"
+      },
+      "hld_architecture_narrative": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-5.4",
+          "gpt-5",
+          "gpt-5-mini"
+        ],
+        "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
+        "quality_gates": [
+          "required section coverage",
+          "migration-risk accuracy",
+          "concise executive narrative",
+          "policy-safe recommendations"
+        ],
+        "workload": "hld_generator"
+      },
+      "iac_generation_repair": {
+        "baseline": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "candidates": [
+          "gpt-5.3-codex",
+          "gpt-5-codex",
+          "gpt-5.4"
+        ],
+        "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
+        "quality_gates": [
+          "terraform fmt/validate",
+          "bicep diagnostics",
+          "least-privilege defaults",
+          "no secret leakage"
+        ],
+        "workload": "iac_generator"
+      },
+      "regression_judge": {
+        "baseline": [
+          "gpt-4o",
+          "gpt-4.1"
+        ],
+        "candidates": [
+          "gpt-5-pro",
+          "gpt-5.4",
+          "o4-mini"
+        ],
+        "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
+        "quality_gates": [
+          "grader agreement",
+          "false-pass rate",
+          "false-fail rate",
+          "stable JSON scores"
+        ],
+        "workload": "eval_judge"
+      }
+    },
+    "current_account": {
+      "account_name": "archmorph-openai-we-acm7pd",
+      "region": "westeurope",
+      "resource_group": "archmorph-rg-dev",
+      "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
+      "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
+      "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3"
+    },
+    "current_deployments": {
+      "fallback": {
+        "capacity": 10,
+        "deployment": "gpt-4o",
+        "model": "gpt-4o",
+        "rai_policy": "Microsoft.DefaultV2",
+        "sku": "GlobalStandard",
+        "version": "2024-11-20"
+      },
+      "primary": {
+        "capacity": 10,
+        "deployment": "gpt-4.1",
+        "model": "gpt-4.1",
+        "rai_policy": "Microsoft.DefaultV2",
+        "sku": "GlobalStandard",
+        "version": "2025-04-14"
+      }
+    },
+    "decision_rule": "Keep current gpt-4.1/gpt-4o unless a candidate improves quality or cost without breaking structured output, export artifacts, safety gates, quota headroom, or SLA.",
+    "generated_for_date": "2026-05-07",
+    "issue": 781,
+    "minimum_required_lanes": 5,
+    "production_routing_change": false,
+    "recommendation_matrix": [
+      {
+        "candidate": "gpt-5.4",
+        "decision": "defer",
+        "lane": "diagram_image_understanding",
+        "reason": "Potential quality candidate, but requires live image/PDF benchmark and quota proof before routed model deployment."
+      },
+      {
+        "candidate": "gpt-5.4-mini",
+        "decision": "add_routed_model_candidate",
+        "lane": "cloud_service_mapping",
+        "reason": "Low-risk structured mapping lane; benchmark for cost and p95 latency savings before any feature-flagged route."
+      },
+      {
+        "candidate": "gpt-5.3-codex",
+        "decision": "add_routed_model_candidate",
+        "lane": "iac_generation_repair",
+        "reason": "Codex-specialized deployable candidate; must pass IaC validation and security gates before canary."
+      },
+      {
+        "candidate": "gpt-5.4",
+        "decision": "defer",
+        "lane": "hld_architecture_narrative",
+        "reason": "Narrative quality may improve, but current baseline remains until live report shows better section coverage without verbosity regressions."
+      },
+      {
+        "candidate": "gpt-5.4-mini",
+        "decision": "add_routed_model_candidate",
+        "lane": "cost_explanation",
+        "reason": "Candidate for cheaper explanation prompts if numeric consistency and no fabricated pricing hold in the benchmark."
+      },
+      {
+        "candidate": "gpt-5-pro",
+        "decision": "defer",
+        "lane": "regression_judge",
+        "reason": "Use only as an offline judge candidate until cost and evaluator agreement justify continuous use."
+      },
+      {
+        "candidate": "gpt-5.4-mini",
+        "decision": "defer",
+        "lane": "chat_refinement_assistant",
+        "reason": "Multi-turn tool use needs stronger evidence on tool-call accuracy and constraint retention before routing."
+      }
+    ],
+    "regional_availability": {
+      "swedencentral": {
+        "current_deployments": [],
+        "deployable_candidates": {},
+        "quota_notes": "Treat as migration-region validation pending. Do not route Archmorph traffic here until account model list, quota, RBAC, and rollback drills are captured.",
+        "source": "subscription resource inventory found AIServices account agentsecysbz; list-models query was interrupted after hanging, 2026-05-07"
+      },
+      "westeurope": {
+        "current_deployments": [
+          "gpt-4.1",
+          "gpt-4o"
+        ],
+        "deployable_candidates": {
+          "gpt-4.1": "baseline primary, GlobalStandard, version 2025-04-14",
+          "gpt-4.1-mini": "Standard, version 2025-04-14",
+          "gpt-4.1-nano": "GlobalStandard, version 2025-04-14",
+          "gpt-4o": "baseline fallback, GlobalStandard deployable versions include 2024-05-13/2024-08-06 and current deployment 2024-11-20",
+          "gpt-4o-mini": "GlobalStandard, version 2024-07-18",
+          "gpt-5": "GlobalStandard, version 2025-08-07",
+          "gpt-5-codex": "GlobalStandard, version 2025-09-15",
+          "gpt-5-mini": "GlobalStandard, version 2025-08-07",
+          "gpt-5-nano": "GlobalStandard, version 2025-08-07",
+          "gpt-5-pro": "GlobalStandard, version 2025-10-06",
+          "gpt-5.3-codex": "GlobalStandard, version 2026-02-24",
+          "gpt-5.4": "GlobalStandard, version 2026-03-05",
+          "gpt-5.4-mini": "GlobalStandard, version 2026-03-17",
+          "gpt-5.4-nano": "GlobalStandard, version 2026-03-17",
+          "gpt-5.5": "GlobalProvisionedManaged, version 2026-04-24; benchmark only after capacity approval",
+          "o4-mini": "GlobalStandard, version 2025-04-16"
+        },
+        "quota_notes": "Usage CLI returned no rows in this environment; live run must capture TPM/RPM and throttling before any routed deployment.",
+        "source": "az cognitiveservices account list-models on archmorph-openai-we-acm7pd, 2026-05-07"
+      }
+    }
+  },
   "dry_run": true,
-  "finished_at": "2026-05-01T13:37:09Z",
+  "finished_at": "2026-05-07T16:24:31Z",
   "judge_model": "gpt-5-pro",
   "models_seen": [
     "gpt-4.1",
@@ -14,7 +269,7 @@
   ],
   "n_results": 21,
   "n_tasks_total": 21,
-  "started_at": "2026-05-01T13:37:09Z",
+  "started_at": "2026-05-07T16:24:31Z",
   "summaries": [
     {
       "composite_score": 0.948,

--- a/docs/eval/data/model_bench_2026_05.json
+++ b/docs/eval/data/model_bench_2026_05.json
@@ -22,13 +22,14 @@
           "o4-mini"
         ],
         "dataset": "multi-turn refinement prompts with tool-call expectations and customer constraints",
+        "harness_workload": "agent_paas_react",
+        "lane_id": "agent_paas_react",
         "quality_gates": [
           "tool-call accuracy",
           "constraint retention",
           "latency p95",
           "safe refusal behavior"
-        ],
-        "workload": "agent_paas_react"
+        ]
       },
       "cloud_service_mapping": {
         "baseline": [
@@ -41,13 +42,14 @@
           "gpt-5.4-mini"
         ],
         "dataset": "AWS/GCP/on-prem service mapping prompts with catalog references",
+        "harness_workload": "mapping_suggester",
+        "lane_id": "mapping_suggester",
         "quality_gates": [
           "primary mapping accuracy",
           "confidence calibration",
           "rationale safety",
           "JSON schema validity"
-        ],
-        "workload": "mapping_suggester"
+        ]
       },
       "cost_explanation": {
         "baseline": [
@@ -60,13 +62,14 @@
           "gpt-5.4-mini"
         ],
         "dataset": "Azure retail-price summaries and FinOps trade-off prompts",
+        "harness_workload": null,
+        "lane_id": "cost_explainer",
         "quality_gates": [
           "numeric consistency",
           "SKU caveat accuracy",
           "unit-cost clarity",
           "no fabricated prices"
-        ],
-        "workload": "cost_explainer"
+        ]
       },
       "diagram_image_understanding": {
         "baseline": [
@@ -78,13 +81,14 @@
           "gpt-5.5"
         ],
         "dataset": "synthetic architecture diagrams plus the legal-approved golden PDF corpus when available",
+        "harness_workload": "vision_analyzer",
+        "lane_id": "vision_analyzer",
         "quality_gates": [
           "service inventory F1",
           "relationship edge F1",
           "JSON schema validity",
           "image/PDF refusal rate"
-        ],
-        "workload": "vision_analyzer"
+        ]
       },
       "hld_architecture_narrative": {
         "baseline": [
@@ -97,13 +101,14 @@
           "gpt-5-mini"
         ],
         "dataset": "HLD prompts with expected sections, risks, service map, and cost context",
+        "harness_workload": "hld_generator",
+        "lane_id": "hld_generator",
         "quality_gates": [
           "required section coverage",
           "migration-risk accuracy",
           "concise executive narrative",
           "policy-safe recommendations"
-        ],
-        "workload": "hld_generator"
+        ]
       },
       "iac_generation_repair": {
         "baseline": [
@@ -116,13 +121,14 @@
           "gpt-5.4"
         ],
         "dataset": "Terraform/Bicep generation and repair prompts from canonical starter architectures",
+        "harness_workload": "iac_generator",
+        "lane_id": "iac_generator",
         "quality_gates": [
           "terraform fmt/validate",
           "bicep diagnostics",
           "least-privilege defaults",
           "no secret leakage"
-        ],
-        "workload": "iac_generator"
+        ]
       },
       "regression_judge": {
         "baseline": [
@@ -135,22 +141,23 @@
           "o4-mini"
         ],
         "dataset": "known-pass/known-fail regression answers for quality, schema, safety, and concision rubrics",
+        "harness_workload": null,
+        "lane_id": "eval_judge",
         "quality_gates": [
           "grader agreement",
           "false-pass rate",
           "false-fail rate",
           "stable JSON scores"
-        ],
-        "workload": "eval_judge"
+        ]
       }
     },
     "current_account": {
       "account_name": "archmorph-openai-we-acm7pd",
       "region": "westeurope",
       "resource_group": "archmorph-rg-dev",
-      "resource_id": "/subscriptions/152f2bd5-8f6b-48ba-a702-21a23172a224/resourceGroups/archmorph-rg-dev/providers/Microsoft.CognitiveServices/accounts/archmorph-openai-we-acm7pd",
-      "subscription_id": "152f2bd5-8f6b-48ba-a702-21a23172a224",
-      "tenant_id": "16b3c013-d300-468d-ac64-7eda0820b6d3"
+      "resource_id": "<redacted-foundry-account-resource-id>",
+      "subscription_id": "<redacted-subscription-id>",
+      "tenant_id": "<redacted-tenant-id>"
     },
     "current_deployments": {
       "fallback": {
@@ -255,7 +262,7 @@
     }
   },
   "dry_run": true,
-  "finished_at": "2026-05-07T16:24:31Z",
+  "finished_at": "2026-05-07T21:37:13Z",
   "judge_model": "gpt-5-pro",
   "models_seen": [
     "gpt-4.1",
@@ -269,7 +276,7 @@
   ],
   "n_results": 21,
   "n_tasks_total": 21,
-  "started_at": "2026-05-07T16:24:31Z",
+  "started_at": "2026-05-07T21:37:13Z",
   "summaries": [
     {
       "composite_score": 0.948,

--- a/docs/eval/foundry_benchmark_spike_781_2026_05_07.md
+++ b/docs/eval/foundry_benchmark_spike_781_2026_05_07.md
@@ -1,0 +1,98 @@
+# Foundry Benchmark Spike #781 — May 7, 2026
+
+> Issue: [#781](https://github.com/idokatz86/Archmorph/issues/781)  
+> Status: Spike recommendation, no production routing change  
+> Machine-readable plan: [data/foundry_benchmark_plan_781_2026_05_07.json](data/foundry_benchmark_plan_781_2026_05_07.json)
+
+## Decision Summary
+
+Keep the current Azure OpenAI baseline for production: `gpt-4.1` primary with `gpt-4o` fallback on the West Europe account `archmorph-openai-we-acm7pd`.
+
+Add benchmark candidates only for the low-risk or specialist lanes where live evidence may justify a later feature-flagged route. Do not create, update, or route production deployments until the live benchmark proves quality or cost improvement without breaking structured output, export artifacts, quota headroom, safety behavior, or SLA gates.
+
+## Current Baseline
+
+Read-only Azure inventory on May 7, 2026 confirmed:
+
+| Field | Value |
+| --- | --- |
+| Subscription | `152f2bd5-8f6b-48ba-a702-21a23172a224` |
+| Tenant | `16b3c013-d300-468d-ac64-7eda0820b6d3` |
+| Resource group | `archmorph-rg-dev` |
+| Account | `archmorph-openai-we-acm7pd` |
+| Region | West Europe (`westeurope`) |
+| Primary deployment | `gpt-4.1`, model version `2025-04-14`, `GlobalStandard`, capacity `10` |
+| Fallback deployment | `gpt-4o`, model version `2024-11-20`, `GlobalStandard`, capacity `10` |
+| RAI policy | `Microsoft.DefaultV2` on both deployments |
+
+Terraform already matches the desired auth posture: local auth is disabled on the OpenAI account, the Container App receives `AZURE_OPENAI_DEPLOYMENT=gpt-4.1` and `AZURE_OPENAI_FALLBACK_DEPLOYMENT=gpt-4o`, and both user-assigned and system-assigned identities hold `Cognitive Services OpenAI User` on the account.
+
+## Regional Availability
+
+| Region | Evidence | Candidate posture |
+| --- | --- | --- |
+| West Europe | `az cognitiveservices account list-models` on `archmorph-openai-we-acm7pd` exposed current `gpt-4.1`/`gpt-4o` plus deployable `gpt-4o-mini`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o4-mini`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-codex`, `gpt-5-pro`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, and `gpt-5.5`. | Eligible for benchmark candidates. `gpt-5.5` is `GlobalProvisionedManaged`, so it is capacity-gated and should not be treated as a default route candidate. |
+| Sweden Central | Subscription inventory found an `AIServices` account, `agentsecysbz`, in `rg-agent-security-foundry-sc`. The model-list query hung and was interrupted. | Treat as pending validation for #783 migration planning. No Archmorph routing until model list, quota, RBAC, and rollback drills are captured cleanly. |
+
+Quota usage discovery for West Europe returned no rows in this CLI environment. That is not evidence of quota headroom; the live benchmark must capture TPM/RPM, 429s, retry behavior, and p95 latency before any routed deployment is proposed.
+
+## Benchmark Lanes
+
+The benchmark plan covers seven Archmorph workload lanes, exceeding the issue requirement of at least five:
+
+| Lane | Current baseline | Candidates | Dataset and gates |
+| --- | --- | --- | --- |
+| Diagram/image understanding | `gpt-4.1`, `gpt-4o` | `gpt-5.4`, `gpt-5.5` | Synthetic diagrams plus the legal-approved golden PDF corpus when available. Gate on service inventory F1, relationship edge F1, JSON schema validity, image/PDF refusal rate. |
+| Cloud service mapping suggestions | `gpt-4.1`, `gpt-4o` | `gpt-4.1-mini`, `gpt-4o-mini`, `gpt-5.4-mini` | AWS/GCP/on-prem mapping prompts. Gate on primary mapping accuracy, confidence calibration, rationale safety, JSON schema validity. |
+| IaC generation and repair | `gpt-4.1`, `gpt-4o` | `gpt-5.3-codex`, `gpt-5-codex`, `gpt-5.4` | Terraform/Bicep generation and repair from canonical starters. Gate on `terraform fmt`/validate, Bicep diagnostics, least-privilege defaults, no secret leakage. |
+| HLD architecture narrative | `gpt-4.1`, `gpt-4o` | `gpt-5.4`, `gpt-5`, `gpt-5-mini` | HLD prompts with expected sections, risks, service map, and cost context. Gate on section coverage, migration-risk accuracy, concise narrative, policy-safe recommendations. |
+| Cost explanation | `gpt-4.1`, `gpt-4o` | `gpt-4.1-mini`, `gpt-4o-mini`, `gpt-5.4-mini` | Retail-price and FinOps trade-off prompts. Gate on numeric consistency, SKU caveat accuracy, unit-cost clarity, and no fabricated prices. |
+| Regression judge | `gpt-4o`, `gpt-4.1` | `gpt-5-pro`, `gpt-5.4`, `o4-mini` | Known-pass and known-fail regression answers. Gate on grader agreement, false-pass rate, false-fail rate, stable JSON scores. |
+| Chat/refinement assistant | `gpt-4.1`, `gpt-4o` | `gpt-5.4-mini`, `gpt-5-mini`, `o4-mini` | Multi-turn refinement prompts with tool-call expectations and customer constraints. Gate on tool-call accuracy, constraint retention, p95 latency, safe refusal behavior. |
+
+## Recommendation Matrix
+
+| Lane | Candidate | Recommendation | Reason |
+| --- | --- | --- | --- |
+| Diagram/image understanding | `gpt-5.4` | Defer | Potential quality candidate, but it needs live image/PDF evidence and quota proof before any routed deployment. |
+| Cloud service mapping | `gpt-5.4-mini` | Add routed-model candidate | Low-risk structured lane. Benchmark for cost and p95 latency savings before a feature-flag route. |
+| IaC generation and repair | `gpt-5.3-codex` | Add routed-model candidate | Specialist candidate. Must pass IaC validation and security gates before canary. |
+| HLD architecture narrative | `gpt-5.4` | Defer | Current baseline remains until live report proves better section coverage without verbosity regressions. |
+| Cost explanation | `gpt-5.4-mini` | Add routed-model candidate | Candidate for cheaper explanation prompts if numeric consistency and no fabricated pricing hold. |
+| Regression judge | `gpt-5-pro` | Defer | Use only as an offline judge candidate until cost and evaluator agreement justify continuous use. |
+| Chat/refinement assistant | `gpt-5.4-mini` | Defer | Multi-turn tool use needs stronger evidence on tool-call accuracy and constraint retention. |
+
+## Auth And Safety Requirements
+
+- Use managed identity or local developer Azure credentials for benchmark access.
+- Do not add API-key based benchmark routes or committed secret material.
+- Keep `local_auth_enabled = false` as the target posture for Archmorph-owned OpenAI resources.
+- Require `Cognitive Services OpenAI User` on the benchmark identity.
+- Preserve `Microsoft.DefaultV2` or stricter RAI policy on any temporary benchmark deployment.
+- Store benchmark artifacts as sanitized JSON/Markdown only: prompt IDs, timings, token counts, rubric scores, errors, and short excerpts. Do not store customer content or raw diagrams outside the approved golden corpus.
+
+## Live Benchmark Procedure
+
+1. Create temporary benchmark deployments only after explicit approval and quota validation.
+2. Run the offline plan first: `cd backend && python -m eval.model_bench --plan --output ../docs/eval/data/foundry_benchmark_plan_781_2026_05_07.json`.
+3. Run dry-run regression to ensure the harness is healthy: `cd backend && python -m eval.model_bench --dry-run --full --output ../docs/eval/data/model_bench_2026_05.json`.
+4. For live tests, run one lane at a time with cache bypass and record prompt/completion tokens, p50/p95 latency, refusal rate, 429/5xx rate, and rubric scores.
+5. Compare each candidate against both `gpt-4.1` and `gpt-4o` where the fallback is behaviorally relevant.
+6. Reject any candidate that fails structured-output validity, export artifact compatibility, safety behavior, or SLA gates even if it is cheaper.
+
+## Rollback Plan For Any Later Route
+
+This spike does not implement routing. A later routing PR must include:
+
+- Feature flag per workload, defaulting to the current baseline.
+- Deployment name metrics with `workload` and `model` dimensions.
+- A rollback drill proving traffic returns to `gpt-4.1`/`gpt-4o` within 60 seconds of flag reversal.
+- Cache-key verification, already protected by the existing model-sensitive cache key tests.
+- Canary stages with alert gates for 429 rate, p95 latency, schema-validity failures, and export failures.
+
+## Open Follow-Ups
+
+- Re-run Sweden Central model and quota discovery in a clean command before #783 migration planning.
+- Capture West Europe quota/usage from Azure portal or a non-hanging quota API path because CLI usage returned no rows here.
+- Attach the first live benchmark result as a separate dated JSON artifact before any production-route issue is opened.
+- Keep the older #602 synthetic report for historical context, but treat this #781 report and plan artifact as the current decision record.

--- a/docs/eval/foundry_benchmark_spike_781_2026_05_07.md
+++ b/docs/eval/foundry_benchmark_spike_781_2026_05_07.md
@@ -16,8 +16,8 @@ Read-only Azure inventory on May 7, 2026 confirmed:
 
 | Field | Value |
 | --- | --- |
-| Subscription | `152f2bd5-8f6b-48ba-a702-21a23172a224` |
-| Tenant | `16b3c013-d300-468d-ac64-7eda0820b6d3` |
+| Subscription | Redacted in-repo; use the private operator runbook or Azure context for the concrete ID. |
+| Tenant | Redacted in-repo; use the private operator runbook or Azure context for the concrete ID. |
 | Resource group | `archmorph-rg-dev` |
 | Account | `archmorph-openai-we-acm7pd` |
 | Region | West Europe (`westeurope`) |


### PR DESCRIPTION
## Summary
- Adds the #781 deployment-aware Foundry benchmark plan to the existing model benchmark harness.
- Captures current West Europe baseline (`gpt-4.1` primary, `gpt-4o` fallback), managed-identity/RBAC requirements, regional availability notes, and no-production-routing guardrail.
- Adds seven Archmorph benchmark lanes plus a keep/add/defer recommendation matrix and generated JSON artifacts.

## Validation
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_model_bench.py`
- `/Users/idokatz/VSCode/.venv/bin/python -m eval.model_bench --dry-run --full --output ../docs/eval/data/model_bench_2026_05.json`

Closes #781