### PR TITLE
fix: close P2 analysis and focus bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions Node.js 24 readiness** — audited workflow action runtimes, moved deprecated Node.js 20 action pins to Node.js 24-compatible majors, pinned Trivy to a release tag, and documented the workflow runtime inventory for release maintenance.
 - **Dependabot PR #785** — upgraded `hashicorp/setup-terraform` from v3 to v4 in CI after a clean rebase and green checks, keeping Terraform validation on the action's Node.js 24-compatible runtime.
 - **Audit P2 CI/security hygiene (#865 #891 #892 #918)** — kept generated Terraform/Bicep validation and CodeQL SAST in the merge gate, added a Vite environment exposure guard that fails CI on secret-like `VITE_*` names, and rejects blanket `define: { 'process.env': ... }` Vite config patterns.
+- **Audit P2 bug hygiene (#916 #917 #920)** — stabilized Roadmap modal close callbacks to avoid repeated Escape listener churn on parent rerenders, mapped retryable vision-analysis failures to 503 responses with `Retry-After`, and hardened focus-trap cleanup so Esc, close buttons, backdrop clicks, and submit-driven closes restore focus to the opener.
 
 #### QA guardrails
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Archmorph is an AI-assisted cloud migration workbench. The live path analyzes up
 
 | Status | Meaning | Capabilities |
 |--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard |
+| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
 | Beta | Implemented but needs hardening, deeper tests, or production validation | Cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
 | Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault |
 | Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |

--- a/backend/error_envelope.py
+++ b/backend/error_envelope.py
@@ -78,16 +78,18 @@ class ArchmorphException(Exception):
     Standardized exception for expected business logic errors.
     Automatically caught and formatted as an error envelope.
     """
-    def __init__(self, status_code: int, detail: str, details: Any = None):
+    def __init__(self, status_code: int, detail: str, details: Any = None, headers: Optional[Dict[str, str]] = None):
         self.status_code = status_code
         self.detail = detail
         self.details = details
+        self.headers = headers
 
 async def _archmorph_exception_handler(_request: Request, exc: ArchmorphException) -> JSONResponse:
     logger.info("ArchmorphException raised: %d %s", exc.status_code, exc.detail)
     return JSONResponse(
         status_code=exc.status_code,
         content=_build_envelope(exc.status_code, exc.detail, details=exc.details),
+        headers=exc.headers,
     )
 
 # ── Exception handlers ─────────────────────────────────────
@@ -96,6 +98,7 @@ async def _http_exception_handler(_request: Request, exc: HTTPException) -> JSON
     return JSONResponse(
         status_code=exc.status_code,
         content=_build_envelope(exc.status_code, detail),
+        headers=exc.headers,
     )
 
 

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -29,6 +29,7 @@ from usage_metrics import record_event, record_funnel_step
 from export_capabilities import attach_export_capability
 from image_classifier import classify_image
 from vision_analyzer import analyze_image
+from openai_client import OpenAIServiceError, handle_openai_error
 from hld_generator import generate_hld, generate_hld_markdown  # noqa: F401 — re-exported for test monkeypatching
 from auth import get_user_from_request_headers
 from analysis_history import maybe_save_from_session
@@ -317,6 +318,38 @@ async def restore_session(
 # ─────────────────────────────────────────────────────────────
 # Diagrams — Analyze (sync)
 # ─────────────────────────────────────────────────────────────
+
+def _retry_after_seconds(exc: Exception, default: int = 30) -> int:
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", {}) or {}
+    value = headers.get("Retry-After") or headers.get("retry-after")
+    try:
+        retry_after = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        retry_after = default
+    return max(1, min(retry_after, 300))
+
+
+def _raise_analysis_service_failure(exc: Exception) -> None:
+    service_error = exc if isinstance(exc, OpenAIServiceError) else handle_openai_error(exc, "Vision analysis")
+    if service_error.status_code == 429:
+        retry_after = _retry_after_seconds(exc)
+        raise ArchmorphException(
+            503,
+            "Analysis service is busy. Please wait a moment and try again.",
+            details={"error": "analysis_retryable", "retry_after_seconds": retry_after},
+            headers={"Retry-After": str(retry_after)},
+        )
+    if service_error.retryable:
+        raise ArchmorphException(
+            503,
+            service_error.args[0] if service_error.args else "Analysis service is temporarily unavailable.",
+            details={"error": "analysis_retryable", "retry_after_seconds": 30},
+            headers={"Retry-After": "30"},
+        )
+    raise ArchmorphException(service_error.status_code, service_error.args[0] if service_error.args else "Vision analysis failed.")
+
+
 @router.post("/api/diagrams/{diagram_id}/analyze")
 @limiter.limit("5/minute")
 async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verify_api_key)):
@@ -376,7 +409,7 @@ async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verif
 
     if isinstance(analysis_result_or_exc, Exception):
         logger.error("Vision analysis failed for %s: %s", str(diagram_id).replace('\n', '').replace('\r', ''), str(analysis_result_or_exc).replace('\n', '').replace('\r', ''), exc_info=True)  # codeql[py/log-injection] Handled by custom
-        raise ArchmorphException(500, "Vision analysis failed. Please try again with a different image.")
+        _raise_analysis_service_failure(analysis_result_or_exc)
 
     result = await asyncio.to_thread(_normalize_analysis, analysis_result_or_exc)
     result["diagram_id"] = diagram_id

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -24,6 +24,7 @@ from usage_metrics import record_event, record_funnel_step, get_metrics_summary,
 from guided_questions import generate_questions, apply_answers
 from diagram_export import generate_diagram, get_azure_stencil_id
 from services import AWS_SERVICES, AZURE_SERVICES, GCP_SERVICES, CROSS_CLOUD_MAPPINGS
+from openai_client import OpenAIServiceError
 
 
 # ====================================================================
@@ -229,6 +230,24 @@ class TestAnalyze:
         """Analyze without prior upload should return 404."""
         resp = client.post("/api/diagrams/nonexistent-diag/analyze")
         assert resp.status_code == 404
+
+    def test_analyze_rate_limit_returns_retryable_503(self, client, clean_session):
+        did = self._upload(client)
+        analysis_error = OpenAIServiceError(
+            "Vision analysis is temporarily rate-limited. Please retry shortly.",
+            retryable=True,
+            status_code=429,
+        )
+
+        with patch("routers.diagrams.analyze_image", side_effect=analysis_error), \
+             patch("routers.diagrams.classify_image", return_value={"is_architecture_diagram": True, "confidence": 0.95, "image_type": "architecture_diagram", "reason": "Mock"}):
+            resp = client.post(f"/api/diagrams/{did}/analyze")
+
+        assert resp.status_code == 503
+        assert resp.headers["retry-after"] == "30"
+        body = resp.json()
+        assert body["error"]["details"]["error"] == "analysis_retryable"
+        assert body["error"]["details"]["retry_after_seconds"] == 30
 
 
 # ====================================================================

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, and CI now enforces generated IaC validation, CodeQL SAST, and Vite client-env exposure guardrails.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, and Vite client-env exposure guardrails, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
 
 ---
 
@@ -24,7 +24,7 @@ Current infrastructure posture: West Europe remains the active production region
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, and Vite env exposure lint |
+| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
 | Beta | Cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -683,6 +683,12 @@ export default function DiagramTranslator() {
         });
         return;
       }
+      if ((err.status === 429 || err.status === 503) && err.body?.error?.details?.error === 'analysis_retryable') {
+        const retryAfter = err.body.error.details.retry_after_seconds;
+        const retryCopy = retryAfter ? ` Please retry in about ${retryAfter} seconds.` : ' Please retry shortly.';
+        set({ error: `${err.body.error.message}${retryCopy}`, step: 'upload' });
+        return;
+      }
       if (err.name === 'AbortError') return; // Component unmounted
       set({ error: err.message, step: 'upload' });
     }

--- a/frontend/src/components/Roadmap.jsx
+++ b/frontend/src/components/Roadmap.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import DOMPurify from 'dompurify';
 import {
   Calendar, Rocket, Clock, Lightbulb, CheckCircle2, Loader2, ChevronDown, ChevronRight,
@@ -419,6 +419,12 @@ export default function Roadmap() {
     });
   };
 
+  const openFeatureModal = useCallback(() => setFeatureModalOpen(true), []);
+  const closeFeatureModal = useCallback(() => setFeatureModalOpen(false), []);
+  const openBugModal = useCallback(() => setBugModalOpen(true), []);
+  const closeBugModal = useCallback(() => setBugModalOpen(false), []);
+  const closeToast = useCallback(() => setToast(null), []);
+
   const filteredReleases = useMemo(() => {
     if (!roadmap) return { sections: [] };
     const { released = [], in_progress = [], planned = [], ideas = [] } = roadmap.timeline || {};
@@ -537,14 +543,14 @@ export default function Roadmap() {
         
         <div className="flex items-center gap-3">
           <button
-            onClick={() => setFeatureModalOpen(true)}
+            onClick={openFeatureModal}
             className="flex items-center gap-2 px-4 py-2.5 bg-cta hover:bg-cta-hover text-surface text-sm font-semibold rounded-lg transition-colors cursor-pointer"
           >
             <Sparkles className="w-4 h-4" />
             Request Feature
           </button>
           <button
-            onClick={() => setBugModalOpen(true)}
+            onClick={openBugModal}
             className="flex items-center gap-2 px-4 py-2.5 bg-error/10 hover:bg-error/20 text-error text-sm font-semibold rounded-lg border border-error/30 transition-colors cursor-pointer"
           >
             <Bug className="w-4 h-4" />
@@ -675,7 +681,7 @@ export default function Roadmap() {
       {/* Modals */}
       {featureModalOpen && (
         <FeatureRequestModal
-          onClose={() => setFeatureModalOpen(false)}
+          onClose={closeFeatureModal}
           onSubmit={handleFeatureSubmit}
           loading={submitting}
         />
@@ -683,7 +689,7 @@ export default function Roadmap() {
       
       {bugModalOpen && (
         <BugReportModal
-          onClose={() => setBugModalOpen(false)}
+          onClose={closeBugModal}
           onSubmit={handleBugSubmit}
           loading={submitting}
         />
@@ -694,7 +700,7 @@ export default function Roadmap() {
         <SuccessToast
           message={toast.message}
           issueUrl={toast.issueUrl}
-          onClose={() => setToast(null)}
+          onClose={closeToast}
         />
       )}
     </div>

--- a/frontend/src/components/__tests__/Roadmap.test.jsx
+++ b/frontend/src/components/__tests__/Roadmap.test.jsx
@@ -99,4 +99,21 @@ describe('Roadmap', () => {
     await user.click(screen.getByText('Request Feature'))
     expect(screen.getByText('Request a Feature')).toBeInTheDocument()
   })
+
+  it('keeps modal Escape listener stable across parent rerenders', async () => {
+    const user = userEvent.setup()
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    const { rerender } = render(<Roadmap />)
+
+    await screen.findByText('Request Feature')
+    await user.click(screen.getByText('Request Feature'))
+    const keydownAdds = addSpy.mock.calls.filter(([eventName]) => eventName === 'keydown').length
+    const keydownRemoves = removeSpy.mock.calls.filter(([eventName]) => eventName === 'keydown').length
+
+    rerender(<Roadmap />)
+
+    expect(addSpy.mock.calls.filter(([eventName]) => eventName === 'keydown')).toHaveLength(keydownAdds)
+    expect(removeSpy.mock.calls.filter(([eventName]) => eventName === 'keydown')).toHaveLength(keydownRemoves)
+  })
 })

--- a/frontend/src/hooks/__tests__/useFocusTrap.test.jsx
+++ b/frontend/src/hooks/__tests__/useFocusTrap.test.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useFocusTrap from '../useFocusTrap';
+
+function FocusTrapHarness() {
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const trapRef = useFocusTrap(open);
+  const close = () => setOpen(false);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>Open dialog</button>
+      {open && (
+        <div
+          ref={trapRef}
+          role="dialog"
+          aria-modal="true"
+          onClick={close}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') close();
+          }}
+        >
+          <div onClick={(event) => event.stopPropagation()}>
+            <button type="button" onClick={close}>Close</button>
+            <button
+              type="button"
+              onClick={() => {
+                setSubmitted(true);
+                close();
+              }}
+            >
+              Submit
+            </button>
+          </div>
+        </div>
+      )}
+      {submitted && <p>Submitted</p>}
+    </div>
+  );
+}
+
+async function expectFocusRestoredToOpener() {
+  await waitFor(() => expect(screen.getByRole('button', { name: /open dialog/i })).toHaveFocus());
+}
+
+describe('useFocusTrap', () => {
+  it('restores focus to opener when closed with Escape', async () => {
+    const user = userEvent.setup();
+    render(<FocusTrapHarness />);
+
+    await user.click(screen.getByRole('button', { name: /open dialog/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /^close$/i })).toHaveFocus());
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await expectFocusRestoredToOpener();
+  });
+
+  it('restores focus to opener when closed with the close button', async () => {
+    const user = userEvent.setup();
+    render(<FocusTrapHarness />);
+
+    await user.click(screen.getByRole('button', { name: /open dialog/i }));
+    await user.click(screen.getByRole('button', { name: /^close$/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await expectFocusRestoredToOpener();
+  });
+
+  it('restores focus to opener when closed from the backdrop', async () => {
+    const user = userEvent.setup();
+    render(<FocusTrapHarness />);
+
+    await user.click(screen.getByRole('button', { name: /open dialog/i }));
+    await user.click(screen.getByRole('dialog'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await expectFocusRestoredToOpener();
+  });
+
+  it('restores focus to opener after submit-driven close', async () => {
+    const user = userEvent.setup();
+    render(<FocusTrapHarness />);
+
+    await user.click(screen.getByRole('button', { name: /open dialog/i }));
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(screen.getByText('Submitted')).toBeInTheDocument();
+    await expectFocusRestoredToOpener();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.js
+++ b/frontend/src/hooks/useFocusTrap.js
@@ -20,11 +20,23 @@ export default function useFocusTrap(active = true) {
   useEffect(() => {
     if (!active) return;
 
+    const restoreFocus = () => {
+      const element = previousFocus.current;
+      previousFocus.current = null;
+      if (
+        element
+        && element.isConnected
+        && typeof element.focus === 'function'
+      ) {
+        element.focus({ preventScroll: true });
+      }
+    };
+
     // Remember the element that had focus before the modal opened
     previousFocus.current = document.activeElement;
 
     const container = containerRef.current;
-    if (!container) return;
+    if (!container) return restoreFocus;
 
     // Move focus into the modal
     const focusFirst = () => {
@@ -61,10 +73,7 @@ export default function useFocusTrap(active = true) {
     return () => {
       cancelAnimationFrame(raf);
       container.removeEventListener('keydown', handleKeyDown);
-      // Restore focus
-      if (previousFocus.current && typeof previousFocus.current.focus === 'function') {
-        previousFocus.current.focus();
-      }
+      restoreFocus();
     };
   }, [active]);
 


### PR DESCRIPTION
## Summary
- Stabilize Roadmap modal and toast close callbacks so parent rerenders do not churn Escape listeners.
- Return retryable 503 analysis failures with Retry-After and a structured analysis_retryable detail instead of success-shaped empty results.
- Show explicit retry copy for retryable analysis failures in the upload flow.
- Harden useFocusTrap cleanup so Esc, close button, backdrop, and submit-driven closes restore focus to the opener.
- Update README, PRD, and CHANGELOG for this P2 bug batch.

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest -q backend/tests/test_api.py::TestAnalyze
- npm --prefix frontend run test -- --run src/hooks/__tests__/useFocusTrap.test.jsx src/components/__tests__/Roadmap.test.jsx
- npm --prefix frontend run lint
- /Users/idokatz/VSCode/.venv/bin/python -m py_compile backend/error_envelope.py backend/routers/diagrams.py backend/tests/test_api.py

Closes #916
Closes #917
Closes #920