### PR TITLE
test: cover container apps subnet nsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **IaC chat history trimming (#838)** — compacted legacy chat history before model calls so prior turns keep conversational context and change summaries without replaying complete IaC code blobs.
 - **Vision response cache sizing (#839)** — moved the vision analyzer cache onto the shared store with deploy-configurable size/TTL defaults sized for the 200-repeat upload profile.
 - **Audit actor/IP coverage (#878)** — state-changing guest requests now stamp a daily rotating guest actor/session ID plus client IP in audit rows, closing the forensic gap for unauthenticated activity.
+- **Container Apps subnet NSG regression (#905)** — added CI coverage that keeps the delegated Container Apps subnet associated with its NSG and verifies lateral inbound probes such as port 8000 remain denied.
 - **Analyze latency budget stability** — widened the CI smoke latency regression ratio from 30% to 50% so runner jitter does not fail near-baseline `/analyze` samples while still catching material regressions.
 - **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
 - **Service catalog refresh health verification (#941)** — daily refresh now verifies `/api/health` with the production API key or admin-key fallback, preventing false critical alerts when the refresh succeeds but the public health endpoint requires authentication.

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -4,6 +4,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _terraform_resource_block(terraform: str, resource_type: str, name: str) -> str:
+    marker = f'resource "{resource_type}" "{name}"'
+    assert marker in terraform, f"Missing Terraform resource: {marker}"
+    start = terraform.index(marker)
+    next_resource = terraform.find('\nresource "', start + len(marker))
+    if next_resource == -1:
+        return terraform[start:]
+    return terraform[start:next_resource]
+
+
 def test_ci_runs_archmorph_checkov_policy_gate():
     ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
@@ -36,3 +46,26 @@ def test_checked_in_postgres_explicitly_disables_public_network_access():
     assert 'resource "azurerm_postgresql_flexible_server" "main"' in infra
     postgres_block = infra.split('resource "azurerm_postgresql_flexible_server" "main"', 1)[1].split('resource "azurerm_postgresql_flexible_server_database"', 1)[0]
     assert "public_network_access_enabled = false" in postgres_block
+
+
+def test_container_apps_subnet_nsg_blocks_lateral_inbound_probe():
+    infra = (ROOT / "infra/main.tf").read_text(encoding="utf-8")
+
+    association_block = _terraform_resource_block(
+        infra,
+        "azurerm_subnet_network_security_group_association",
+        "container_apps",
+    )
+    assert "subnet_id                 = azurerm_subnet.container_apps.id" in association_block
+    assert "network_security_group_id = azurerm_network_security_group.container_apps.id" in association_block
+
+    nsg_block = _terraform_resource_block(infra, "azurerm_network_security_group", "container_apps")
+    assert 'name                       = "DenyAllInbound"' in nsg_block
+    assert 'priority                   = 4000' in nsg_block
+    assert 'direction                  = "Inbound"' in nsg_block
+    assert 'access                     = "Deny"' in nsg_block
+    assert 'source_address_prefix      = "*"' in nsg_block
+    assert 'destination_address_prefix = "*"' in nsg_block
+    assert 'destination_port_range     = "*"' in nsg_block
+    assert 'source_address_prefix      = "VirtualNetwork"' not in nsg_block
+    assert 'destination_port_range     = "8000"' not in nsg_block


### PR DESCRIPTION
## Summary
- add a regression test that the Container Apps subnet remains associated with its NSG
- assert the Container Apps NSG keeps the priority-4000 deny-all inbound rule that blocks lateral probes such as port 8000
- document the #905 guardrail in the changelog

Closes #905

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_infra_policy_ci.py
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_infra_policy_ci.py
- git diff --check