### PR TITLE
docs(infra): plan Sweden Central migration

### DIFF
--- a/docs/infra/sweden-central-migration-plan.md
+++ b/docs/infra/sweden-central-migration-plan.md
@@ -1,0 +1,215 @@
+# Sweden Central One-Region Migration Plan
+
+> Issue: [#783](https://github.com/idokatz86/Archmorph/issues/783)
+> Status: Planning artifact only
+> Production impact: None. Do not apply this plan without an approved change window.
+
+## Executive Decision
+
+Migrate Archmorph to Sweden Central by building a parallel regional stack, validating it, shifting traffic gradually, and retiring old regions only after zero-traffic proof. Do not edit existing Terraform `location` or `openai_location` values and apply in place. Most Azure regional resources in this stack are ForceNew or operationally risky to move in place.
+
+The current production-ready baseline remains West Europe for the application and Azure OpenAI. East US and West Europe resources must stay available as rollback paths until Sweden Central passes readiness, dark-launch, traffic-shift, soak, and rollback drills.
+
+## Scope
+
+In scope:
+
+- Terraform migration strategy for a new Sweden Central stack.
+- Availability and quota readiness gates.
+- Readiness evidence checklist in [sweden-central-readiness-report.md](sweden-central-readiness-report.md).
+- Data/configuration migration order.
+- Managed identity, RBAC, and no-key-auth requirements.
+- Dark launch, traffic shift, rollback, and old-region retirement gates.
+
+Out of scope:
+
+- Running `terraform apply`, `terraform import`, `terraform state rm`, or `terraform destroy`.
+- Creating Azure resources from this plan.
+- Changing live DNS, Front Door routes, OpenAI deployments, or production app settings.
+- Decommissioning West Europe or East US resources.
+
+## Current Terraform Region Shape
+
+| Area | Current configuration | Migration implication |
+| --- | --- | --- |
+| Main Azure region | `var.location`, currently `westeurope` in `infra/terraform.tfvars` | Create a separate Sweden Central stack or workspace; do not mutate the current state in place. |
+| Azure OpenAI region | `var.openai_location`, currently `westeurope` | Validate Sweden Central model availability and quota before any AI cutover. App/data can move first if AI capacity is blocked. |
+| Static Web Apps | Hardcoded `westeurope` in `infra/main.tf` | Must be parameterized or replaced during the parallel build plan. Treat as ForceNew. |
+| Terraform remote state bootstrap | Commented bootstrap uses West Europe state RG/storage | Keep current state untouched; create a separate state key/workspace for Sweden Central. Do not reuse the current state key. |
+| Front Door/WAF | Global services in `infra/main.tf` | Can front both old and new origins during migration; traffic shift must be explicit and reversible. |
+| Regional dependencies | Container Apps, ACR, PostgreSQL Flexible Server, Redis, Storage, Key Vault, Log Analytics, Application Insights, VNet, subnets, private endpoints, NSGs | Build parallel resources in Sweden Central, validate diagnostics and private networking before traffic. |
+
+## Readiness Gate 1: Inventory And Freeze
+
+Before any Terraform preview:
+
+- Export current resource inventory for all Archmorph resource groups.
+- Pull Terraform state to an encrypted backup outside the repository.
+- Capture current app settings, container image tags, secrets names, managed identities, role assignments, private endpoints, DNS records, diagnostic settings, alerts, dashboards, and Front Door origin/routing configuration.
+- Freeze non-emergency infrastructure changes until the Sweden Central plan is approved or explicitly paused.
+- Confirm which resources are Terraform-managed, workflow-owned, manually adopted, or pending import.
+- Confirm the rollback region and exact production URL routing path.
+
+Exit criteria:
+
+- Inventory is reviewed by Cloud, Security, and product owner.
+- State backup exists and has a restore owner.
+- No unresolved drift blocks a no-apply plan.
+
+## Readiness Gate 2: Sweden Central Service Availability
+
+Validate Sweden Central support for every required service and SKU before building:
+
+| Service family | Required validation |
+| --- | --- |
+| Resource groups and networking | VNet, delegated Container Apps subnet, database subnet, private endpoint subnet, NSGs, private DNS zones and links. |
+| Container Apps | Managed environment support, workload profile/consumption support, ingress, revisions, health probes, managed identity, ACR pull. |
+| Container Registry | SKU availability, geo/security policy, private pull posture, Defender/Trivy compatibility. |
+| PostgreSQL Flexible Server | Version, SKU, storage, backup retention, zone/HA options, private networking, migration tooling. |
+| Redis | SKU/capacity parity or accepted replacement path if unavailable. |
+| Storage | Account kind/SKU, blob containers, RBAC, diagnostic logs, soft delete/retention, public access disabled. |
+| Key Vault | SKU, purge protection, soft delete, private endpoint, access model, managed identity access. |
+| Log Analytics and Application Insights | Region support, workspace-based App Insights, diagnostic sink compatibility, alert queries. |
+| Static Web Apps | Region/SKU support or explicit alternative hosting choice. |
+| Front Door and DNS | Global routing support, Sweden backend origin health, WAF policy reuse, rollback origin group. |
+| Azure OpenAI / Foundry | `gpt-4.1`, `gpt-4o`, model versions, deployment SKU, quota, content filter policy, p95 latency, 429 rate. |
+
+Exit criteria:
+
+- A region availability table is attached to the change request and reflected in [sweden-central-readiness-report.md](sweden-central-readiness-report.md).
+- Any unavailable service has an approved workaround or phase split.
+- Azure OpenAI capacity is explicitly marked `ready`, `partial`, or `blocked`.
+
+## Readiness Gate 3: Terraform Stack Isolation
+
+The Sweden Central build must be isolated from the current West Europe state.
+
+Required approach:
+
+- Use a separate backend key, Terraform workspace, or environment folder for Sweden Central.
+- Use a Sweden Central tfvars file based on [../../infra/sweden-central.example.tfvars](../../infra/sweden-central.example.tfvars).
+- Use unique resource naming suffixes where Azure global names would collide.
+- Parameterize hardcoded regional values before plan, especially Static Web Apps.
+- Run `terraform fmt -check`, `terraform init -backend=false`, and `terraform validate` locally and in CI.
+- Run a no-apply plan against the Sweden Central state and confirm it creates new resources only.
+
+Forbidden approach:
+
+- Do not change `infra/terraform.tfvars` from `westeurope` to `swedencentral` and apply against the current state.
+- Do not remove or destroy West Europe/East US resources during the build PR.
+- Do not import Sweden resources into the current West Europe state key unless the operator plan explicitly calls for it.
+
+Exit criteria:
+
+- Plan output shows only Sweden Central create operations for the new stack.
+- No West Europe or East US destroy/replace appears in the plan.
+- State isolation is documented in the change ticket.
+
+## Readiness Gate 4: Data And Configuration Migration
+
+Migration order:
+
+1. Provision Sweden Central storage, Key Vault, PostgreSQL, Redis, monitoring, networking, and identities.
+2. Restore or replicate PostgreSQL data into the Sweden Central server.
+3. Copy storage blobs with checksums and retention settings.
+4. Recreate secrets and app settings with Sweden Central endpoints only.
+5. Confirm Container App identities have RBAC on Sweden resources and no accidental dependency on West Europe storage, Key Vault, OpenAI, or Log Analytics.
+6. Validate service-catalog persistence, sessions, exports, package generation, and OpenAI health against Sweden endpoints.
+
+Exit criteria:
+
+- Database restore has row-count and application smoke validation.
+- Storage copy has checksum or inventory parity evidence.
+- App settings contain no old-region endpoint values except documented rollback references.
+
+## Readiness Gate 5: AI Runtime Validation
+
+AI movement is its own gate. If Sweden Central lacks model or quota parity, split migration into app/data first and AI later.
+
+Required checks:
+
+- `gpt-4.1` deployment availability, version, SKU, quota, content filter policy, and latency.
+- `gpt-4o` fallback availability, version, SKU, quota, content filter policy, and latency.
+- Candidate models from the Foundry benchmark plan only as optional benchmark lanes, not production routes.
+- Managed identity access using `Cognitive Services OpenAI User`.
+- Local auth disabled on Archmorph-owned OpenAI resources.
+- No API keys in app settings or committed artifacts.
+- Health response shows `openai=ok` against Sweden only.
+
+Exit criteria:
+
+- AI data-plane smoke tests pass with managed identity.
+- 429/5xx/error behavior is within SLO under expected load.
+- Rollback to West Europe OpenAI is documented and tested before live cutover.
+
+## Dark Launch And Traffic Shift
+
+Dark launch:
+
+- Deploy Sweden Central backend and frontend with no user traffic.
+- Run health, auth, storage, OpenAI, IaC generation, HLD export, architecture package export, service catalog, and Starter Architecture smoke tests.
+- Confirm alerts, dashboards, logs, and dependency telemetry are live before traffic.
+
+Traffic shift:
+
+1. Add Sweden Central as a Front Door origin with zero or low traffic.
+2. Shift 1% internal traffic or synthetic traffic and monitor for at least 30 minutes.
+3. Shift 10% and monitor p95 latency, error rate, OpenAI dependency failures, storage errors, database errors, and export failures.
+4. Shift 50% only after the 10% gate is clean.
+5. Shift 100% and soak for at least 24 hours before old-region retirement planning.
+
+Rollback trigger examples:
+
+- API health fails or reports `openai`/`storage` degraded.
+- p95 latency breaches SLO for two consecutive windows.
+- Elevated 429/5xx from Azure OpenAI or PostgreSQL.
+- Export/package generation fails above baseline.
+- Alerting or diagnostics pipeline is unavailable.
+
+Rollback action:
+
+- Move Front Door origin weight back to West Europe.
+- Restore old app settings only from reviewed rollback artifacts.
+- Keep Sweden Central resources for diagnosis unless they are causing active harm.
+
+## Old-Region Retirement
+
+Retirement is a separate work item after successful 100% traffic soak.
+
+Required evidence:
+
+- Front Door, App Insights, OpenAI dependency logs, storage logs, and database metrics show zero production traffic to West Europe/East US for the approved window.
+- Backups and exports are retained according to policy.
+- Destroy plans are separate, reviewed, and scoped to old-region resources only.
+- DNS TTL and rollback windows have expired.
+
+Do not delete old-region OpenAI, database, storage, or Key Vault resources inside the initial migration PR.
+
+## Validation Commands
+
+Planning-only local validation:
+
+```bash
+cd infra
+terraform fmt -check
+terraform init -backend=false -input=false
+terraform validate -no-color
+```
+
+Example no-apply preview for the future isolated Sweden stack:
+
+```bash
+cd infra
+terraform plan \
+  -var-file=sweden-central.tfvars \
+  -out=/tmp/archmorph-sweden-central.tfplan
+```
+
+Only run the preview above against an explicitly isolated backend/workspace. Do not run it against the current West Europe state key.
+
+## Open Follow-Ups
+
+- Parameterize hardcoded Static Web Apps region before any Sweden Central plan.
+- Produce a region/SKU availability report from Azure quota and service availability tooling.
+- Decide whether Sweden Central AI is required for day-one traffic or can follow app/data migration.
+- Create a separate old-region retirement issue after successful Sweden Central soak.

--- a/docs/infra/sweden-central-migration-plan.md
+++ b/docs/infra/sweden-central-migration-plan.md
@@ -32,8 +32,8 @@ Out of scope:
 
 | Area | Current configuration | Migration implication |
 | --- | --- | --- |
-| Main Azure region | `var.location`, currently `westeurope` in `infra/terraform.tfvars` | Create a separate Sweden Central stack or workspace; do not mutate the current state in place. |
-| Azure OpenAI region | `var.openai_location`, currently `westeurope` | Validate Sweden Central model availability and quota before any AI cutover. App/data can move first if AI capacity is blocked. |
+| Main Azure region | `var.location`, default `westeurope` in `infra/variables.tf`; operator tfvars may override it outside the repository | Create a separate Sweden Central stack or workspace; do not mutate the current state in place. |
+| Azure OpenAI region | `var.openai_location`, default `westeurope` in `infra/variables.tf` | Validate Sweden Central model availability and quota before any AI cutover. App/data can move first if AI capacity is blocked. |
 | Static Web Apps | Hardcoded `westeurope` in `infra/main.tf` | Must be parameterized or replaced during the parallel build plan. Treat as ForceNew. |
 | Terraform remote state bootstrap | Commented bootstrap uses West Europe state RG/storage | Keep current state untouched; create a separate state key/workspace for Sweden Central. Do not reuse the current state key. |
 | Front Door/WAF | Global services in `infra/main.tf` | Can front both old and new origins during migration; traffic shift must be explicit and reversible. |
@@ -200,12 +200,13 @@ Example no-apply preview for the future isolated Sweden stack:
 
 ```bash
 cd infra
+cp sweden-central.example.tfvars sweden-central.tfvars
 terraform plan \
   -var-file=sweden-central.tfvars \
   -out=/tmp/archmorph-sweden-central.tfplan
 ```
 
-Only run the preview above against an explicitly isolated backend/workspace. Do not run it against the current West Europe state key.
+Populate the operator-local `sweden-central.tfvars` with approved secret inputs before planning. Only run the preview above against an explicitly isolated backend/workspace. Do not run it against the current West Europe state key.
 
 ## Open Follow-Ups
 

--- a/docs/infra/sweden-central-readiness-report.md
+++ b/docs/infra/sweden-central-readiness-report.md
@@ -8,7 +8,7 @@ This report is the controlled evidence table for the Sweden Central migration. I
 
 ## Current Evidence Summary
 
-| Gate | Current status | Required evidence before proceed |
+| Gate | Current status | Required evidence before proceeding |
 | --- | --- | --- |
 | Resource inventory and freeze | Not started | Exported inventory, state backup owner, app settings/secrets/RBAC/DNS/monitoring capture, drift review. |
 | Sweden Central service/SKU availability | Not started | Availability and quota results for each required Azure service/SKU in `swedencentral`. |

--- a/docs/infra/sweden-central-readiness-report.md
+++ b/docs/infra/sweden-central-readiness-report.md
@@ -1,0 +1,90 @@
+# Sweden Central Readiness Report
+
+> Issue: [#783](https://github.com/idokatz86/Archmorph/issues/783)
+> Status: Operator validation required before any deployment
+> Scope: Availability, quota, smoke, observability, rollback, and retirement gates for a future Sweden Central stack.
+
+This report is the controlled evidence table for the Sweden Central migration. It intentionally contains no subscription IDs, tenant IDs, resource IDs, connection strings, API keys, or live secrets. Operators should attach raw Azure evidence to the private change record, not to this repository.
+
+## Current Evidence Summary
+
+| Gate | Current status | Required evidence before proceed |
+| --- | --- | --- |
+| Resource inventory and freeze | Not started | Exported inventory, state backup owner, app settings/secrets/RBAC/DNS/monitoring capture, drift review. |
+| Sweden Central service/SKU availability | Not started | Availability and quota results for each required Azure service/SKU in `swedencentral`. |
+| Azure OpenAI / Foundry availability | Not started | Model/version/SKU/quota evidence for `gpt-4.1`, `gpt-4o`, and any benchmark candidates. |
+| Terraform stack isolation | Planned | Separate backend key/workspace/environment, plan proves Sweden Central creates only and no old-region destroy/replace. |
+| Data/config migration | Not started | PostgreSQL restore parity, storage checksum/inventory parity, app settings contain only Sweden endpoints plus documented rollback refs. |
+| Production-like smoke tests | Not started | Health, auth, storage, OpenAI, service catalog, IaC generation, HLD export, package export, and Starter Architecture smoke results. |
+| Observability and alerts | Not started | App Insights, Log Analytics, diagnostics, Front Door/WAF logs, availability tests, action groups, and alert query validation. |
+| Rollback drill | Not started | Front Door rollback to West Europe tested, rollback app settings reviewed, old-region paths still healthy. |
+| Traffic shift | Not started | 1%, 10%, 50%, and 100% shift windows with p95/error/dependency evidence and no incident. |
+| Old-region retirement | Blocked until soak | Separate issue and reviewed destroy plan after zero-traffic evidence. |
+
+## Required Service/SKU Checks
+
+| Service | Target region | Expected result | Evidence owner | Status |
+| --- | --- | --- | --- | --- |
+| Resource group | `swedencentral` | Supported | Cloud owner | Pending |
+| Virtual Network, subnets, NSGs | `swedencentral` | Supported with required address plan | Cloud owner | Pending |
+| Private endpoints and Private DNS | `swedencentral` | Supported for PostgreSQL, Key Vault, and any private dependency | Cloud owner | Pending |
+| Azure Container Apps managed environment | `swedencentral` | Supported with required ingress, revisions, managed identity, and workload profile/consumption mode | Platform owner | Pending |
+| Azure Container Registry | `swedencentral` | Supported SKU and secure pull posture | Platform owner | Pending |
+| PostgreSQL Flexible Server | `swedencentral` | Supported version/SKU/storage/backup/private networking/HA posture | Data owner | Pending |
+| Azure Cache for Redis | `swedencentral` | Supported capacity and SKU, or approved alternative | Platform owner | Pending |
+| Storage account | `swedencentral` | Supported account kind/SKU, public access disabled, soft delete/retention enabled | Cloud owner | Pending |
+| Key Vault | `swedencentral` | Supported with purge protection, soft delete, RBAC/private endpoint posture | Security owner | Pending |
+| Log Analytics | `swedencentral` | Supported workspace and diagnostic sink | Observability owner | Pending |
+| Application Insights | `swedencentral` | Supported workspace-based resource and web tests | Observability owner | Pending |
+| Static Web Apps | `swedencentral` | Supported, or approved hosting alternative if unavailable | Frontend owner | Pending |
+| Front Door and WAF | Global | Supports Sweden Central origin, health probes, and rollback origin group | Cloud owner | Pending |
+| Azure OpenAI `gpt-4.1` | `swedencentral` | Required model version/SKU/quota/content filter available | AI owner | Pending |
+| Azure OpenAI `gpt-4o` | `swedencentral` | Required fallback model version/SKU/quota/content filter available | AI owner | Pending |
+
+## Terraform Plan Acceptance
+
+A Sweden Central no-apply plan can proceed only when all of the following are true:
+
+- Plan uses isolated state, not the current West Europe backend key.
+- Plan creates Sweden Central resources only.
+- Plan does not replace, destroy, or mutate current West Europe/East US resources.
+- Static Web Apps region handling is parameterized or otherwise explicitly handled.
+- Global resource name collisions are resolved with approved naming.
+- Managed identity and RBAC are used for AI and storage access.
+- No API keys, connection strings, resource IDs, subscription IDs, or tenant IDs are committed.
+
+## Smoke Test Acceptance
+
+Sweden Central dark launch can accept traffic only after these checks pass against Sweden dependencies:
+
+- API health returns healthy.
+- Health includes `openai=ok` and `storage=ok`.
+- Authenticated user flow succeeds.
+- Service catalog reads/writes persist.
+- IaC generation succeeds.
+- HLD export succeeds.
+- Architecture package export succeeds.
+- Starter Architecture smoke test succeeds.
+- Azure OpenAI dependency latency and 429/5xx rate are within SLO.
+- Application Insights and Log Analytics receive traces, dependencies, exceptions, and availability data.
+- Alerts fire in a controlled test and notify the expected action group.
+
+## Rollback Acceptance
+
+Rollback is considered tested only when:
+
+- Front Door can route 100% of traffic back to West Europe.
+- West Europe API health remains healthy.
+- West Europe OpenAI and storage health remain healthy.
+- Reverted app settings are sourced from reviewed artifacts.
+- Sweden Central resources remain available for diagnosis unless the incident commander approves shutdown.
+
+## Retirement Acceptance
+
+Old-region retirement is blocked until a separate issue confirms:
+
+- 100% traffic has run on Sweden Central for the approved soak period.
+- Front Door, App Insights, OpenAI dependency logs, storage logs, and database metrics show zero production traffic to West Europe/East US.
+- Backups and legal/compliance retention are complete.
+- Destroy plans are reviewed and scoped to old-region resources only.
+- The rollback window has expired.

--- a/infra/README.md
+++ b/infra/README.md
@@ -30,6 +30,22 @@ Before any state-changing operation:
 5. Keep the East US account alive until at least 24 hours of zero traffic is verified.
 6. Apply only from an approved operator session with rollback notes and smoke checks ready.
 
+## Sweden Central One-Region Migration Guardrails
+
+Issue #783 tracks the plan to move Archmorph toward a single `swedencentral` regional footprint. This is a parallel-build migration, not an in-place edit of `location` or `openai_location` against the current state.
+
+- Runbook: [../docs/infra/sweden-central-migration-plan.md](../docs/infra/sweden-central-migration-plan.md)
+- Readiness report template: [../docs/infra/sweden-central-readiness-report.md](../docs/infra/sweden-central-readiness-report.md)
+- Example variables for a future isolated stack: [sweden-central.example.tfvars](sweden-central.example.tfvars)
+
+Before any Sweden Central plan or apply:
+
+1. Use a separate backend key, Terraform workspace, or environment folder from the current West Europe state.
+2. Validate Sweden Central service/SKU availability for Container Apps, Static Web Apps, ACR, PostgreSQL, Redis, Storage, Key Vault, Log Analytics, Application Insights, networking, DNS, and monitoring.
+3. Validate Azure OpenAI / Foundry model availability and quota for `gpt-4.1`, `gpt-4o`, and any benchmark candidates before changing AI routing.
+4. Keep West Europe and East US rollback paths live until Sweden Central passes dark launch, traffic shift, soak, and rollback drills.
+5. Treat old-region deletion as a separate reviewed destroy plan after zero-traffic evidence.
+
 ## Local Validation
 
 Run these commands when editing files under `infra/`:

--- a/infra/sweden-central.example.tfvars
+++ b/infra/sweden-central.example.tfvars
@@ -1,0 +1,22 @@
+# Example variables for a future isolated Sweden Central stack.
+#
+# Do not use this with the current West Europe Terraform state key.
+# Copy to an operator-local tfvars file only after a separate backend key,
+# workspace, or environment folder has been approved for #783.
+
+# subscription_id = Set via TF_VAR_subscription_id or an operator-local tfvars file.
+location        = "swedencentral"
+openai_location = "swedencentral"
+environment     = "dev"
+
+# Keep global URLs and secrets operator-owned. Do not commit real values here.
+frontend_url      = "https://archmorphai.com"
+db_admin_username = "archmorphadmin"
+# db_admin_password = Set via TF_VAR_db_admin_password or an approved secret store.
+
+# Match current West Europe baseline until Sweden Central quota proves otherwise.
+openai_capacity = 10
+
+# DR stays disabled for the parallel build unless the change request explicitly
+# validates an additional secondary region and cost envelope.
+enable_dr = false


### PR DESCRIPTION
## Summary
- add a Sweden Central one-region migration runbook for #783
- add a readiness/evidence report covering availability, quota, smoke, observability, rollback, traffic shift, and old-region retirement gates
- add an isolated Sweden Central tfvars example and README guardrails that prohibit in-place location mutation

## Validation
- git diff --check
- git diff --cached --check
- find infra -path 'infra/.terraform' -prune -o -name '*.tf' -print0 | xargs -0 terraform fmt -check\n- terraform fmt -check infra/sweden-central.example.tfvars\n- sensitive string scan over staged diff for subscription/resource IDs and secret-like terms\n\n## Note\n- `terraform init -backend=false && terraform validate` was attempted with a fresh `TF_DATA_DIR`, but provider installation hung and was interrupted; this PR is docs/example-only and does not change live Terraform resources.\n\nCloses #783