### PR TITLE
fix: authenticate service catalog health verification

### DIFF
--- a/.github/workflows/service-catalog-refresh.yml
+++ b/.github/workflows/service-catalog-refresh.yml
@@ -112,23 +112,36 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify freshness via /api/health
+        env:
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
         run: |
           set -euo pipefail
           BASE="${API_URL%/}"
           BASE="${BASE%/api}"
           # Pass API key when configured — /api/health requires auth in production (#844).
+          HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"
           _CURL_ARGS=(-sS --max-time 30)
-          if [ -n "${ARCHMORPH_API_KEY:-}" ]; then
-            _CURL_ARGS+=(-H "X-API-Key: ${ARCHMORPH_API_KEY}")
+          if [ -n "${HEALTH_API_KEY}" ]; then
+            _CURL_ARGS+=(-H "X-API-Key: ${HEALTH_API_KEY}")
           fi
-          BODY=$(curl "${_CURL_ARGS[@]}" "${BASE}/api/health")
-          HAS_REFRESH=$(echo "$BODY" | jq -r 'has("service_catalog_refresh")')
+          HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}" "${BASE}/api/health" || echo "000")
+          if [ "$HTTP_CODE" != "200" ]; then
+            ERROR_CODE=$(jq -r '.error.code // empty' health.json 2>/dev/null || true)
+            if [ -n "$ERROR_CODE" ]; then
+              echo "::error::/api/health returned HTTP ${HTTP_CODE} (${ERROR_CODE}); check ARCHMORPH_API_KEY/ADMIN_KEY secrets"
+            else
+              echo "::error::/api/health returned HTTP ${HTTP_CODE}; cannot verify refresh freshness"
+            fi
+            cat health.json || true
+            exit 1
+          fi
+          HAS_REFRESH=$(jq -r 'has("service_catalog_refresh")' health.json)
           if [ "$HAS_REFRESH" != "true" ]; then
             echo "::error::/api/health does not expose service_catalog_refresh; cannot verify refresh freshness"
             exit 1
           fi
