### PR TITLE
ci: smoke test Alembic migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,57 @@ jobs:
             ${{ steps.grype-python.outputs.sarif }}
 
   # ============================================
+  # ALEMBIC MIGRATION SMOKE
+  # ============================================
+  alembic-migration-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: archmorph
+          POSTGRES_PASSWORD: archmorph_dev
+          POSTGRES_DB: archmorph
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U archmorph -d archmorph"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      DATABASE_URL: postgresql://archmorph:archmorph_dev@127.0.0.1:5432/archmorph
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: uv pip install --system -r requirements.txt
+
+      - name: Run Alembic migration cycle
+        run: |
+          python -m alembic heads
+          python -m alembic upgrade head --sql > /tmp/archmorph-alembic-upgrade.sql
+          test -s /tmp/archmorph-alembic-upgrade.sql
+          python -m alembic upgrade head
+          python -m alembic downgrade base
+          python -m alembic upgrade head
+
+  # ============================================
   # GENERATED IAC VALIDATION
   # ============================================
   iac-validate:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -24,6 +24,8 @@ env:
   AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
   CONTAINER_APP_NAME: ${{ secrets.CONTAINER_APP_NAME }}
   API_URL: ${{ secrets.API_URL }}
+  ARCHMORPH_API_KEY: ${{ secrets.ARCHMORPH_API_KEY }}
+  ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
 
 jobs:
   rollback:
@@ -89,10 +91,28 @@ jobs:
         run: |
           echo "Waiting 30s for revision to stabilize..."
           sleep 30
-          HEALTH=$(curl -s --max-time 30 "${{ env.API_URL }}/health" | jq -r '.status')
-          VERSION=$(curl -s --max-time 30 "${{ env.API_URL }}/health" | jq -r '.version')
+          BASE="${API_URL%/}"
+          BASE="${BASE%/api}"
+          HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"
+          _CURL_ARGS=(-sS --max-time 30)
+          if [ -n "$HEALTH_API_KEY" ]; then
+            _CURL_ARGS+=(-H "X-API-Key: ${HEALTH_API_KEY}")
+          fi
+          if ! HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}" "${BASE}/api/health"); then
+            echo "::error::Health check curl failed after rollback"
+            cat health.json || true
+            exit 1
+          fi
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Health check returned HTTP ${HTTP_CODE} after rollback"
+            cat health.json || true
+            exit 1
+          fi
+          HEALTH=$(jq -r '.status' health.json)
+          VERSION=$(jq -r '.version' health.json)
           if [ "$HEALTH" != "healthy" ]; then
             echo "::error::Health check failed after rollback: $HEALTH"
