### PR TITLE
fix: harden profile modal auth and accessibility

### DIFF
--- a/frontend/src/components/Auth/ProfilePage.jsx
+++ b/frontend/src/components/Auth/ProfilePage.jsx
@@ -5,10 +5,12 @@
  * IaC format preferences. Includes account deletion with confirmation.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useId } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Save, Trash2, Loader2, AlertTriangle } from 'lucide-react';
 import { useAuth } from './AuthProvider';
 import { API_BASE } from '../../constants';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 const ROLES = [
   { value: 'cloud_architect', label: 'Cloud Architect' },
@@ -31,6 +33,19 @@ const IAC_FORMATS = [
 
 const normalizeIacFormat = (format) => (format === 'terraform' || format === 'bicep' ? format : null);
 
+function authHeaders(extra = {}) {
+  let token = null;
+  try {
+    token = localStorage.getItem('archmorph_session_token');
+  } catch {
+    token = null;
+  }
+  return {
+    ...extra,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
 function Select({ label, value, onChange, options, placeholder }) {
   return (
     <div>
@@ -51,6 +66,8 @@ function Select({ label, value, onChange, options, placeholder }) {
 
 export default function ProfilePage({ isOpen, onClose }) {
   const { user, isAuthenticated, logout } = useAuth();
+  const titleId = useId();
+  const trapRef = useFocusTrap(isOpen);
   const [form, setForm] = useState({
     display_name: '',
     company: '',
@@ -67,9 +84,9 @@ export default function ProfilePage({ isOpen, onClose }) {
   useEffect(() => {
     if (!isOpen || !isAuthenticated) return;
 
-    const token = localStorage.getItem('archmorph_session_token');
     fetch(`${API_BASE}/me/profile`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      headers: authHeaders(),
+      credentials: 'include',
     })
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
@@ -86,19 +103,33 @@ export default function ProfilePage({ isOpen, onClose }) {
       .catch(() => {});
   }, [isOpen, isAuthenticated]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') onClose?.();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const handleSave = async () => {
     setSaving(true);
     setMessage(null);
     try {
-      const token = localStorage.getItem('archmorph_session_token');
       const res = await fetch(`${API_BASE}/me/profile`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        credentials: 'include',
         body: JSON.stringify(form),
       });
       if (res.ok) {
@@ -117,10 +148,10 @@ export default function ProfilePage({ isOpen, onClose }) {
   const handleDelete = async () => {
     setDeleting(true);
     try {
-      const token = localStorage.getItem('archmorph_session_token');
       const res = await fetch(`${API_BASE}/me/account`, {
         method: 'DELETE',
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        headers: authHeaders(),
+        credentials: 'include',
       });
       if (res.ok) {
         logout();
@@ -136,13 +167,20 @@ export default function ProfilePage({ isOpen, onClose }) {
     }
   };
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto p-4 sm:p-6 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]">
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 my-auto bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-semibold text-text-primary">Profile Settings</h2>
-          <button onClick={onClose} className="p-1 hover:bg-secondary rounded-lg transition-colors cursor-pointer">
+          <h2 id={titleId} className="text-lg font-semibold text-text-primary">Profile Settings</h2>
+          <button onClick={onClose} className="p-1 hover:bg-secondary rounded-lg transition-colors cursor-pointer" aria-label="Close profile settings">
             <X className="w-5 h-5 text-text-muted" />
           </button>
         </div>
@@ -249,6 +287,7 @@ export default function ProfilePage({ isOpen, onClose }) {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/frontend/src/components/Auth/ProfilePage.jsx
+++ b/frontend/src/components/Auth/ProfilePage.jsx
@@ -11,6 +11,7 @@ import { X, Save, Trash2, Loader2, AlertTriangle } from 'lucide-react';
 import { useAuth } from './AuthProvider';
 import { API_BASE } from '../../constants';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import { TOKEN_KEY } from '../../stores/useAuthStore';
 
 const ROLES = [
   { value: 'cloud_architect', label: 'Cloud Architect' },
@@ -36,7 +37,7 @@ const normalizeIacFormat = (format) => (format === 'terraform' || format === 'bi
 function authHeaders(extra = {}) {
   let token = null;
   try {
-    token = localStorage.getItem('archmorph_session_token');
+    token = localStorage.getItem(TOKEN_KEY);
   } catch {
     token = null;
   }
@@ -169,7 +170,7 @@ export default function ProfilePage({ isOpen, onClose }) {
 
   return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto p-4 sm:p-6 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]">
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" data-testid="profile-backdrop" onClick={onClose} />
       <div
         ref={trapRef}
         role="dialog"

--- a/frontend/src/components/__tests__/ProfilePage.test.jsx
+++ b/frontend/src/components/__tests__/ProfilePage.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 import ProfilePage from '../Auth/ProfilePage'
 
 const logout = vi.fn()
@@ -37,6 +38,31 @@ describe('ProfilePage', () => {
 
     await user.keyboard('{Escape}')
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on backdrop click and restores focus after unmount', async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Open profile</button>
+          <ProfilePage isOpen={open} onClose={() => setOpen(false)} />
+        </>
+      )
+    }
+
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'Open profile' })
+    trigger.focus()
+    await user.click(trigger)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close profile settings' })).toHaveFocus())
+    await user.click(screen.getByTestId('profile-backdrop'))
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Profile Settings' })).not.toBeInTheDocument())
+    expect(trigger).toHaveFocus()
   })
 
   it('sends SWA credentials and stored token when loading profile', async () => {

--- a/frontend/src/components/__tests__/ProfilePage.test.jsx
+++ b/frontend/src/components/__tests__/ProfilePage.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProfilePage from '../Auth/ProfilePage'
+
+const logout = vi.fn()
+
+vi.mock('../Auth/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', name: 'Ada', email: 'ada@example.com', provider: 'github' },
+    isAuthenticated: true,
+    logout,
+  }),
+}))
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    document.body.style.overflow = ''
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ display_name: 'Ada' }),
+    })
+  })
+
+  it('renders as an accessible dialog and closes on Escape', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<ProfilePage isOpen onClose={onClose} />)
+
+    expect(screen.getByRole('dialog', { name: 'Profile Settings' })).toBeInTheDocument()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends SWA credentials and stored token when loading profile', async () => {
+    localStorage.setItem('archmorph_session_token', 'stored-token')
+
+    render(<ProfilePage isOpen onClose={vi.fn()} />)
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    const [, options] = fetch.mock.calls[0]
+    expect(options.credentials).toBe('include')
+    expect(options.headers.Authorization).toBe('Bearer stored-token')
+  })
+
+  it('sends SWA credentials when saving profile without localStorage token', async () => {
+    const user = userEvent.setup()
+    render(<ProfilePage isOpen onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /Save/ }))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+    const [, options] = fetch.mock.calls[1]
+    expect(options.method).toBe('PUT')
+    expect(options.credentials).toBe('include')
+    expect(options.headers.Authorization).toBeUndefined()
+  })
+})

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -10,7 +10,7 @@
 import { create } from 'zustand';
 import { API_BASE } from '../constants';
 
-const TOKEN_KEY = 'archmorph_session_token';
+export const TOKEN_KEY = 'archmorph_session_token';
 const REFRESH_KEY = 'archmorph_refresh_token';
 
 /** Read stored token from localStorage */


### PR DESCRIPTION
Fixes #804\nFixes #808\n\n## Summary\n- Ports ProfilePage to document.body and gives it dialog semantics, Escape close, scroll lock, backdrop close, and focus trapping.\n- Sends credentials on profile/account requests so SWA cookie auth works, while preserving bearer token support for localStorage sessions.\n- Adds ProfilePage regression coverage for dialog behavior and SWA/token request options.\n\n## Verification\n- npx vitest run src/components/__tests__/ProfilePage.test.jsx\n- npm run lint -- --quiet\n- npm run build