### PR TITLE
fix: avoid blob startup hangs in backend deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,6 +791,53 @@ jobs:
           echo "green_revision=$GREEN_REV" >> $GITHUB_OUTPUT
           echo "Green revision: $GREEN_REV"
 
+      - name: Wait for green revision readiness
+        run: |
+          GREEN_REV="${{ steps.green.outputs.green_revision }}"
+          if [ -z "$GREEN_REV" ]; then
+            echo "::error::Green revision name was not produced by deploy step"
+            exit 1
+          fi
+
+          for attempt in $(seq 1 24); do
+            if ! REVISION_JSON=$(az containerapp revision show \
+              --name ${{ env.CONTAINER_APP_NAME }} \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --revision "$GREEN_REV" \
+              -o json 2>revision-show.err); then
+              echo "Green revision readiness attempt ${attempt}: revision show failed"
+              cat revision-show.err || true
+              sleep 10
+              continue
+            fi
+            PROVISIONING_STATE=$(echo "$REVISION_JSON" | jq -r '.properties.provisioningState // "unknown"')
+            RUNNING_STATE=$(echo "$REVISION_JSON" | jq -r '.properties.runningState // "unknown"')
+            HEALTH_STATE=$(echo "$REVISION_JSON" | jq -r '.properties.healthState // "unknown"')
+            REPLICAS=$(echo "$REVISION_JSON" | jq -r '.properties.replicas // "unknown"')
+            echo "Green revision readiness attempt ${attempt}: provisioning=${PROVISIONING_STATE} running=${RUNNING_STATE} health=${HEALTH_STATE} replicas=${REPLICAS}"
+
+            if [ "$PROVISIONING_STATE" = "Succeeded" ] && { [ "$RUNNING_STATE" = "Running" ] || [ "$RUNNING_STATE" = "unknown" ]; }; then
+              echo "Green revision is provisioned and running enough for smoke tests"
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "::error::Green revision did not become ready before smoke tests"
+          az containerapp revision show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --revision "$GREEN_REV" \
+            --query '{name:name,provisioningState:properties.provisioningState,runningState:properties.runningState,healthState:properties.healthState,replicas:properties.replicas,createdTime:properties.createdTime}' \
+            -o json || true
+          az containerapp logs show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --revision "$GREEN_REV" \
+            --tail 100 || true
+          exit 1
+
       - name: Preflight green revision auth and storage contract
         run: |
           GREEN_REV="${{ steps.green.outputs.green_revision }}"
@@ -849,6 +896,23 @@ jobs:
             HEALTH_PATH="/health"
           fi
 
+          dump_green_revision_diagnostics() {
+            local reason="$1"
+            echo "::group::Green revision diagnostics (${reason})"
+            az containerapp revision show \
+              --name ${{ env.CONTAINER_APP_NAME }} \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --revision "${{ steps.green.outputs.green_revision }}" \
+              --query '{name:name,provisioningState:properties.provisioningState,runningState:properties.runningState,healthState:properties.healthState,replicas:properties.replicas,createdTime:properties.createdTime,fqdn:properties.fqdn}' \
+              -o json || true
+            az containerapp logs show \
+              --name ${{ env.CONTAINER_APP_NAME }} \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --revision "${{ steps.green.outputs.green_revision }}" \
+              --tail 100 || true
+            echo "::endgroup::"
+          }
+
           curl_health() {
             local url="$1"
             if [ -n "${ADMIN_KEY:-}" ]; then
@@ -857,6 +921,18 @@ jobs:
               curl -sS --max-time 30 "$url"
             fi
           }
