### PR TITLE
fix: portal sign-in modal and restore auth focus

### DIFF
--- a/frontend/src/components/Auth/LoginModal.jsx
+++ b/frontend/src/components/Auth/LoginModal.jsx
@@ -5,9 +5,11 @@
  * plus "Continue as Guest" — all using Azure SWA auth redirects.
  */
 
-import React from 'react';
+import React, { useEffect, useId } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { useAuth } from './AuthProvider';
+import useFocusTrap from '../../hooks/useFocusTrap';
 /* Simple inline SVG provider icons — avoids external dependency */
 function MicrosoftIcon({ className }) {
   return (
@@ -44,42 +46,67 @@ const PROVIDERS = [
     id: 'microsoft',
     label: 'Continue with Microsoft',
     Icon: MicrosoftIcon,
-    bg: 'bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700',
-    text: 'text-gray-800 dark:text-gray-100',
-    border: 'border-gray-300 dark:border-gray-600',
+    bg: 'bg-secondary hover:bg-border',
+    text: 'text-text-primary',
+    border: 'border-border',
   },
   {
     id: 'google',
     label: 'Continue with Google',
     Icon: GoogleIcon,
-    bg: 'bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700',
-    text: 'text-gray-800 dark:text-gray-100',
-    border: 'border-gray-300 dark:border-gray-600',
+    bg: 'bg-secondary hover:bg-border',
+    text: 'text-text-primary',
+    border: 'border-border',
   },
   {
     id: 'github',
     label: 'Continue with GitHub',
     Icon: GitHubIcon,
-    bg: 'bg-gray-900 hover:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600',
-    text: 'text-white',
-    border: 'border-gray-900 dark:border-gray-600',
+    bg: 'bg-text-primary hover:bg-text-secondary',
+    text: 'text-surface',
+    border: 'border-text-primary',
   },
 ];
 
 export default function LoginModal({ isOpen, onClose }) {
   const { loginWithProvider } = useAuth();
+  const titleId = useId();
+  const trapRef = useFocusTrap(isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') onClose?.();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center">
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto p-4 sm:p-6 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
       />
       {/* Modal */}
-      <div className="relative z-10 w-full max-w-sm mx-4 bg-surface border border-border rounded-2xl shadow-2xl p-6 animate-modal-in">
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 my-auto w-full max-w-sm max-h-[calc(100dvh-2rem)] overflow-y-auto bg-surface border border-border rounded-2xl shadow-2xl p-6 animate-modal-in"
+      >
         {/* Close button */}
         <button
           onClick={onClose}
@@ -91,7 +118,7 @@ export default function LoginModal({ isOpen, onClose }) {
 
         {/* Header */}
         <div className="text-center mb-6">
-          <h2 className="text-xl font-bold text-text-primary">Sign in to Archmorph</h2>
+          <h2 id={titleId} className="text-xl font-bold text-text-primary">Sign in to Archmorph</h2>
           <p className="text-sm text-text-muted mt-1">Save your work across sessions</p>
         </div>
 
@@ -130,6 +157,7 @@ export default function LoginModal({ isOpen, onClose }) {
           No account needed to use the translator. Sign in to save your work.
         </p>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/frontend/src/components/Auth/LoginModal.jsx
+++ b/frontend/src/components/Auth/LoginModal.jsx
@@ -96,7 +96,7 @@ export default function LoginModal({ isOpen, onClose }) {
     <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto p-4 sm:p-6 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
       />
       {/* Modal */}

--- a/frontend/src/components/Auth/UserMenu.jsx
+++ b/frontend/src/components/Auth/UserMenu.jsx
@@ -42,7 +42,10 @@ export default function UserMenu() {
       <>
         <button
           onClick={() => setLoginModalOpen(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-cta hover:bg-cta/10 rounded-lg transition-colors cursor-pointer"
+          className="flex min-h-11 min-w-11 items-center justify-center gap-0 rounded-lg p-1.5 text-sm font-medium text-cta transition-colors hover:bg-cta/10 cursor-pointer sm:min-h-0 sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
+          aria-label="Sign in"
+          aria-haspopup="dialog"
+          aria-expanded={loginModalOpen}
         >
           <User className="w-4 h-4" />
           <span className="hidden sm:inline">Sign In</span>

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -46,7 +46,7 @@ const useAuthStore = create((set, get) => ({
 
     // 1. Try Azure SWA built-in auth (production on Static Web Apps)
     try {
-      const res = await fetch('/.auth/me');
+      const res = await fetch('/.auth/me', { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
         const principal = data?.clientPrincipal;
@@ -54,6 +54,7 @@ const useAuthStore = create((set, get) => ({
           // SWA authenticated — get full user from our API
           const apiRes = await fetch(`${API_BASE}/auth/me`, {
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
           });
           if (apiRes.ok) {
             const user = await apiRes.json();
@@ -99,10 +100,13 @@ const useAuthStore = create((set, get) => ({
 
   // ── Login via provider (Azure SWA redirect) ──
   loginWithProvider: (provider) => {
+    const redirectUri = encodeURIComponent(
+      `${window.location.pathname}${window.location.search}${window.location.hash}`
+    );
     const urls = {
-      microsoft: '/.auth/login/aad?post_login_redirect_uri=' + encodeURIComponent(window.location.pathname),
-      google: '/.auth/login/google?post_login_redirect_uri=' + encodeURIComponent(window.location.pathname),
-      github: '/.auth/login/github?post_login_redirect_uri=' + encodeURIComponent(window.location.pathname),
+      microsoft: `/.auth/login/aad?post_login_redirect_uri=${redirectUri}`,
+      google: `/.auth/login/google?post_login_redirect_uri=${redirectUri}`,
+      github: `/.auth/login/github?post_login_redirect_uri=${redirectUri}`,
     };
     const url = urls[provider];
     if (url) {


### PR DESCRIPTION
Fixes #803\nFixes #805\nFixes #815\nFixes #816\nFixes #817\nFixes #818\nFixes #819\nFixes #907\nFixes #908\n\n## Summary\n- Portals LoginModal to document.body so fixed positioning is no longer constrained by the blurred Nav header.\n- Adds dialog semantics, aria-modal/labelledby, focus trap, Escape close, body scroll lock, safe-area/dvh viewport sizing, and focus restoration.\n- Makes the mobile Sign In trigger a named 44x44 control with dialog state attributes.\n- Preserves search/hash across SWA provider redirects and includes credentials for SWA auth checks.\n\n## Verification\n- npm run lint -- --quiet\n- npm run build\n- Browser check at 127.0.0.1:5173: modal is in document.body, fully in viewport, focus moves to Close, Escape closes and restores focus to Sign in, body overflow resets.