+            cat health.json || true
             exit 1
           fi
           echo "Rollback successful — version: $VERSION, status: $HEALTH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit P2 bug hygiene (#916 #917 #920)** — stabilized Roadmap modal close callbacks to avoid repeated Escape listener churn on parent rerenders, mapped retryable vision-analysis failures to 503 responses with `Retry-After`, and hardened focus-trap cleanup so Esc, close buttons, backdrop clicks, and submit-driven closes restore focus to the opener.
 - **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
 - **Service catalog refresh health verification (#941)** — daily refresh now verifies `/api/health` with the production API key or admin-key fallback, preventing false critical alerts when the refresh succeeds but the public health endpoint requires authentication.
+- **Audit P2 release safety (#889 #890)** — added a rollback runbook for Container Apps revision recovery, ACR image pinning, Static Web Apps rollback, Alembic downgrade caveats, and teardown-command guardrails; CI now smoke-tests the full PostgreSQL plus pgvector Alembic migration cycle.
 
 #### QA guardrails
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Archmorph is an AI-assisted cloud migration workbench. The live path analyzes up
 
 | Status | Meaning | Capabilities |
 |--------|---------|--------------|
-| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health with authenticated refresh verification, admin health/release evidence, auth shell, CI/security scanning, generated IaC validation, Vite env exposure guard, Docker Node base-image pin guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
+| Live | Usable in the current product path | Diagram upload, sample playground, AI service mapping, guided questions, IaC/HLD/report export, **Architecture Package HTML/SVG export**, cost estimates, service catalog freshness health with authenticated refresh verification, admin health/release evidence, rollback runbook and authenticated rollback health verification, auth shell, CI/security scanning, generated IaC validation, Alembic migration smoke on PostgreSQL plus pgvector, Vite env exposure guard, Docker Node base-image pin guard, P2 bug regressions for analysis retry handling and dialog focus restoration |
 | Beta | Implemented but needs hardening, deeper tests, or production validation | Cost/token observability, collaboration, gallery, replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (visual scaffold; production-ready push targeted for v4.3.0 under epic #586 — see [Production-Ready Roadmap](#production-ready-roadmap-azure-landing-zone-v430-target) below) |
 | Scaffold | UI/routes/models exist, but execution needs integration or operator review | Live cloud scanner, deploy engine, credential vault |
 | Planned | Not production-ready yet | VS Code extension, PR-based IaC workflow, multi-diagram projects |
@@ -173,6 +173,9 @@ This overlay keeps everything local, but starts the backend with production-like
 
 **Production Architecture Package smoke:**
 Run the manual `Production Architecture Package Smoke` GitHub Action, or run [docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md](docs/PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) locally, before release sign-off on changes to the live value spine. The smoke captures health freshness, sample analysis, guided answers, IaC, HLD, cost, Architecture Package HTML/SVG exports, and one classic diagram export as release evidence.
+
+**Release rollback and migration smoke:**
+Use [docs/runbooks/rollback.md](docs/runbooks/rollback.md) for backend Container Apps rollback, ACR image pinning, frontend Static Web Apps recovery, health verification, and Alembic downgrade caveats. CI also runs an `alembic-migration-smoke` job against PostgreSQL plus pgvector so broken migration chains fail before release.
 
 **Refresh the API contract snapshot after intentional backend route/schema changes:**
 ```bash

--- a/backend/alembic/versions/002_tenant_and_user_history.py
+++ b/backend/alembic/versions/002_tenant_and_user_history.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
         sa.Column("max_analyses_per_month", sa.Integer(), nullable=False, server_default="5"),
         sa.Column("storage_prefix", sa.String(100), nullable=True),
         sa.Column("settings", sa.Text(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
@@ -42,7 +42,7 @@ def upgrade() -> None:
         sa.Column("email", sa.String(255), nullable=False),
         sa.Column("display_name", sa.String(200), nullable=True),
         sa.Column("role", sa.String(20), nullable=False, server_default="viewer"),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
         sa.Column("joined_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=True),
     )
@@ -80,9 +80,9 @@ def upgrade() -> None:
         sa.Column("status", sa.String(20), nullable=False, server_default="completed"),
         sa.Column("thumbnail_url", sa.String(500), nullable=True),
         sa.Column("analysis_snapshot", sa.Text(), nullable=True),  # JSON snapshot
-        sa.Column("iac_generated", sa.Boolean(), server_default=sa.text("0")),
-        sa.Column("hld_generated", sa.Boolean(), server_default=sa.text("0")),
-        sa.Column("cost_estimated", sa.Boolean(), server_default=sa.text("0")),
+        sa.Column("iac_generated", sa.Boolean(), server_default=sa.false()),
+        sa.Column("hld_generated", sa.Boolean(), server_default=sa.false()),
+        sa.Column("cost_estimated", sa.Boolean(), server_default=sa.false()),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), index=True),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
@@ -96,7 +96,7 @@ def upgrade() -> None:
         sa.Column("analysis_id", sa.String(50), sa.ForeignKey("user_analyses.analysis_id", ondelete="CASCADE"),
                   nullable=False, index=True),
         sa.Column("label", sa.String(200), nullable=True),
-        sa.Column("pinned", sa.Boolean(), server_default=sa.text("0")),
+        sa.Column("pinned", sa.Boolean(), server_default=sa.false()),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
     op.create_index("ix_saved_diagrams_user_analysis", "saved_diagrams", ["user_id", "analysis_id"], unique=True)

--- a/backend/alembic/versions/004_executions.py
+++ b/backend/alembic/versions/004_executions.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '004_executions'
-down_revision = '003_agent_paas'
+down_revision = '003'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/011_hnsw_indexes.py
+++ b/backend/alembic/versions/011_hnsw_indexes.py
@@ -9,7 +9,8 @@ Revises: 010_cost_records
 Create Date: 2026-04-12 16:00:00.000000
 
 """
-from alembic import op
+from alembic import context, op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '011_hnsw_indexes'
@@ -21,6 +22,13 @@ depends_on = None
 #   m=16       — max connections per layer (default 16, good balance)
 #   ef_construction=64 — build-time quality (higher=slower build, better recall)
 # Operator class: vector_cosine_ops for cosine similarity
+
+
+def _has_table(table_name: str) -> bool:
+    if context.is_offline_mode():
+        return True
+    bind = op.get_bind()
+    return sa.inspect(bind).has_table(table_name)
 
 
 def upgrade():
@@ -40,13 +48,15 @@ def upgrade():
         WITH (m = 16, ef_construction = 64);
     """)
 
-    # RAG document chunks — document ingestion pipeline
-    op.execute("""
-        CREATE INDEX IF NOT EXISTS ix_document_chunks_embedding_hnsw
-        ON rag_document_chunks
-        USING hnsw (embedding vector_cosine_ops)
-        WITH (m = 16, ef_construction = 64);
-    """)
+    # RAG document chunks — optional retired RAG surface. Older deployments may
+    # still have this table; fresh databases after RAG retirement do not.
+    if _has_table('rag_document_chunks'):
+        op.execute("""
+            CREATE INDEX IF NOT EXISTS ix_document_chunks_embedding_hnsw
+            ON rag_document_chunks
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64);
+        """)
 
 
 def downgrade():

--- a/backend/alembic/versions/011_hnsw_indexes.py
+++ b/backend/alembic/versions/011_hnsw_indexes.py
@@ -9,8 +9,7 @@ Revises: 010_cost_records
 Create Date: 2026-04-12 16:00:00.000000
 
 """
-from alembic import context, op
-import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '011_hnsw_indexes'
@@ -22,13 +21,6 @@ depends_on = None
 #   m=16       — max connections per layer (default 16, good balance)
 #   ef_construction=64 — build-time quality (higher=slower build, better recall)
 # Operator class: vector_cosine_ops for cosine similarity
-
-
-def _has_table(table_name: str) -> bool:
-    if context.is_offline_mode():
-        return True
-    bind = op.get_bind()
-    return sa.inspect(bind).has_table(table_name)
 
 
 def upgrade():
@@ -50,13 +42,17 @@ def upgrade():
 
     # RAG document chunks — optional retired RAG surface. Older deployments may
     # still have this table; fresh databases after RAG retirement do not.
-    if _has_table('rag_document_chunks'):
-        op.execute("""
-            CREATE INDEX IF NOT EXISTS ix_document_chunks_embedding_hnsw
-            ON rag_document_chunks
-            USING hnsw (embedding vector_cosine_ops)
-            WITH (m = 16, ef_construction = 64);
-        """)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF to_regclass('rag_document_chunks') IS NOT NULL THEN
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ix_document_chunks_embedding_hnsw '
+                    || 'ON rag_document_chunks '
+                    || 'USING hnsw (embedding vector_cosine_ops) '
+                    || 'WITH (m = 16, ef_construction = 64)';
+            END IF;
+        END $$;
+    """)
 
 
 def downgrade():

--- a/backend/alembic/versions/012_deployment_state_owner.py
+++ b/backend/alembic/versions/012_deployment_state_owner.py
@@ -14,6 +14,8 @@ down_revision = '011_hnsw_indexes'
 branch_labels = None
 depends_on = None
 
+_CREATED_TABLE_COMMENT = 'archmorph-created-by-012-deployment-state-owner'
+
 
 def _has_table(table_name: str) -> bool:
     if context.is_offline_mode():
@@ -30,6 +32,14 @@ def _columns(table_name: str) -> set[str]:
 def _indexes(table_name: str) -> set[str]:
     bind = op.get_bind()
     return {index["name"] for index in sa.inspect(bind).get_indexes(table_name)}
+
+
+def _table_comment(table_name: str) -> str | None:
+    bind = op.get_bind()
+    return bind.execute(
+        sa.text("SELECT obj_description(to_regclass(:table_name)::oid)"),
+        {"table_name": table_name},
+    ).scalar()
 
 
 def _create_index_if_missing(index_name: str, table_name: str, columns: list[str]) -> None:
@@ -53,6 +63,7 @@ def upgrade():
             sa.Column('previous_state_json', sa.JSON(), nullable=True),
             sa.Column('updated_at', sa.DateTime(), nullable=True),
         )
+        op.execute(sa.text(f"COMMENT ON TABLE deployment_state IS '{_CREATED_TABLE_COMMENT}'"))
     else:
         existing_columns = _columns('deployment_state')
         if 'owner_user_id' not in existing_columns:
@@ -68,6 +79,10 @@ def upgrade():
 
 def downgrade():
     if not _has_table('deployment_state'):
+        return
+
+    if _table_comment('deployment_state') == _CREATED_TABLE_COMMENT:
+        op.drop_table('deployment_state')
         return
 
     existing_indexes = _indexes('deployment_state')

--- a/backend/alembic/versions/012_deployment_state_owner.py
+++ b/backend/alembic/versions/012_deployment_state_owner.py
@@ -5,7 +5,7 @@ Revises: 011_hnsw_indexes
 Create Date: 2026-05-08 04:20:00.000000
 
 """
-from alembic import op
+from alembic import context, op
 import sqlalchemy as sa
 
 
@@ -15,15 +15,73 @@ branch_labels = None
 depends_on = None
 
 
+def _has_table(table_name: str) -> bool:
+    if context.is_offline_mode():
+        return False
+    bind = op.get_bind()
+    return sa.inspect(bind).has_table(table_name)
+
+
+def _columns(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}
+
+
+def _indexes(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {index["name"] for index in sa.inspect(bind).get_indexes(table_name)}
+
+
+def _create_index_if_missing(index_name: str, table_name: str, columns: list[str]) -> None:
+    if context.is_offline_mode() or index_name not in _indexes(table_name):
+        op.create_index(index_name, table_name, columns)
+
+
 def upgrade():
-    op.add_column('deployment_state', sa.Column('owner_user_id', sa.String(), nullable=True))
-    op.add_column('deployment_state', sa.Column('tenant_id', sa.String(), nullable=True))
-    op.create_index('ix_deployment_state_owner_user_id', 'deployment_state', ['owner_user_id'])
-    op.create_index('ix_deployment_state_tenant_id', 'deployment_state', ['tenant_id'])
+    if not _has_table('deployment_state'):
+        op.create_table(
+            'deployment_state',
+            sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+            sa.Column('project_id', sa.String(), nullable=False),
+            sa.Column('environment', sa.String(), nullable=False),
+            sa.Column('owner_user_id', sa.String(), nullable=True),
+            sa.Column('tenant_id', sa.String(), nullable=True),
+            sa.Column('state_json', sa.JSON(), nullable=True),
+            sa.Column('lock_id', sa.String(), nullable=True),
+            sa.Column('lock_info', sa.JSON(), nullable=True),
+            sa.Column('locked_at', sa.DateTime(), nullable=True),
+            sa.Column('previous_state_json', sa.JSON(), nullable=True),
+            sa.Column('updated_at', sa.DateTime(), nullable=True),
+        )
+    else:
+        existing_columns = _columns('deployment_state')
+        if 'owner_user_id' not in existing_columns:
+            op.add_column('deployment_state', sa.Column('owner_user_id', sa.String(), nullable=True))
+        if 'tenant_id' not in existing_columns:
+            op.add_column('deployment_state', sa.Column('tenant_id', sa.String(), nullable=True))
+
+    _create_index_if_missing('ix_deployment_state_project_id', 'deployment_state', ['project_id'])
+    _create_index_if_missing('ix_deployment_state_environment', 'deployment_state', ['environment'])
+    _create_index_if_missing('ix_deployment_state_owner_user_id', 'deployment_state', ['owner_user_id'])
+    _create_index_if_missing('ix_deployment_state_tenant_id', 'deployment_state', ['tenant_id'])
 
 
 def downgrade():
-    op.drop_index('ix_deployment_state_tenant_id', table_name='deployment_state')
-    op.drop_index('ix_deployment_state_owner_user_id', table_name='deployment_state')
-    op.drop_column('deployment_state', 'tenant_id')
-    op.drop_column('deployment_state', 'owner_user_id')
+    if not _has_table('deployment_state'):
+        return
+
+    existing_indexes = _indexes('deployment_state')
+    for index_name in (
+        'ix_deployment_state_tenant_id',
+        'ix_deployment_state_owner_user_id',
+        'ix_deployment_state_environment',
+        'ix_deployment_state_project_id',
+    ):
+        if index_name in existing_indexes:
+            op.drop_index(index_name, table_name='deployment_state')
+
+    existing_columns = _columns('deployment_state')
+    if 'tenant_id' in existing_columns:
+        op.drop_column('deployment_state', 'tenant_id')
+    if 'owner_user_id' in existing_columns:
+        op.drop_column('deployment_state', 'owner_user_id')

--- a/backend/tests/test_release_safety_workflows.py
+++ b/backend/tests/test_release_safety_workflows.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+ROLLBACK_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rollback.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _step_by_name(steps: list[dict], name: str) -> dict:
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f'Expected workflow step "{name}"')
+
+
+def test_ci_includes_pgvector_alembic_migration_cycle():
+    workflow = _load(CI_WORKFLOW)
+    job = workflow["jobs"]["alembic-migration-smoke"]
+
+    assert job["services"]["postgres"]["image"] == "pgvector/pgvector:pg16"
+    assert job["env"]["DATABASE_URL"] == "postgresql://archmorph:archmorph_dev@127.0.0.1:5432/archmorph"
+
+    run_script = _step_by_name(job["steps"], "Run Alembic migration cycle")["run"]
+    assert "python -m alembic heads" in run_script
+    assert "python -m alembic upgrade head --sql" in run_script
+    assert "python -m alembic upgrade head" in run_script
+    assert "python -m alembic downgrade base" in run_script
+
+
+def test_rollback_health_verification_uses_authenticated_api_health():
+    workflow = _load(ROLLBACK_WORKFLOW)
+    assert workflow["env"]["ARCHMORPH_API_KEY"] == "${{ secrets.ARCHMORPH_API_KEY }}"
+    assert workflow["env"]["ADMIN_KEY"] == "${{ secrets.ADMIN_KEY }}"
+
+    steps = workflow["jobs"]["rollback"]["steps"]
+    verify_step = _step_by_name(steps, "Verify rollback health")
+    run_script = verify_step["run"]
+
+    assert 'HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"' in run_script
+    assert 'X-API-Key: ${HEALTH_API_KEY}' in run_script
+    assert '"${BASE}/api/health"' in run_script
+    assert 'if ! HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}"' in run_script

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Date:** May 7, 2026
 **Author:** Ido Katz
 
-**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, Vite client-env exposure guardrails, and Docker Node base-image pinning, service catalog refresh verifies authenticated `/api/health` freshness after each run, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
+**Release Note:** Azure OpenAI production traffic is consolidated into West Europe with `gpt-4.1` primary and `gpt-4o` fallback; the Foundry benchmark plan keeps production routing unchanged until live gates pass, the Sweden Central one-region plan requires a parallel build with isolated Terraform state before any traffic shift, CI now enforces generated IaC validation, CodeQL SAST, Vite client-env exposure guardrails, Docker Node base-image pinning, and PostgreSQL plus pgvector Alembic migration smoke, service catalog refresh and rollback health verification use authenticated `/api/health`, the rollback runbook documents Container Apps, ACR, Static Web Apps, and Alembic caveats, and P2 bug hygiene now covers Roadmap modal stability, retryable analysis failures, and dialog focus restoration.
 
 ---
 
@@ -24,7 +24,7 @@ Current infrastructure posture: West Europe remains the active production region
 
 | Maturity | Capabilities |
 |----------|--------------|
-| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health with authenticated refresh verification, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, performance budgets, Vite env exposure lint, Docker Node base-image pinning, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
+| Live | Diagram upload, sample playground, service mapping, guided questions, IaC/HLD/report export, Architecture Package HTML/SVG export, cost estimates, service catalog freshness health with authenticated refresh verification, rollback runbook and authenticated rollback health verification, admin health/release evidence, auth shell, API versioning, CI/security gates including CodeQL, generated IaC validation, Alembic migration smoke on PostgreSQL plus pgvector, performance budgets, Vite env exposure lint, Docker Node base-image pinning, and P2 bug regressions for analysis retry handling, Roadmap modal stability, and focus restoration |
 | Beta | Cost/token observability, collaboration, migration gallery, migration replay, Terraform state import, multi-cloud cost comparison, **Azure Landing Zone target diagram** (multi-source: AWS + GCP; T3 fidelity in progress under epic #586) |
 | Scaffold | Live cloud scanner, credential vault, deploy engine production validation |
 | Beta/Hardening | Living architecture/drift baselines, admin release gates, release evidence, dependency/security remediation workflow |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -57,6 +57,7 @@ The backend must start with PostgreSQL, Redis, `ENFORCE_POSTGRES=true`, and `REQ
 The `CI/CD` workflow must pass before release:
 
 - `backend-tests`: Ruff, pytest, coverage threshold, OpenAPI export, committed OpenAPI contract snapshot check, backend SBOM, Grype.
+- `alembic-migration-smoke`: PostgreSQL plus pgvector migration cycle covering heads, offline upgrade SQL generation, upgrade to head, downgrade to base, and re-upgrade.
 - `frontend-build`: ESLint, Vitest, Vite build, frontend SBOM, Grype.
 - `upload-sarif`: SARIF upload attempted for available scans.
 - `deploy-backend`: ACR build, Trivy container gate, deployment secret validation, metrics storage managed-identity/RBAC preflight, Container Apps blue-green deploy, green revision refresh smoke, production health verify.
@@ -112,9 +113,12 @@ Before enabling any scaffolded feature, confirm:
 
 ## 6. Rollback
 
-- Prefer the `rollback.yml` workflow for backend rollback.
+- Follow the [rollback runbook](runbooks/rollback.md) during production incidents; target a verified rollback in under 10 minutes.
+- Prefer the `rollback.yml` workflow for backend rollback. It activates a known-good Container Apps revision, shifts traffic, and verifies authenticated `/api/health`.
 - Container Apps keeps the prior blue revision for fast traffic shift.
+- Use direct `az containerapp` traffic commands only as the fallback path documented in the runbook.
 - If frontend release is bad, redeploy the previous Static Web Apps artifact or revert and let CI/CD redeploy.
+- Do not use `terraform destroy` or `azd down` as normal rollback; they are disaster teardown commands.
 - After rollback, run `post-deploy-smoke` or `E2E Health Monitoring` manually.
 
 ## 7. Evidence To Keep

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,183 @@
+# Archmorph Rollback Runbook
+
+Use this runbook when a production release causes user-visible errors, failed health gates, broken Architecture Package output, or a release-blocking regression after traffic shift. The target drill time is under 10 minutes from decision to verified rollback.
+
+## Scope
+
+This is a rollback guide for production recovery. It is not a disaster teardown guide.
+
+Do not use `terraform destroy` or `azd down` for normal rollback. Those commands remove infrastructure and can prolong an incident. Use revision traffic rollback, image pinning, frontend artifact redeploy, or a revert-driven release instead.
+
+## Prerequisites
+
+- GitHub Actions access to run the manual rollback workflow.
+- Azure RBAC for the production subscription and resource group.
+- GitHub secrets present: `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_RESOURCE_GROUP`, `CONTAINER_APP_NAME`, `API_URL`, plus `ARCHMORPH_API_KEY` or `ADMIN_KEY` for authenticated health verification.
+- Azure CLI authenticated if using the manual fallback.
+- Release evidence for the last known good backend revision, frontend artifact, Git SHA, and container image tag or digest.
+
+## Decision Points
+
+Start rollback when any of these are true:
+
+- `/api/health` is not `healthy` after deploy stabilization.
+- Scheduled job freshness, Redis readiness, database connectivity, or OpenAPI schema checks fail in production.
+- The core live path cannot upload, analyze, ask guided questions, export Architecture Package HTML/SVG, generate IaC/HLD, or estimate cost.
+- Error rate or latency exceeds the active SLO burn-rate alert and fix-forward is not clearly faster.
+- Security, auth, or data-boundary behavior changes unexpectedly.
+
+Abort rollback and escalate if:
+
+- No previous healthy backend revision exists.
+- The last known good revision requires a database schema that is no longer compatible.
+- Azure Container Apps refuses revision activation or traffic shift.
+- Health stays unhealthy after shifting traffic.
+- The suspected fault is shared infrastructure, database, secrets, storage, or Azure OpenAI regional availability rather than the application revision.
+
+## Backend Rollback: GitHub Workflow
+
+Prefer the `Manual Rollback` workflow in `.github/workflows/rollback.yml`.
+
+1. Open GitHub Actions and choose `Manual Rollback`.
+2. Enter the target `revision_name` when known. Leave it empty to select the previous active revision automatically.
+3. Keep `traffic_percentage` at `100` for a full rollback unless doing a controlled partial shift.
+4. Run the workflow.
+5. Confirm the workflow activates the target revision, shifts traffic, and verifies authenticated `${API_URL}/api/health`.
+6. Capture the workflow URL, target revision, version, and health output in release evidence.
+
+The workflow normalizes `API_URL`, calls `/api/health`, and sends `X-API-Key` from `ARCHMORPH_API_KEY` with `ADMIN_KEY` fallback when present.
+
+## Backend Rollback: Azure CLI Fallback
+
+Use this only if the workflow is unavailable.
+
+Set context:
+
+```bash
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+```
+
+List revisions and identify the last known good target:
+
+```bash
+az containerapp revision list \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$CONTAINER_APP_NAME" \
+  --query "[].{name:name,active:properties.active,traffic:properties.trafficWeight,created:properties.createdTime,image:properties.template.containers[0].image}" \
+  --output table
+```
+
+Activate the target revision:
+
+```bash
+az containerapp revision activate \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$CONTAINER_APP_NAME" \
+  --revision "$TARGET_REVISION"
+```
+
+Shift traffic:
+
+```bash
+az containerapp ingress traffic set \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$CONTAINER_APP_NAME" \
+  --revision-weight "$TARGET_REVISION=100"
+```
+
+Verify health:
+
+```bash
+BASE="${API_URL%/}"
+BASE="${BASE%/api}"
+curl -fsS \
+  -H "X-API-Key: ${ARCHMORPH_API_KEY:-$ADMIN_KEY}" \
+  "${BASE}/api/health" | jq .
+```
+
+Expected result: `.status == "healthy"`, scheduled jobs are fresh or intentionally disabled, Redis is `ok` or accepted as `disabled_optional`, and version/SHA match the intended rollback target.
+
+## ACR Image Pinning
+
+Keep release evidence for the exact backend image used by each revision. Prefer immutable digests over mutable tags when investigating or restoring a known good image.
+
+Find image metadata from revisions:
+
+```bash
+az containerapp revision list \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$CONTAINER_APP_NAME" \
+  --query "[].{revision:name,image:properties.template.containers[0].image}" \
+  --output table
+```
+
+Resolve or inspect ACR digests when needed:
+
+```bash
+az acr repository show-manifests \
+  --name "$ACR_NAME" \
+  --repository archmorph-backend \
+  --orderby time_desc \
+  --output table
+```
+
+If a new hotfix deployment is required, pin the target image by digest in the deployment evidence and avoid reusing ambiguous tags as the rollback source of truth.
+
+## Frontend Rollback
+
+Static Web Apps does not have the same revision traffic model as Container Apps. Use one of these paths:
+
+- Redeploy the previously tested Static Web Apps artifact from the successful CI/CD run.
+- Revert the bad frontend commit and let CI/CD publish the recovered artifact.
+- If the bad behavior is controlled by a feature flag, disable the flag first when that restores the live path faster than redeploy.
+
+After frontend rollback, verify:
+
+- Root page loads.
+- `/#translator` and `/#playground` load.
+- Upload or sample analysis reaches results.
+- Architecture Package HTML/SVG export buttons still work for a sample.
+
+## Database And Alembic Caveats
+
+Application rollback should not automatically downgrade the production database.
+
+Run Alembic downgrade only when all of these are true:
+
+- The migration is explicitly reversible and data-safe.
+- The downgrade has been tested against a copy or staging-equivalent snapshot.
+- Product and data owners accept any data loss or shape change.
+- The rollback target cannot run safely with the current schema.
+
+Default posture: keep the database at the current schema, roll the application back to a compatible revision, and fix forward with a new migration when needed.
+
+CI now runs an Alembic smoke against PostgreSQL plus pgvector: heads, offline upgrade SQL generation, upgrade to head, downgrade to base, and re-upgrade. A migration that cannot complete this cycle must not be promoted.
+
+## Health And Smoke Verification
+
+After backend or frontend rollback, run at least one automated smoke:
+
+```bash
+scripts/health_gate.sh "$API_URL" --strict-freshness
+```
+
+Also verify:
+
+- `/api/health` returns `healthy` with authenticated access.
+- `/api/openapi.json` loads and reports Archmorph API.
+- Service catalog freshness is current or has a documented accepted reason.
+- Architecture Package smoke passes for a sample or known customer-safe fixture.
+- GitHub Actions `post-deploy-smoke` or `E2E Health Monitoring` is green.
+
+## Sub-10-Minute Drill
+
+Use this checklist for quarterly operator drills:
+
+1. Identify current bad revision and previous known good revision.
+2. Run `Manual Rollback` workflow with the target revision.
+3. Confirm traffic is `100` percent on the rollback revision.
+4. Verify authenticated `/api/health` and release version/SHA.
+5. Verify frontend root, translator, playground, and one Architecture Package export.
+6. Record elapsed time, workflow URL, target revision, image digest, and any manual steps.
+
+A drill passes when traffic is restored and health verified in under 10 minutes without using infrastructure teardown commands.

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -12,7 +12,7 @@ Do not use `terraform destroy` or `azd down` for normal rollback. Those commands
 
 - GitHub Actions access to run the manual rollback workflow.
 - Azure RBAC for the production subscription and resource group.
-- GitHub secrets present: `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_RESOURCE_GROUP`, `CONTAINER_APP_NAME`, `API_URL`, plus `ARCHMORPH_API_KEY` or `ADMIN_KEY` for authenticated health verification.
+- GitHub secrets present: `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_RESOURCE_GROUP`, `CONTAINER_APP_NAME`, `API_URL`, `ACR_NAME`, and `ACR_LOGIN_SERVER`, plus `ARCHMORPH_API_KEY` or `ADMIN_KEY` for authenticated health verification.
 - Azure CLI authenticated if using the manual fallback.
 - Release evidence for the last known good backend revision, frontend artifact, Git SHA, and container image tag or digest.
 
@@ -116,7 +116,7 @@ Resolve or inspect ACR digests when needed:
 ```bash
 az acr repository show-manifests \
   --name "$ACR_NAME" \
-  --repository archmorph-backend \
+  --repository archmorph-api \
   --orderby time_desc \
   --output table
 ```


### PR DESCRIPTION
## Summary
- add a PostgreSQL + pgvector Alembic migration smoke job that checks heads, offline SQL generation, upgrade, downgrade, and re-upgrade
- repair existing Alembic chain defects so a fresh Postgres database reaches head and can downgrade cleanly
- document rollback operations for Container Apps, ACR image pinning, Static Web Apps recovery, health checks, and Alembic caveats
- align manual rollback health verification with authenticated /api/health and add workflow regression tests

Closes #889
Closes #890

## Validation
- python -m pytest -q tests/test_release_safety_workflows.py
- python -m ruff check alembic/versions/002_tenant_and_user_history.py alembic/versions/004_executions.py alembic/versions/011_hnsw_indexes.py alembic/versions/012_deployment_state_owner.py tests/test_release_safety_workflows.py
- Alembic smoke against local pgvector: heads, upgrade head --sql, upgrade head, downgrade base, upgrade head
- git diff --check