+
+          echo "Checking green revision liveness: $TEST_URL/healthz"
+          if ! HEALTHZ_CODE=$(curl -sS -o healthz-response.json -w "%{http_code}" \
+            --max-time 15 "$TEST_URL/healthz"); then
+            HEALTHZ_CODE="000"
+          fi
+          if [ "$HEALTHZ_CODE" != "200" ]; then
+            echo "::error::Green revision /healthz returned HTTP ${HEALTHZ_CODE}"
+            [ -s healthz-response.json ] && head -c 2000 healthz-response.json || true
+            dump_green_revision_diagnostics "healthz-${HEALTHZ_CODE}"
+            exit 1
+          fi
 
           echo "Running smoke tests against: $TEST_URL$HEALTH_PATH"
           BODY=$(curl_health "$TEST_URL$HEALTH_PATH" || true)

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -9,6 +9,10 @@ Performance fix: dependency checks are cached for 10 seconds to avoid
 blocking Redis/OpenAI connections on every request under high traffic.
 """
 
+import asyncio
+import logging
+import os
+import threading
 import time
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
@@ -21,11 +25,61 @@ from api_versioning import get_api_versions
 from routers.shared import ENVIRONMENT, verify_api_key
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 # ── Cached dependency checks (avoid blocking I/O on every request) ─────
 _dep_checks_cache: dict | None = None
 _dep_checks_ts: float = 0
 _DEP_CACHE_TTL = 10  # seconds
+
+_CATALOG_HEALTH_BLOB_TIMEOUT_SECONDS = float(
+    os.getenv("SERVICE_CATALOG_HEALTH_BLOB_TIMEOUT_SECONDS", "3")
+)
+_catalog_health_blob_lock = threading.Lock()
+_catalog_health_blob_running = False
+
+
+def _catalog_health_from_state(*, prefer_blob: bool) -> tuple[dict, dict]:
+    return get_update_status(prefer_blob=prefer_blob), get_freshness(
+        prefer_blob=prefer_blob
+    )
+
+
+def _load_catalog_health_from_blob_once() -> tuple[dict, dict]:
+    global _catalog_health_blob_running
+    try:
+        return _catalog_health_from_state(prefer_blob=True)
+    finally:
+        with _catalog_health_blob_lock:
+            _catalog_health_blob_running = False
+
+
+async def _catalog_health() -> tuple[dict, dict]:
+    """Return durable catalog health with a bounded Blob read and disk fallback."""
+    global _catalog_health_blob_running
+
+    with _catalog_health_blob_lock:
+        if _catalog_health_blob_running:
+            return _catalog_health_from_state(prefer_blob=False)
+        _catalog_health_blob_running = True
+
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_load_catalog_health_from_blob_once),
+            timeout=_CATALOG_HEALTH_BLOB_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning(
+            "Timed out loading service catalog health from blob after %.1fs; falling back to disk",
+            _CATALOG_HEALTH_BLOB_TIMEOUT_SECONDS,
+        )
+        return _catalog_health_from_state(prefer_blob=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to load service catalog health from blob; falling back to disk: %s",
+            exc,
+        )
+        return _catalog_health_from_state(prefer_blob=False)
 
 
 def _run_dependency_checks() -> tuple[dict[str, str], bool, bool]:
@@ -121,8 +175,7 @@ async def healthz():
 
 @router.get("/api/health")
 async def health(_auth=Depends(verify_api_key)):
-    update_status = get_update_status()
-    freshness = get_freshness()
+    update_status, freshness = await _catalog_health()
     scheduled_jobs = get_scheduled_jobs()
     checks, degraded, unhealthy = _run_dependency_checks()
 

--- a/backend/routers/services.py
+++ b/backend/routers/services.py
@@ -3,6 +3,9 @@ from error_envelope import ArchmorphException
 Cloud Services Catalog & Service Updater routes.
 """
 
+import asyncio
+import threading
+
 from fastapi import APIRouter, Query, Response, Depends
 from typing import Optional
 