-          AGE=$(echo "$BODY" | jq -r '.service_catalog_refresh.age_hours // "null"')
-          STALE=$(echo "$BODY" | jq -r '.service_catalog_refresh.stale | tostring')
+          AGE=$(jq -r '.service_catalog_refresh.age_hours // "null"' health.json)
+          STALE=$(jq -r '.service_catalog_refresh.stale | tostring' health.json)
           echo "post-refresh age=${AGE}h stale=${STALE}"
           if [ "$STALE" != "false" ]; then
             echo "::error::Refresh succeeded but /api/health still reports stale catalog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit P2 CI/security hygiene (#865 #891 #892 #918)** — kept generated Terraform/Bicep validation and CodeQL SAST in the merge gate, added a Vite environment exposure guard that fails CI on secret-like `VITE_*` names, and rejects blanket `define: { 'process.env': ... }` Vite config patterns.
 - **Audit P2 bug hygiene (#916 #917 #920)** — stabilized Roadmap modal close callbacks to avoid repeated Escape listener churn on parent rerenders, mapped retryable vision-analysis failures to 503 responses with `Retry-After`, and hardened focus-trap cleanup so Esc, close buttons, backdrop clicks, and submit-driven closes restore focus to the opener.
 - **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
+- **Service catalog refresh health verification (#941)** — daily refresh now verifies `/api/health` with the production API key or admin-key fallback, preventing false critical alerts when the refresh succeeds but the public health endpoint requires authentication.
 
 #### QA guardrails
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Archmorph is an AI-assisted cloud migration workbench. The live path analyzes up
 
 | Status | Meaning | Capabilities |
 |--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, Docker Node base-image pin guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
+| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health with authenticated refresh verification, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, Docker Node base-image pin guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
 | Beta | Implemented but needs hardening, deeper tests, or production validation | Cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
 | Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault |
 | Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
@@ -63,7 +63,7 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 - **Cost & Token Observability** — per-execution token metering, budget management with alerts, timeseries analytics, CSV export
 - **Cost comparison** — side-by-side AWS/GCP vs Azure cost analysis with optimization recommendations
 - **Migration Timeline Generator** — 7-phase migration plan with dependency ordering (topological sort), parallel workstreams, export as JSON/Markdown/CSV
-- **Self-updating service catalog** — daily auto-discovery and auto-integration of new cloud services with fuzzy matching and category classification
+- **Self-updating service catalog** — daily auto-discovery and auto-integration of new cloud services with fuzzy matching, category classification, and authenticated post-refresh freshness verification
 - **AI cross-cloud mapping suggestions** — GPT-powered mapping with few-shot learning, auto-approve at 0.9 confidence, admin review queue
 - **Icon Registry** — 405 normalized cloud service icons with Draw.io, Excalidraw, and Visio library builders; custom pack upload/delete requires an admin bearer session from `/api/admin/login`, is SVG-sanitized, generation-aware, and bounded without evicting built-in provider icons
 - **AI-powered HLD generation** — 13-section High-Level Design documents with WAF assessment

--- a/backend/tests/test_health_gate_script.py
+++ b/backend/tests/test_health_gate_script.py
@@ -31,6 +31,7 @@ def run_gate_via_mock_curl(
     *,
     health_api_key: str | None = None,
     archmorph_api_key: str | None = None,
+    admin_key: str | None = None,
     mode: str = "healthy",
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     curl_stub = tmp_path / "curl"
@@ -63,6 +64,8 @@ fi
         env["HEALTH_API_KEY"] = health_api_key
     if archmorph_api_key is not None:
         env["ARCHMORPH_API_KEY"] = archmorph_api_key
+    if admin_key is not None:
+        env["ADMIN_KEY"] = admin_key
 
     result = subprocess.run(
         ["bash", str(SCRIPT)],
@@ -216,6 +219,13 @@ def test_health_gate_uses_archmorph_api_key_fallback_for_curl_header(tmp_path: P
 
     assert result.returncode == 0
     assert "X-API-Key: fallback-secret" in curl_args
+
+
+def test_health_gate_uses_admin_key_fallback_for_curl_header(tmp_path: Path):
+    result, curl_args = run_gate_via_mock_curl(tmp_path, admin_key="admin-secret")
+
+    assert result.returncode == 0
+    assert "X-API-Key: admin-secret" in curl_args
 
 
 def test_health_gate_reports_unauthorized_payload_without_api_key(tmp_path: Path):

--- a/backend/tests/test_service_catalog_refresh_workflow.py
+++ b/backend/tests/test_service_catalog_refresh_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "service-catalog-refresh.yml"
+
+
+def _verify_freshness_step() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["refresh"]["steps"]
+    for step in steps:
+        if step.get("name") == "Verify freshness via /api/health":
+            return step
+    raise AssertionError('Expected workflow step "Verify freshness via /api/health"')
+
+
+def test_verify_freshness_receives_admin_key_secret():
+    step = _verify_freshness_step()
+
+    assert step["env"]["ADMIN_KEY"] == "${{ secrets.ADMIN_KEY }}"
+
+
+def test_verify_freshness_falls_back_to_admin_key_for_health_auth():
+    run_script = _verify_freshness_step()["run"]
+
+    assert 'HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"' in run_script
+    assert 'X-API-Key: ${HEALTH_API_KEY}' in run_script
+
+
+def test_verify_freshness_reports_health_http_status():
+    run_script = _verify_freshness_step()["run"]
+
+    assert 'HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}"' in run_script
+    assert "check ARCHMORPH_API_KEY/ADMIN_KEY secrets" in run_script

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, Vite client-env exposure guardrails, and Docker Node base-image pinning, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, Vite client-env exposure guardrails, and Docker Node base-image pinning, service catalog refresh verifies authenticated `/api/health` freshness after each run, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
 
 ---
 
@@ -24,7 +24,7 @@ Current infrastructure posture: West Europe remains the active production region
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, Docker Node base-image pinning, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
+| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health with authenticated refresh verification, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, Docker Node base-image pinning, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
 | Beta | Cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |


### PR DESCRIPTION
## Summary
- pass ADMIN_KEY into the service catalog refresh health verification step
- fall back from ARCHMORPH_API_KEY to ADMIN_KEY when calling authenticated /api/health
- add workflow regression coverage and update PRD, changelog, and README

Closes #941

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest -q backend/tests/test_health_gate_script.py backend/tests/test_service_catalog_refresh_workflow.py
- git diff --check