### PR TITLE
fix: stamp audit actor context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mutation score baseline (#862)** — added a quarterly/manual `mutmut` workflow for `session_store`, `vision_analyzer`, and `iac_generator`, with a 60% per-module baseline gate and raw result artifacts for drop triage.
 - **IaC chat history trimming (#838)** — compacted legacy chat history before model calls so prior turns keep conversational context and change summaries without replaying complete IaC code blobs.
 - **Vision response cache sizing (#839)** — moved the vision analyzer cache onto the shared store with deploy-configurable size/TTL defaults sized for the 200-repeat upload profile.
+- **Audit actor/IP coverage (#878)** — state-changing guest requests now stamp a daily rotating guest actor/session ID plus client IP in audit rows, closing the forensic gap for unauthenticated activity.
 - **Analyze latency budget stability** — widened the CI smoke latency regression ratio from 30% to 50% so runner jitter does not fail near-baseline `/analyze` samples while still catching material regressions.
 - **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
 - **Service catalog refresh health verification (#941)** — daily refresh now verifies `/api/health` with the production API key or admin-key fallback, preventing false critical alerts when the refresh succeeds but the public health endpoint requires authentication.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The post-merge CTO end-to-end review of `landing-zone-svg` (May 1, 2026) flagged
 - **Multi-stage Docker** — optimized build with ~50% image size reduction, uv for fast installs
 - **API versioning** — all `/api/*` routes mirrored at `/api/v1/*` for stable integrations
 - **Feature flags system** — percentage rollout + user targeting with audited admin API and runtime dashboard toggles
-- **Comprehensive audit logging** — structured JSON with risk levels, alerting rules, compliance queries
+- **Comprehensive audit logging** — structured JSON with actor/IP context, risk levels, alerting rules, compliance queries
 - **Session persistence** — pluggable SessionStore with InMemory and Redis backends
 - **GPT response caching** — content-hash TTLCache for GPT-4o responses with configurable timeout and fallback model
 - **Vision analysis cache** — TTLCache for repeated diagram analysis avoiding redundant API calls

--- a/backend/audit_logging.py
+++ b/backend/audit_logging.py
@@ -281,6 +281,7 @@ class AuditLogger:
         ip_address: Optional[str] = None,
         session_id: Optional[str] = None,
         details: Optional[Dict[str, Any]] = None,
+        correlation_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Log an API access event with latency tracking."""
         if status_code >= 500:
@@ -310,7 +311,7 @@ class AuditLogger:
             method=method,
             status_code=status_code,
             latency_ms=round(latency_ms, 2),
-            correlation_id=correlation_id_var.get(""),
+            correlation_id=correlation_id or correlation_id_var.get(""),
             details=details or {},
             risk_level=risk.value,
             severity=sev.value,

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,10 +14,12 @@ from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 from starlette.middleware.gzip import GZipMiddleware  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
 import os  # noqa: E402
 import logging  # noqa: E402
 import time  # noqa: E402
 import uuid  # noqa: E402
+import hashlib  # noqa: E402
 import concurrent.futures  # noqa: E402
 import asyncio  # noqa: E402
 
@@ -151,6 +153,7 @@ from routers.collaboration_routes import router as collaboration_router  # noqa:
 from routers.replay_routes import router as replay_router  # noqa: E402
 from routers.v1 import build_v1_router  # noqa: E402
 from api_versioning import VersionMiddleware  # noqa: E402
+from auth import get_user_from_request_headers  # noqa: E402
 from audit_logging import audit_logger, AuditEventType  # noqa: E402, F401
 from error_envelope import register_error_handlers  # noqa: E402
 
@@ -298,6 +301,27 @@ class ArchmorphMiddleware(BaseHTTPMiddleware):
         "/openapi.json", "/docs", "/redoc",
     })
 
+    @staticmethod
+    def _client_ip(request: Request) -> str:
+        return request.client.host if request.client and request.client.host else "unknown"
+
+    @staticmethod
+    def _daily_guest_session_id(request: Request, ip_address: str) -> str:
+        day = datetime.now(timezone.utc).strftime("%Y%m%d")
+        user_agent = request.headers.get("user-agent", "")
+        digest = hashlib.sha256(f"{day}|{ip_address}|{user_agent}".encode("utf-8")).hexdigest()[:16]
+        return f"guest-{day}-{digest}"
+
+    @classmethod
+    def _audit_actor_context(cls, request: Request) -> tuple[str, str, str]:
+        ip_address = cls._client_ip(request)
+        user = get_user_from_request_headers(request.headers)
+        if user:
+            return user.id, "authenticated", ip_address
+
+        session_id = cls._daily_guest_session_id(request, ip_address)
+        return session_id, "guest", ip_address
+
     async def dispatch(self, request: Request, call_next):
         # ── Correlation ID ──
         cid = request.headers.get("X-Correlation-ID") or str(uuid.uuid4())
@@ -386,13 +410,17 @@ class ArchmorphMiddleware(BaseHTTPMiddleware):
         # ── Audit Logging ──
         if endpoint not in self._AUDIT_SKIP:
             try:
-                ip = request.client.host if request.client else None
+                actor_id, actor_kind, ip = self._audit_actor_context(request)
                 audit_logger.log_api_access(
                     endpoint=endpoint,
                     method=method,
                     status_code=status,
                     latency_ms=duration_ms,
+                    user_id=actor_id,
+                    session_id=actor_id if actor_kind == "guest" else None,
                     ip_address=ip,
+                    correlation_id=cid,
+                    details={"actor_kind": actor_kind},
                 )
             except Exception as exc:  # nosec B110 - audit must never break request handling
                 logger.debug("audit error: %s", exc)

--- a/backend/tests/test_middleware_and_routers.py
+++ b/backend/tests/test_middleware_and_routers.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
+from audit_logging import clear_audit_logs, get_audit_logs
 from main import app, SESSION_STORE, IMAGE_STORE
 
 
@@ -204,6 +205,34 @@ class TestLatencyTrackingMiddleware:
         """POST requests also get timing header."""
         resp = client.post("/api/chat", json={"message": "hello"})
         assert resp.headers.get("x-response-time") is not None
+
+
+# ====================================================================
+# 3b. AuditMiddleware
+# ====================================================================
+
+class TestAuditMiddleware:
+    """Verify request audit context is forensically useful."""
+
+    def test_guest_state_changing_request_records_actor_and_ip(self, client):
+        clear_audit_logs()
+
+        client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={
+                "User-Agent": "archmorph-audit-test",
+                "X-Correlation-ID": "audit-cid-878",
+            },
+        )
+
+        logs = get_audit_logs(limit=10)
+        entry = next(log for log in logs if log.get("endpoint") == "/api/chat")
+        assert entry["user_id"].startswith("guest-")
+        assert entry["session_id"] == entry["user_id"]
+        assert entry["ip_address"]
+        assert entry["correlation_id"] == "audit-cid-878"
+        assert entry["details"]["actor_kind"] == "guest"
 
 
 # ====================================================================


### PR DESCRIPTION
## Summary
- stamp audit API rows with authenticated user IDs or daily rotating guest actor/session IDs
- preserve client IP on every audited request through the consolidated middleware
- add middleware regression coverage for guest state-changing calls and document audit actor/IP coverage

Closes #878

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_middleware_and_routers.py::TestAuditMiddleware backend/tests/test_audit_logging.py
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check backend/main.py backend/tests/test_middleware_and_routers.py
- git diff --check