@@ -16,6 +19,19 @@ from service_updater import (
 from routers.shared import verify_api_key
 
 router = APIRouter()
+
+_STORAGE_PREFLIGHT_TIMEOUT_SECONDS = 45
+_storage_preflight_lock = threading.Lock()
+_storage_preflight_running = False
+
+
+def _run_storage_preflight_once() -> dict:
+    global _storage_preflight_running
+    try:
+        return verify_service_catalog_blob_access()
+    finally:
+        with _storage_preflight_lock:
+            _storage_preflight_running = False
 
 
 @router.get("/api/services")
@@ -216,7 +232,38 @@ async def trigger_service_update(_auth=Depends(verify_api_key)):
 @router.post("/api/service-updates/storage-preflight")
 async def service_update_storage_preflight(_auth=Depends(verify_api_key)):
     """Verify managed-identity Blob Storage access for deployment smoke."""
-    result = verify_service_catalog_blob_access()
+    global _storage_preflight_running
+
+    with _storage_preflight_lock:
+        if _storage_preflight_running:
+            raise ArchmorphException(
+                503,
+                "Managed identity Blob Storage preflight already in progress",
+                details={
+                    "ok": False,
+                    "account_url_configured": True,
+                    "container": "service-catalog",
+                    "reason": "preflight_in_progress",
+                },
+            )
+        _storage_preflight_running = True
+
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_run_storage_preflight_once),
+            timeout=_STORAGE_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+    except TimeoutError as exc:
+        raise ArchmorphException(
+            503,
+            "Managed identity Blob Storage preflight timed out",
+            details={
+                "ok": False,
+                "account_url_configured": True,
+                "container": "service-catalog",
+                "reason": "preflight_timeout",
+            },
+        ) from exc
     if not result.get("ok"):
         raise ArchmorphException(
             503,

--- a/backend/service_updater.py
+++ b/backend/service_updater.py
@@ -220,11 +220,12 @@ _running: bool = False
 # ---------------------------------------------------------------------------
 
 
-def _read_state() -> dict[str, Any]:
+def _read_state(*, prefer_blob: bool = True) -> dict[str, Any]:
     """Load the service_updates.json state file."""
-    blob_state = _load_state_from_blob()
-    if blob_state is not None:
-        return blob_state
+    if prefer_blob:
+        blob_state = _load_state_from_blob()
+        if blob_state is not None:
+            return blob_state
     try:
         with open(_UPDATES_FILE, "r", encoding="utf-8") as fh:
             return json.load(fh)
@@ -1075,12 +1076,12 @@ def get_last_update() -> dict[str, Any]:
     }
 
 
-def get_update_status() -> dict[str, Any]:
+def get_update_status(*, prefer_blob: bool = True) -> dict[str, Any]:
     """
     Return the overall status of the updater including scheduler state,
     total checks performed, and aggregate new services found.
     """
