### PR TITLE
ci: guard Node Docker base image pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,20 @@ jobs:
       - name: Lint mapping freshness
         run: python scripts/lint_mappings_freshness.py
 
+  container-image-pins:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Guard Docker base image pins
+        run: python3 scripts/lint_docker_base_images.py
+
   # ============================================
   # BACKEND TESTS (3.12 only — production version)
   # ============================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot PR #785** — upgraded `hashicorp/setup-terraform` from v3 to v4 in CI after a clean rebase and green checks, keeping Terraform validation on the action's Node.js 24-compatible runtime.
 - **Audit P2 CI/security hygiene (#865 #891 #892 #918)** — kept generated Terraform/Bicep validation and CodeQL SAST in the merge gate, added a Vite environment exposure guard that fails CI on secret-like `VITE_*` names, and rejects blanket `define: { 'process.env': ... }` Vite config patterns.
 - **Audit P2 bug hygiene (#916 #917 #920)** — stabilized Roadmap modal close callbacks to avoid repeated Escape listener churn on parent rerenders, mapped retryable vision-analysis failures to 503 responses with `Retry-After`, and hardened focus-trap cleanup so Esc, close buttons, backdrop clicks, and submit-driven closes restore focus to the opener.
+- **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
 
 #### QA guardrails
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Archmorph is an AI-assisted cloud migration workbench. The live path analyzes up
 
 | Status | Meaning | Capabilities |
 |--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
+| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, Docker Node base-image pin guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
 | Beta | Implemented but needs hardening, deeper tests, or production validation | Cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
 | Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault |
 | Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
@@ -187,6 +187,13 @@ python3 scripts/lint_vite_env_guard.py
 ```
 
 The guard fails CI when a secret-like client variable such as `VITE_*_KEY`, `VITE_*_TOKEN`, `VITE_*_SECRET`, or `VITE_*_PASSWORD` is introduced, and it rejects blanket Vite `process.env` defines. Server-only proxy or credential values must use non-`VITE_` names.
+
+**Check Docker base-image pinning before adding frontend container images:**
+```bash
+python3 scripts/lint_docker_base_images.py
+```
+
+The guard rejects Node Docker base images unless they use a full patch tag and immutable `sha256` digest, for example `node:22.13.1-alpine@sha256:...`.
 
 ---
 

--- a/backend/tests/test_docker_base_image_guard.py
+++ b/backend/tests/test_docker_base_image_guard.py
@@ -1,0 +1,75 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[2]
+DOCKER_GUARD = REPO_ROOT / "scripts" / "lint_docker_base_images.py"
+
+
+def _load_guard_module():
+    spec = importlib.util.spec_from_file_location("lint_docker_base_images", DOCKER_GUARD)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+find_violations = _load_guard_module().find_violations
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "node:22",
+        "node:22-alpine",
+        "node:22.13-alpine",
+        "docker.io/library/node:22.13.1-alpine",
+    ],
+)
+def test_rejects_floating_node_base_images(tmp_path, image):
+    dockerfile = tmp_path / "frontend" / "Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text(f"FROM {image} AS build\n", encoding="utf-8")
+
+    violations = find_violations([dockerfile])
+
+    assert len(violations) == 1
+    assert image in violations[0]
+
+
+def test_allows_node_patch_tag_with_sha256_digest(tmp_path):
+    digest = "a" * 64
+    dockerfile = tmp_path / "frontend" / "Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text(f"FROM node:22.13.1-alpine@sha256:{digest} AS build\n", encoding="utf-8")
+
+    assert find_violations([dockerfile]) == []
+
+
+def test_rejects_floating_node_base_image_from_arg(tmp_path):
+    dockerfile = tmp_path / "frontend" / "Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text("ARG NODE_IMAGE=node:22\nFROM ${NODE_IMAGE} AS build\n", encoding="utf-8")
+
+    violations = find_violations([dockerfile])
+
+    assert len(violations) == 1
+    assert "${NODE_IMAGE}" in violations[0]
+
+
+def test_skips_non_file_paths(tmp_path):
+    missing = tmp_path / "missing.Dockerfile"
+
+    assert find_violations([tmp_path, missing]) == []
+
+
+def test_ignores_non_node_base_images(tmp_path):
+    dockerfile = tmp_path / "backend" / "Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text("FROM python:3.14-slim-bookworm\n", encoding="utf-8")
+
+    assert find_violations([dockerfile]) == []

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, and Vite client-env exposure guardrails, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, Vite client-env exposure guardrails, and Docker Node base-image pinning, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
 
 ---
 
@@ -24,7 +24,7 @@ Current infrastructure posture: West Europe remains the active production region
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
+| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, Docker Node base-image pinning, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
 | Beta | Cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |

--- a/scripts/lint_docker_base_images.py
+++ b/scripts/lint_docker_base_images.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+FROM_RE = re.compile(r"^\s*FROM\s+(?:--platform=\S+\s+)?(?P<image>\S+)", re.IGNORECASE)
+ARG_RE = re.compile(r"^\s*ARG\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?:=(?P<value>\S+))?", re.IGNORECASE)
+NODE_PATCH_TAG_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9_.-]+)?$")
+
+
+def _git_files(repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*Dockerfile*", "*.Dockerfile"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def _is_node_image(image: str) -> bool:
+    without_digest = image.split("@", 1)[0]
+    repository = without_digest.rsplit(":", 1)[0] if ":" in without_digest else without_digest
+    return repository == "node" or repository.endswith("/node")
+
+
+def _has_pinned_node_patch_digest(image: str) -> bool:
+    if not _is_node_image(image):
+        return True
+    if "@sha256:" not in image:
+        return False
+    image_without_digest, digest = image.split("@sha256:", 1)
+    if not re.fullmatch(r"[a-fA-F0-9]{64}", digest):
+        return False
+    if ":" not in image_without_digest:
+        return False
+    tag = image_without_digest.rsplit(":", 1)[1]
+    return bool(NODE_PATCH_TAG_RE.match(tag))
+
+
+def _resolve_image_token(image: str, args: dict[str, str]) -> str:
+    for name, value in args.items():
+        image = image.replace(f"${{{name}}}", value).replace(f"${name}", value)
+    return image
+
+
+def _looks_like_node_image_variable(image: str) -> bool:
+    if not image.startswith("$"):
+        return False
+    name = image.strip("${}").upper()
+    return "NODE" in name
+
+
+def find_violations(paths: list[Path]) -> list[str]:
+    violations: list[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        docker_args: dict[str, str] = {}
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            arg_match = ARG_RE.match(line)
+            if arg_match and arg_match.group("value") is not None:
+                docker_args[arg_match.group("name")] = arg_match.group("value")
+                continue
+            match = FROM_RE.match(line)
+            if not match:
+                continue
+            raw_image = match.group("image")
+            image = _resolve_image_token(raw_image, docker_args)
+            if _looks_like_node_image_variable(image) or (_is_node_image(image) and not _has_pinned_node_patch_digest(image)):
+                violations.append(
+                    f"{path}:{line_number}: Node base image '{raw_image}' must pin a full patch tag and sha256 digest"
+                )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reject floating Node Docker base images.")
+    parser.add_argument("paths", nargs="*", type=Path, help="Dockerfiles to scan. Defaults to git-tracked Dockerfiles.")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    paths = args.paths or _git_files(repo_root)
+    violations = find_violations(paths)
+    if violations:
+        print("Docker base image guard failed:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a Docker base-image guard that rejects floating Node images such as node:22 or node:22-alpine.
- Require future Node Docker images to pin a full patch tag and sha256 digest.
- Wire the guard into CI as container-image-pins.
- Update README, PRD, and CHANGELOG for #919.

## Validation
- /Users/idokatz/VSCode/.venv/bin/python scripts/lint_docker_base_images.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest -q backend/tests/test_docker_base_image_guard.py
- /Users/idokatz/VSCode/.venv/bin/python -m py_compile scripts/lint_docker_base_images.py backend/tests/test_docker_base_image_guard.py

Closes #919