### PR TITLE
fix: coerce object-shaped diagram details before render

### DIFF
--- a/frontend/src/components/DiagramTranslator/PricingTab.jsx
+++ b/frontend/src/components/DiagramTranslator/PricingTab.jsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft, Loader2, TrendingDown, MapPin, ExternalLink, Shield, Layers,
 } from 'lucide-react';
 import { Button, Card, Badge } from '../ui';
+import { toRenderableString } from '../../utils/toRenderableString';
 
 /* ── Per-Service Breakdown Row ─────────────────────────── */
 function ServiceRow({ svc }) {
@@ -51,7 +52,7 @@ function ServiceRow({ svc }) {
               <ul className="space-y-0.5">
                 {svc.assumptions.map((a, i) => (
                   <li key={i} className="text-xs text-text-muted flex items-start gap-1.5">
-                    <span className="text-cta/60 mt-0.5">•</span> {typeof a === 'string' ? a : JSON.stringify(a)}
+                    <span className="text-cta/60 mt-0.5">•</span> {toRenderableString(a)}
                   </li>
                 ))}
               </ul>
@@ -113,7 +114,7 @@ function OptimizationCard({ opt }) {
           {expanded && (
             <ol className="mt-2 space-y-1 list-decimal list-inside">
               {opt.action_steps.map((step, i) => (
-                <li key={i} className="text-xs text-text-muted">{step}</li>
+                <li key={i} className="text-xs text-text-muted">{toRenderableString(step)}</li>
               ))}
             </ol>
           )}
@@ -323,7 +324,7 @@ export default function PricingTab({ costBreakdown, loading, onSetStep, onExport
           <ul className="space-y-1">
             {pricing_assumptions.map((a, i) => (
               <li key={i} className="text-[11px] text-text-muted flex items-start gap-1.5">
-                <span className="text-cta/60 mt-0.5">•</span> {a}
+                <span className="text-cta/60 mt-0.5">•</span> {toRenderableString(a)}
               </li>
             ))}
           </ul>

--- a/frontend/src/components/DiagramTranslator/ResultsTable.jsx
+++ b/frontend/src/components/DiagramTranslator/ResultsTable.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { Badge, Card } from '../ui';
 import { ContextualHint } from '../ContextualHint';
+import { toRenderableString } from '../../utils/toRenderableString';
 
 /* ── Helpers ── */
 const effortValue = (e) => e === 'low' ? 1 : e === 'medium' ? 2 : e === 'high' ? 3 : 0;
@@ -634,7 +635,7 @@ export default function ResultsTable({ analysis, activeView, onViewChange }) {
                                       {m.confidence_explanation.map((reason, idx) => (
                                         <div key={idx} className="flex items-start gap-2 text-text-muted">
                                           <span className="text-cta/60 mt-0.5">•</span>
-                                          <span>{reason}</span>
+                                          <span>{toRenderableString(reason)}</span>
                                         </div>
                                       ))}
                                     </div>
@@ -666,10 +667,10 @@ export default function ResultsTable({ analysis, activeView, onViewChange }) {
                                           </p>
                                           <div className="flex flex-wrap gap-1">
                                             {(m.confidence_provenance.feature_parity.matched_features || []).map((f, i) => (
-                                              <span key={i} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-green-500/10 text-green-400">✓ {f}</span>
+                                              <span key={i} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-green-500/10 text-green-400">✓ {toRenderableString(f)}</span>
                                             ))}
                                             {(m.confidence_provenance.feature_parity.missing_features || []).map((f, i) => (
-                                              <span key={i} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-red-500/10 text-red-400">✗ {f}</span>
+                                              <span key={i} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-red-500/10 text-red-400">✗ {toRenderableString(f)}</span>
                                             ))}
                                           </div>
                                         </div>
@@ -691,7 +692,7 @@ export default function ResultsTable({ analysis, activeView, onViewChange }) {
                                             <div className="space-y-0.5">
                                               {m.confidence_provenance.migration_guidance.breaking_changes.map((bc, i) => (
                                                 <div key={i} className="flex items-start gap-1 text-[10px] text-red-400">
-                                                  <span>⚠</span><span>{bc}</span>
+                                                  <span>⚠</span><span>{toRenderableString(bc)}</span>
                                                 </div>
                                               ))}
                                             </div>
@@ -718,8 +719,8 @@ export default function ResultsTable({ analysis, activeView, onViewChange }) {
                                     <div className="pl-3 border-l-2 border-warning/30 space-y-1 mt-2">
                                       <p className="text-warning font-semibold">Feature gaps:</p>
                                       {m._gaps.map((g, idx) => {
-                                        const text = typeof g === 'string' ? g : g.factor || '';
-                                        const detail = typeof g === 'string' ? null : g.detail;
+                                        const text = typeof g === 'string' ? g : toRenderableString(g.factor || g);
+                                        const detail = typeof g === 'string' ? null : toRenderableString(g.detail);
                                         return (
                                           <div key={idx} className="flex items-start gap-2 text-text-muted">
                                             <AlertTriangle className="w-3 h-3 text-warning shrink-0 mt-0.5" />

--- a/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
@@ -153,4 +153,42 @@ describe('AnalysisResults', () => {
     expect(screen.getByText('plain string still works')).toBeInTheDocument()
     expect(screen.getByText('Falls back to description key')).toBeInTheDocument()
   })
+
+  it('renders object-shaped confidence provenance details without crashing', async () => {
+    const user = userEvent.setup()
+    const objectDetails = {
+      ...mockAnalysis,
+      mappings: [
+        {
+          source_service: 'Lambda',
+          azure_service: 'Azure Functions',
+          confidence: 0.91,
+          notes: 'Zone 1',
+          confidence_explanation: [
+            { message: 'Runtime capabilities match' },
+          ],
+          confidence_provenance: {
+            feature_parity: {
+              parity_score: 'strong',
+              matched_features: [{ name: 'Event triggers' }],
+              missing_features: [{ message: 'Runtime limit differs' }],
+            },
+            migration_guidance: {
+              estimated_effort: 'medium',
+              breaking_changes: [{ description: 'Rewrite deployment package' }],
+            },
+          },
+        },
+      ],
+    }
+
+    render(<AnalysisResults {...defaultProps} analysis={objectDetails} />)
+    await user.click(screen.getByText('Table'))
+    await user.click(screen.getByText('Lambda'))
+
+    expect(screen.getByText('Runtime capabilities match')).toBeInTheDocument()
+    expect(screen.getByText(/Event triggers/)).toBeInTheDocument()
+    expect(screen.getByText(/Runtime limit differs/)).toBeInTheDocument()
+    expect(screen.getByText('Rewrite deployment package')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/DiagramTranslator/__tests__/PricingTab.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/PricingTab.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PricingTab from '../PricingTab'
+
+describe('PricingTab', () => {
+  it('renders object-shaped pricing assumptions and action steps without crashing', async () => {
+    const user = userEvent.setup()
+    const costBreakdown = {
+      summary: { monthly_low: 10, monthly_mid: 20, monthly_high: 30, region: 'eastus', service_count: 1 },
+      services: [
+        {
+          service: 'Azure Functions',
+          sku: 'Consumption',
+          monthly_low: 10,
+          monthly_mid: 20,
+          monthly_high: 30,
+          formula: 'executions * gb-seconds',
+          assumptions: [{ message: 'One million executions' }],
+        },
+      ],
+      optimizations: [
+        {
+          title: 'Use reserved capacity',
+          description: 'Reduce steady-state cost',
+          savings: '$5/mo',
+          effort: 'low',
+          action_steps: [{ description: 'Review usage baseline' }],
+        },
+      ],
+      pricing_assumptions: [{ message: 'Prices exclude taxes' }],
+    }
+
+    render(
+      <PricingTab
+        costBreakdown={costBreakdown}
+        onSetStep={vi.fn()}
+        onExportPackage={vi.fn()}
+        exportingPackage={false}
+      />
+    )
+
+    await user.click(screen.getByText('Azure Functions'))
+    expect(screen.getByText('One million executions')).toBeInTheDocument()
+    expect(screen.getByText('Prices exclude taxes')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Show action steps'))
+    expect(screen.getByText('Review usage baseline')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #806

## Summary
- Applies `toRenderableString` to remaining confidence provenance, feature parity, breaking-change, gap, pricing assumption, and action-step render paths.
- Adds regression coverage for object-shaped backend arrays in AnalysisResults/ResultsTable and PricingTab.

## Verification
- `npx vitest run src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx src/components/DiagramTranslator/__tests__/PricingTab.test.jsx`
- `npm run lint -- --quiet`
- `npm run build`