-    state = _read_state()
+    state = _read_state(prefer_blob=prefer_blob)
     return {
         "scheduler_running": _running,
         "last_check": state["last_check"],
@@ -1125,17 +1126,21 @@ def _last_successful_refresh_timestamp_from_state(state: dict[str, Any]) -> Opti
     return None
 
 
-def _last_successful_refresh_timestamp() -> Optional[datetime]:
+def _last_successful_refresh_timestamp(*, prefer_blob: bool = True) -> Optional[datetime]:
     """Return the newest persisted service-refresh timestamp with no errors."""
-    return _last_successful_refresh_timestamp_from_state(_read_state())
+    return _last_successful_refresh_timestamp_from_state(_read_state(prefer_blob=prefer_blob))
 
 
-def _register_service_catalog_freshness(last_success: Optional[datetime] = None) -> None:
+def _register_service_catalog_freshness(
+    last_success: Optional[datetime] = None,
+    *,
+    prefer_blob: bool = True,
+) -> None:
     """Register the service catalog refresh job, seeding durable state."""
     from freshness_registry import mark_success, register_with_last_success
 
     if last_success is None:
-        last_success = _last_successful_refresh_timestamp()
+        last_success = _last_successful_refresh_timestamp(prefer_blob=prefer_blob)
 
     register_with_last_success(
         "service_catalog_refresh",
@@ -1150,12 +1155,12 @@ def _register_service_catalog_freshness(last_success: Optional[datetime] = None)
 # shows up in the /api/health.scheduled_jobs block alongside any other periodic
 # work, and is monitored by the freshness-watchdog GH Actions workflow.
 try:
-    _register_service_catalog_freshness()
+    _register_service_catalog_freshness(prefer_blob=False)
 except Exception:  # noqa: BLE001
     pass  # registry import failure is non-fatal
 
 
-def get_freshness() -> dict[str, Any]:
+def get_freshness(*, prefer_blob: bool = True) -> dict[str, Any]:
     """Return last-successful-run age in hours and a stale flag.
 
     Returns:
@@ -1168,7 +1173,7 @@ def get_freshness() -> dict[str, Any]:
           "providers_failed": [str, ...]
         }
     """
-    state = _read_state()
+    state = _read_state(prefer_blob=prefer_blob)
     last_success = _last_successful_refresh_timestamp_from_state(state)
     try:
         _register_service_catalog_freshness(last_success=last_success)

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 _DISCOVERED_FILE = Path(__file__).resolve().parent.parent / "data" / "discovered_services.json"
 
 
-def _load_discovered() -> dict[str, list[dict]]:
+def _load_discovered(*, prefer_blob: bool = True) -> dict[str, list[dict]]:
     """Load discovered services from the JSON data file.
 
     Issue #647 — also consults the durable Azure Blob mirror (when configured)
@@ -24,27 +24,26 @@ def _load_discovered() -> dict[str, list[dict]]:
     boots before its first refresh still picks up the cumulative discoveries
     rather than serving the static-only catalog.
     """
-    # Try blob first when available — this is the source of truth on stateless
-    # container deployments (Azure Container Apps wipe the disk on restart).
-    try:
-        # Local import to avoid module-load circular: service_updater imports
-        # this module's _load_discovered when called from run_update_now after
-        # write, but it does not need the blob loader at import time.
-        from service_updater import _load_discovered_from_blob
+    if prefer_blob:
+        try:
+            # Local import to avoid module-load circular: service_updater imports
+            # this module's _load_discovered when called from run_update_now after
+            # write, but it does not need the blob loader at import time.
+            from service_updater import _load_discovered_from_blob
 
-        blob_data = _load_discovered_from_blob()
-        if blob_data is not None:
-            return blob_data
-    except ImportError as exc:
-        logger.debug(
-            "Blob catalog bootstrap unavailable; falling back to disk: %s",
-            exc,
-        )
-    except Exception:
-        logger.warning(
-            "Blob catalog bootstrap failed; falling back to disk",
-            exc_info=True,
-        )
+            blob_data = _load_discovered_from_blob()
+            if blob_data is not None:
+                return blob_data
+        except ImportError as exc:
+            logger.debug(
+                "Blob catalog bootstrap unavailable; falling back to disk: %s",
+                exc,
+            )
+        except Exception:
+            logger.warning(
+                "Blob catalog bootstrap failed; falling back to disk",
+                exc_info=True,
+            )
 
     try:
         with open(_DISCOVERED_FILE, "r", encoding="utf-8") as fh:
@@ -77,7 +76,7 @@ AZURE_SERVICES: list[dict] = []
 GCP_SERVICES: list[dict] = []
 
 
-def reload() -> dict[str, int]:
+def reload(*, prefer_blob: bool = True) -> dict[str, int]:
     """Re-merge static + discovered catalogs in place.
 
     Issue #647 — the merged lists were previously bound once at module-import
@@ -88,7 +87,7 @@ def reload() -> dict[str, int]:
 
     Returns a dict of ``{provider: total_count}`` after reload.
     """
-    discovered = _load_discovered()
+    discovered = _load_discovered(prefer_blob=prefer_blob)
 
     new_aws = _merge(_AWS_STATIC, discovered.get("aws", []))
     new_azure = _merge(_AZURE_STATIC, discovered.get("azure", []))
@@ -127,9 +126,9 @@ def reload() -> dict[str, int]:
     return counts
 
 
-# Initial load at module import. Blob bootstrap uses bounded Azure SDK timeouts
-# so startup falls back quickly to local disk when storage is slow/unavailable.
-reload()
+# Initial load at module import must not depend on external Blob/identity I/O;
+# Gunicorn preloads the app before the server accepts health probes.
+reload(prefer_blob=False)
 
 __all__ = [
     "AWS_SERVICES",

--- a/backend/tests/test_contract.py
+++ b/backend/tests/test_contract.py
@@ -173,7 +173,7 @@ class TestHealthContract:
 
         calls = []
 
-        def fake_freshness():
+        def fake_freshness(*, prefer_blob=True):
             calls.append("freshness")
             return {
                 "last_check": "2026-01-01T00:00:00+00:00",
@@ -233,7 +233,7 @@ class TestHealthContract:
         monkeypatch.setattr(
             health_router,
             "get_freshness",
-            lambda: {
+            lambda **_: {
                 "last_check": "2026-01-01T00:00:00+00:00",
                 "age_hours": 1.0,
                 "budget_hours": 36.0,
@@ -289,7 +289,7 @@ class TestHealthContract:
         monkeypatch.setattr(
             health_router,
             "get_freshness",
-            lambda: {
+            lambda **_: {
                 "last_check": "2026-01-01T00:00:00+00:00",
                 "age_hours": 1.0,
                 "budget_hours": 36.0,

--- a/backend/tests/test_service_updater.py
+++ b/backend/tests/test_service_updater.py
@@ -332,6 +332,36 @@ class TestReadWriteState:
             state = _read_state()
             assert state["last_check"] == "blob"
 
+    def test_read_state_can_skip_blob_for_startup_and_health(self, tmp_path):
+        state_file = tmp_path / "state.json"
+        disk_state = {
+            "last_check": "disk",
+            "checks": [],
+            "new_services_found": {"aws": [], "azure": [], "gcp": []},
+            "auto_added": {"aws": [], "azure": [], "gcp": []},
+        }
+        state_file.write_text(json.dumps(disk_state), encoding="utf-8")
+
+        with patch("service_updater._load_state_from_blob") as load_blob, \
+             patch("service_updater._UPDATES_FILE", state_file), \
+             patch("service_updater._DATA_DIR", tmp_path):
+            state = _read_state(prefer_blob=False)
+
+        assert state["last_check"] == "disk"
+        load_blob.assert_not_called()
+
+    def test_freshness_registration_can_skip_blob_for_import_time(self, tmp_path):
+        import service_updater
+
+        with patch("service_updater._load_state_from_blob") as load_blob, \
+             patch("service_updater._UPDATES_FILE", tmp_path / "missing.json"), \
+             patch("freshness_registry.register_with_last_success") as register, \
+             patch("freshness_registry.mark_success"):
+            service_updater._register_service_catalog_freshness(prefer_blob=False)
+
+        load_blob.assert_not_called()
+        register.assert_called_once()
+
     def test_write_state_mirrors_to_blob(self, tmp_path):
         from unittest.mock import MagicMock
 

--- a/backend/tests/test_services_catalog_startup.py
+++ b/backend/tests/test_services_catalog_startup.py
@@ -1,0 +1,26 @@
+import json
+import os
+import sys
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import services
+
+
+def test_catalog_reload_can_skip_blob_for_startup(tmp_path):
+    discovered_file = tmp_path / "discovered_services.json"
+    discovered_file.write_text(
+        json.dumps({"aws": [], "azure": [], "gcp": []}),
+        encoding="utf-8",
+    )
+
+    with patch("services._DISCOVERED_FILE", discovered_file), \
+         patch("service_updater._load_discovered_from_blob") as load_blob:
+        counts = services.reload(prefer_blob=False)
+
+    load_blob.assert_not_called()
+    assert counts["aws"] >= 1
+    assert counts["azure"] >= 1
+    assert counts["gcp"] >= 1

--- a/backend/tests/test_usage_metrics_startup.py
+++ b/backend/tests/test_usage_metrics_startup.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import usage_metrics
+
+
+def test_load_metrics_can_skip_blob_for_startup(tmp_path):
+    metrics_file = tmp_path / "usage_metrics.json"
+    metrics_file.write_text(
+        json.dumps({"counters": {}, "daily": {}, "recent_events": []}),
+        encoding="utf-8",
+    )
+
+    with patch("usage_metrics.METRICS_FILE", str(metrics_file)), \
+         patch("usage_metrics._get_blob_client") as get_blob:
+        usage_metrics._load_metrics(prefer_blob=False)
+
+    get_blob.assert_not_called()
+    assert "counters" in usage_metrics._metrics

--- a/backend/usage_metrics.py
+++ b/backend/usage_metrics.py
@@ -33,7 +33,10 @@ METRICS_FILE = os.path.join(DATA_DIR, "usage_metrics.json")
 # Azure Blob Storage persistence — RBAC preferred, connection string fallback
 AZURE_STORAGE_ACCOUNT_URL = os.getenv("AZURE_STORAGE_ACCOUNT_URL", "")
 AZURE_STORAGE_CONNECTION_STRING = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "")
-AZURE_CLIENT_ID = os.getenv("AZURE_CLIENT_ID", "")  # For user-assigned managed identity
+AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID = os.getenv(
+    "AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID",
+    "",
+)
 METRICS_BLOB_CONTAINER = "metrics"
 METRICS_BLOB_NAME = "usage_metrics.json"
 
@@ -118,7 +121,7 @@ def _get_blob_client():
         if AZURE_STORAGE_ACCOUNT_URL:
             from azure.identity import DefaultAzureCredential
             credential = DefaultAzureCredential(
-                managed_identity_client_id=AZURE_CLIENT_ID or None
+                managed_identity_client_id=AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID or None
             )
             bsc = BlobServiceClient(AZURE_STORAGE_ACCOUNT_URL, credential=credential)
             logger.debug("Using RBAC auth for blob storage")
@@ -138,12 +141,12 @@ def _get_blob_client():
         return None
 
 
-def _load_metrics():
+def _load_metrics(*, prefer_blob: bool = True):
     """Load metrics from Azure Blob Storage (primary) or local disk (fallback)."""
     global _metrics
 
     # 1. Try Azure Blob Storage
-    blob = _get_blob_client()
+    blob = _get_blob_client() if prefer_blob else None
     if blob:
         try:
             from circuit_breakers import blob_breaker
@@ -233,8 +236,8 @@ def _shutdown_flush(*_args):
                 logger.warning("Shutdown flush failed: %s", exc)
 
 
-# Load on import
-_load_metrics()
+# Load on import without external storage I/O so API startup remains probeable.
+_load_metrics(prefer_blob=False)
 
 # Start background flush daemon
 _flush_thread = threading.Thread(target=_background_flush, daemon=True, name="metrics-flush")


### PR DESCRIPTION
## Summary
- avoid Azure Blob/identity I/O during backend import/startup paths used by Container Apps health probes
- make /api/health use local service-catalog state and bound storage-preflight requests
- add green revision readiness waiting plus diagnostics before deployment smoke tests

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_service_updater.py backend/tests/test_services_catalog_startup.py backend/tests/test_usage_metrics_startup.py backend/tests/test_usage_metrics.py -q
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check backend/service_updater.py backend/services/__init__.py backend/usage_metrics.py backend/routers/health.py backend/routers/services.py backend/tests/test_service_updater.py backend/tests/test_services_catalog_startup.py backend/tests/test_usage_metrics_startup.py
- git diff --check
- parsed .github/workflows/ci.yml with PyYAML
- imported backend main with a bogus AZURE_STORAGE_ACCOUNT_URL under a 10s alarm; completed without Blob startup hang