### PR TITLE
fix: propagate auth through api client defaults

### DIFF
--- a/frontend/src/services/__tests__/apiClient.test.js
+++ b/frontend/src/services/__tests__/apiClient.test.js
@@ -11,7 +11,7 @@ import api, { ApiError } from '../../services/apiClient'
 
 describe('apiClient', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    fetch.mockReset()
     localStorage.clear()
   })
 
@@ -267,12 +267,17 @@ describe('apiClient', () => {
   it('default methods include stored session token and SWA credentials', async () => {
     localStorage.setItem('archmorph_session_token', 'stored-jwt-token')
 
-    fetch.mockResolvedValue({
+    const response = {
       ok: true,
       status: 200,
       headers: new Headers({ 'content-type': 'application/json' }),
       json: () => Promise.resolve({ ok: true }),
-    })
+    }
+    fetch
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce(response)
 
     await api.get('/diagrams/d1')
     await api.post('/diagrams/d1/analyze', { target: 'azure' })
@@ -300,6 +305,23 @@ describe('apiClient', () => {
     const callArgs = fetch.mock.calls[0]
     expect(callArgs[1].credentials).toBe('include')
     expect(callArgs[1].headers.Authorization).toBe('Bearer explicit-token')
+  })
+
+  it('does not attach default auth or credentials to third-party absolute URLs', async () => {
+    localStorage.setItem('archmorph_session_token', 'stored-jwt-token')
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ ok: true }),
+    })
+
+    await api.get('https://example.com/external.json')
+
+    const callArgs = fetch.mock.calls[0]
+    expect(callArgs[1].credentials).toBeUndefined()
+    expect(callArgs[1].headers.Authorization).toBeUndefined()
   })
 
   // ── Session expiry detection ──

--- a/frontend/src/services/__tests__/apiClient.test.js
+++ b/frontend/src/services/__tests__/apiClient.test.js
@@ -12,6 +12,7 @@ import api, { ApiError } from '../../services/apiClient'
 describe('apiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
   })
 
   // ── GET requests ──
@@ -261,6 +262,44 @@ describe('apiClient', () => {
 
     const callArgs = fetch.mock.calls[0]
     expect(callArgs[1].headers.Authorization).toBe('Bearer my-jwt-token')
+  })
+
+  it('default methods include stored session token and SWA credentials', async () => {
+    localStorage.setItem('archmorph_session_token', 'stored-jwt-token')
+
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ ok: true }),
+    })
+
+    await api.get('/diagrams/d1')
+    await api.post('/diagrams/d1/analyze', { target: 'azure' })
+    await api.patch('/diagrams/d1', { title: 'New title' })
+    await api.delete('/diagrams/d1')
+
+    for (const [, options] of fetch.mock.calls) {
+      expect(options.credentials).toBe('include')
+      expect(options.headers.Authorization).toBe('Bearer stored-jwt-token')
+    }
+  })
+
+  it('does not overwrite caller-provided Authorization header', async () => {
+    localStorage.setItem('archmorph_session_token', 'stored-jwt-token')
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ ok: true }),
+    })
+
+    await api.auth('GET', '/admin/metrics', { token: 'explicit-token' })
+
+    const callArgs = fetch.mock.calls[0]
+    expect(callArgs[1].credentials).toBe('include')
+    expect(callArgs[1].headers.Authorization).toBe('Bearer explicit-token')
   })
 
   // ── Session expiry detection ──

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -70,11 +70,25 @@ function getStoredToken() {
   }
 }
 
-function buildHeaders(optionsHeaders = {}) {
+function isApiRequest(path, url) {
+  if (!path.startsWith('http')) return true;
+
+  try {
+    const origin = typeof window !== 'undefined' && window.location?.origin ? window.location.origin : 'http://localhost';
+    const requestUrl = new URL(url, origin);
+    const apiUrl = new URL(API_BASE, origin);
+    const apiPath = apiUrl.pathname.replace(/\/$/, '');
+    return requestUrl.origin === apiUrl.origin && requestUrl.pathname.startsWith(apiPath || '/');
+  } catch {
+    return false;
+  }
+}
+
+function buildHeaders(optionsHeaders = {}, includeDefaultAuth = true) {
   const headers = { ...optionsHeaders };
   const hasAuthorization = Object.keys(headers).some(key => key.toLowerCase() === 'authorization');
   const token = getStoredToken();
-  if (token && !hasAuthorization) {
+  if (includeDefaultAuth && token && !hasAuthorization) {
     headers.Authorization = `Bearer ${token}`;
   }
   return headers;
@@ -89,8 +103,9 @@ function buildHeaders(optionsHeaders = {}) {
  */
 async function request(path, options = {}, signal) {
   const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
+  const includeDefaultCredentials = isApiRequest(path, url);
 
-  const headers = buildHeaders(options.headers);
+  const headers = buildHeaders(options.headers, includeDefaultCredentials);
   // Auto-set JSON content type for non-FormData bodies
   if (options.body && !(options.body instanceof FormData)) {
     headers['Content-Type'] = headers['Content-Type'] || 'application/json';
@@ -114,12 +129,18 @@ async function request(path, options = {}, signal) {
     }
 
     try {
-      const res = await fetch(url, {
+      const requestOptions = {
         ...options,
         headers,
-        credentials: options.credentials || 'include',
         signal: timeoutController.signal,
-      });
+      };
+      if (options.credentials !== undefined) {
+        requestOptions.credentials = options.credentials;
+      } else if (includeDefaultCredentials) {
+        requestOptions.credentials = 'include';
+      }
+
+      const res = await fetch(url, requestOptions);
 
       clearTimeout(timeoutId);
       if (signal) signal.removeEventListener('abort', onCallerAbort);

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -22,6 +22,7 @@ const BACKOFF_BASE_MS = process.env.NODE_ENV === 'test' ? 10 : 1000;
 
 /** HTTP status codes that are safe to retry */
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const TOKEN_KEY = 'archmorph_session_token';
 
 /**
  * Map raw API errors to user-friendly messages (#305).
@@ -61,6 +62,24 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function getStoredToken() {
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function buildHeaders(optionsHeaders = {}) {
+  const headers = { ...optionsHeaders };
+  const hasAuthorization = Object.keys(headers).some(key => key.toLowerCase() === 'authorization');
+  const token = getStoredToken();
+  if (token && !hasAuthorization) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
 /**
  * Internal fetch wrapper with timeout, retry, and backoff (#268).
  * @param {string} path - API path (appended to API_BASE)
@@ -71,7 +90,7 @@ function sleep(ms) {
 async function request(path, options = {}, signal) {
   const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
 
-  const headers = { ...options.headers };
+  const headers = buildHeaders(options.headers);
   // Auto-set JSON content type for non-FormData bodies
   if (options.body && !(options.body instanceof FormData)) {
     headers['Content-Type'] = headers['Content-Type'] || 'application/json';
@@ -98,6 +117,7 @@ async function request(path, options = {}, signal) {
       const res = await fetch(url, {
         ...options,
         headers,
+        credentials: options.credentials || 'include',
         signal: timeoutController.signal,
       });
 


### PR DESCRIPTION
Fixes #807\nFixes #854\nFixes #867\n\n## Summary\n- Adds default API client propagation for stored session bearer tokens unless a caller supplies its own Authorization header.\n- Sends credentials with API requests so SWA cookie-backed sessions are honored.\n- Adds regression coverage for default GET/POST/PATCH/DELETE auth propagation and explicit auth override behavior.\n\n## Verification\n- npx vitest run src/services/__tests__/apiClient.test.js\n- npm run lint -- --quiet\n- npm run build