### PR TITLE
ci: guard Vite env exposure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,9 @@ jobs:
       - name: Run frontend linter
         run: npm run lint
 
+      - name: Guard Vite environment exposure
+        run: python3 ../scripts/lint_vite_env_guard.py
+
       - name: Run frontend tests
         run: npx vitest run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **GitHub Actions Node.js 24 readiness** — audited workflow action runtimes, moved deprecated Node.js 20 action pins to Node.js 24-compatible majors, pinned Trivy to a release tag, and documented the workflow runtime inventory for release maintenance.
 - **Dependabot PR #785** — upgraded `hashicorp/setup-terraform` from v3 to v4 in CI after a clean rebase and green checks, keeping Terraform validation on the action's Node.js 24-compatible runtime.
+- **Audit P2 CI/security hygiene (#865 #891 #892 #918)** — kept generated Terraform/Bicep validation and CodeQL SAST in the merge gate, added a Vite environment exposure guard that fails CI on secret-like `VITE_*` names, and rejects blanket `define: { 'process.env': ... }` Vite config patterns.
 
 #### QA guardrails
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Archmorph is an AI-assisted cloud migration workbench. The live path analyzes up
 
 | Status | Meaning | Capabilities |
 |--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning |
+| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard |
 | Beta | Implemented but needs hardening, deeper tests, or production validation | Cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
 | Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault |
 | Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
@@ -180,6 +180,13 @@ cd backend
 python export_openapi.py > openapi.snapshot.json
 python check_openapi_contract.py
 ```
+
+**Check frontend environment exposure before adding new Vite variables:**
+```bash
+python3 scripts/lint_vite_env_guard.py
+```
+
+The guard fails CI when a secret-like client variable such as `VITE_*_KEY`, `VITE_*_TOKEN`, `VITE_*_SECRET`, or `VITE_*_PASSWORD` is introduced, and it rejects blanket Vite `process.env` defines. Server-only proxy or credential values must use non-`VITE_` names.
 
 ---
 

--- a/backend/tests/test_vite_env_guard.py
+++ b/backend/tests/test_vite_env_guard.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[2]
+VITE_ENV_GUARD = REPO_ROOT / "scripts" / "lint_vite_env_guard.py"
+
+
+def _load_guard_module():
+    spec = importlib.util.spec_from_file_location("lint_vite_env_guard", VITE_ENV_GUARD)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+find_violations = _load_guard_module().find_violations
+
+
+def test_vite_env_guard_allows_public_api_base(tmp_path: Path):
+    config = tmp_path / "vite.config.js"
+    config.write_text("const apiBase = import.meta.env.VITE_API_BASE\n", encoding="utf-8")
+
+    assert find_violations([config]) == []
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["VITE_OPENAI_KEY", "VITE_SERVICE_TOKEN", "VITE_CLIENT_SECRET", "VITE_DB_PASSWORD"],
+)
+def test_vite_env_guard_rejects_secret_like_vite_names(tmp_path: Path, env_name: str):
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(f"env:\n  {env_name}: fake\n", encoding="utf-8")
+
+    violations = find_violations([workflow])
+
+    assert len(violations) == 1
+    assert env_name in violations[0]
+
+def test_rejects_secret_like_vite_env_names_in_shell_scripts(tmp_path):
+    source = tmp_path / "scripts" / "deploy.sh"
+    source.parent.mkdir(parents=True)
+    source.write_text("export VITE_DEPLOY_TOKEN=value\n", encoding="utf-8")
+
+    violations = find_violations([source])
+
+    assert len(violations) == 1
+    assert "VITE_DEPLOY_TOKEN" in violations[0]
+
+
+def test_vite_env_guard_rejects_blanket_process_env_define(tmp_path: Path):
+    config = tmp_path / "vite.config.ts"
+    config.write_text("export default { define: { 'process.env': process.env } }\n", encoding="utf-8")
+
+    violations = find_violations([config])
+
+    assert len(violations) == 1
+    assert "blanket define" in violations[0]

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, and the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, and CI now enforces generated IaC validation, CodeQL SAST, and Vite client-env exposure guardrails.
 
 ---
 
@@ -24,7 +24,7 @@ Current infrastructure posture: West Europe remains the active production region
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates |
+| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, and Vite env exposure lint |
 | Beta | Cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |

--- a/scripts/lint_vite_env_guard.py
+++ b/scripts/lint_vite_env_guard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SECRET_LIKE_VITE_ENV = re.compile(r"\bVITE_[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*\b")
+PROCESS_ENV_DEFINE = re.compile(r"define\s*:\s*\{[^}]*['\"]process\.env['\"]\s*:", re.DOTALL)
+VITE_CONFIG_NAMES = {"vite.config.js", "vite.config.mjs", "vite.config.ts", "vite.config.mts"}
+SKIP_PARTS = {"node_modules", "dist", "build", ".git", ".vite", ".lighthouseci"}
+TEXT_SUFFIXES = {
+    ".env",
+    ".example",
+    ".js",
+    ".jsx",
+    ".json",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".mjs",
+    ".mts",
+    ".ts",
+    ".tsx",
+    ".yml",
+    ".yaml",
+}
+
+
+def _is_scannable(path: Path) -> bool:
+    if any(part in SKIP_PARTS for part in path.parts):
+        return False
+    if path.name.startswith(".env"):
+        return True
+    return path.suffix in TEXT_SUFFIXES
+
+
+def _git_files(repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def find_violations(paths: list[Path]) -> list[str]:
+    violations: list[str] = []
+    for path in paths:
+        if not path.exists() or not path.is_file() or not _is_scannable(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for match in sorted(set(SECRET_LIKE_VITE_ENV.findall(text))):
+            violations.append(
+                f"{path}: secret-like client env var {match!r}; use a server-only env name without the VITE_ prefix"
+            )
+
+        if path.name in VITE_CONFIG_NAMES and PROCESS_ENV_DEFINE.search(text):
+            violations.append(
+                f"{path}: blanket define for 'process.env' is not allowed in Vite config; define explicit public keys only"
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reject Vite env patterns that can expose server-side secrets")
+    parser.add_argument("paths", nargs="*", type=Path, help="Optional files to scan instead of git-tracked files")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    paths = args.paths or _git_files(repo_root)
+    violations = find_violations(paths)
+    if violations:
+        print("Vite environment guard failed:", file=sys.stderr)
+        for violation in violations:
+            print(f"- {violation}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a Vite environment exposure guard that rejects secret-like VITE_* names in code/config/workflows.
- Reject blanket Vite define process.env patterns.
- Wire the guard into CI before frontend tests/build.
- Document the CI/security hygiene posture in README, PRD, and CHANGELOG.

## Evidence
- Current main already enforces generated Terraform/Bicep artifact validation in iac-validate.
- Current main already runs CodeQL for Python and JavaScript in security.yml.
- New tests cover allowed public VITE_API_BASE, rejected VITE_*KEY/TOKEN/SECRET/PASSWORD, and rejected blanket process.env Vite define.

## Validation
- /Users/idokatz/VSCode/.venv/bin/python scripts/lint_vite_env_guard.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest -q backend/tests/test_vite_env_guard.py backend/tests/test_k6_performance_contract.py
- npm --prefix frontend run lint

Closes #865
Closes #891
Closes #892
Closes #918