### PR TITLE
fix: authenticate monitoring health check

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   API_URL: ${{ secrets.API_URL }}
   FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+  ARCHMORPH_API_KEY: ${{ secrets.ARCHMORPH_API_KEY }}
 
 concurrency:
   group: ${{ github.workflow }}
@@ -38,8 +39,16 @@ jobs:
     steps:
       - name: Check API Health
         id: health
+        env:
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
         run: |
-          RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 30 "${{ env.API_URL }}/health" || echo "FAILED")
+          CURL_ARGS=(-s -w "\n%{http_code}" --max-time 30)
+          HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"
+          if [ -n "$HEALTH_API_KEY" ]; then
+            CURL_ARGS+=(-H "X-API-Key: ${HEALTH_API_KEY}")
+          fi
+
+          RESPONSE=$(curl "${CURL_ARGS[@]}" "${{ env.API_URL }}/health" || echo "FAILED")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | head -n -1)
 

--- a/backend/tests/test_release_safety_workflows.py
+++ b/backend/tests/test_release_safety_workflows.py
@@ -6,6 +6,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ROLLBACK_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rollback.yml"
+MONITORING_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "monitoring.yml"
 
 
 def _load(path: Path) -> dict:
@@ -46,3 +47,17 @@ def test_rollback_health_verification_uses_authenticated_api_health():
     assert 'X-API-Key: ${HEALTH_API_KEY}' in run_script
     assert '"${BASE}/api/health"' in run_script
     assert 'if ! HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}"' in run_script
+
+
+def test_monitoring_health_check_uses_authenticated_health_endpoint():
+    workflow = _load(MONITORING_WORKFLOW)
+    assert workflow["env"]["ARCHMORPH_API_KEY"] == "${{ secrets.ARCHMORPH_API_KEY }}"
+
+    steps = workflow["jobs"]["api-health-check"]["steps"]
+    health_step = _step_by_name(steps, "Check API Health")
+    assert health_step["env"]["ADMIN_KEY"] == "${{ secrets.ADMIN_KEY }}"
+
+    run_script = health_step["run"]
+    assert 'HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"' in run_script
+    assert 'X-API-Key: ${HEALTH_API_KEY}' in run_script
+    assert '"${{ env.API_URL }}/health"' in run_script


### PR DESCRIPTION
## Summary
- send the configured API key on E2E monitoring health checks
- add a release-safety regression test for authenticated monitoring health checks

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_release_safety_workflows.py
- ruby -e 'require "yaml"; [".github/workflows/monitoring.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML OK"'
- git --no-pager diff --check