### PR TITLE
fix: wire jwt secret into backend deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@ AZURE_CLIENT_ID=00000000-0000-0000-0000-000000000000
 # ============================================
 # AUTHENTICATION — Azure AD B2C
 # ============================================
+# JWT_SECRET must be set in production/staging.
+# JWT_SECRET=replace-with-strong-random-secret
 # AZURE_AD_B2C_TENANT=your-tenant
 # AZURE_AD_B2C_CLIENT_ID=your-client-id
 # AZURE_AD_B2C_POLICY=B2C_1_signupsignin

--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -17,7 +17,7 @@ These secrets are required in `.github/workflows/ci.yml`:
 | `CONTAINER_APP_NAME` | Azure Container Apps name | `archmorph-api` |
 | `CONTAINER_APP_ENV` | Container Apps Environment name | `archmorph-cae-dev` |
 | `ADMIN_KEY` | Backend admin/API key used by deploy smoke to authenticate service catalog refresh | (strong random secret) |
-| `JWT_SECRET` | Backend JWT signing secret for production user/session tokens. If omitted, deploy falls back to `ADMIN_KEY`; a distinct strong random value is recommended. | (strong random secret) |
+| `JWT_SECRET` | Recommended dedicated backend JWT signing secret for production user/session tokens. If omitted, deploy falls back to `ADMIN_KEY`; a distinct strong random value is strongly recommended. | (strong random secret) |
 | `SWA_NAME` | Static Web App name | `archmorph-frontend` |
 | `API_URL` | Backend API URL (with `/api` suffix) | `https://your-app.azurecontainerapps.io/api` |
 | `SWA_DEPLOYMENT_TOKEN` | Static Web App deployment token | (from Azure Portal) |

--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -17,6 +17,7 @@ These secrets are required in `.github/workflows/ci.yml`:
 | `CONTAINER_APP_NAME` | Azure Container Apps name | `archmorph-api` |
 | `CONTAINER_APP_ENV` | Container Apps Environment name | `archmorph-cae-dev` |
 | `ADMIN_KEY` | Backend admin/API key used by deploy smoke to authenticate service catalog refresh | (strong random secret) |
+| `JWT_SECRET` | Backend JWT signing secret for production user/session tokens. If omitted, deploy falls back to `ADMIN_KEY`; a distinct strong random value is recommended. | (strong random secret) |
 | `SWA_NAME` | Static Web App name | `archmorph-frontend` |
 | `API_URL` | Backend API URL (with `/api` suffix) | `https://your-app.azurecontainerapps.io/api` |
 | `SWA_DEPLOYMENT_TOKEN` | Static Web App deployment token | (from Azure Portal) |
@@ -83,6 +84,7 @@ az staticwebapp secrets list --name YOUR_SWA_NAME --query properties.apiKey -o t
 - Rotate secrets periodically
 - Use production GitHub environment secrets; Archmorph does not maintain a separate staging environment
 - Backend Container Apps deployments require `ARCHMORPH_API_KEY` and `ARCHMORPH_ADMIN_KEY` to reference the `ADMIN_KEY` secret in the deployed revision.
+- Backend Container Apps deployments require `JWT_SECRET` in production/staging. The workflow maps repository secret `JWT_SECRET` into a Container App secret named `jwt-secret`; if the repository secret is absent, it uses `ADMIN_KEY` as a compatibility fallback.
 - The `archmorphmetrics` storage account must keep shared-key access disabled; backend storage access is expected to use `AZURE_STORAGE_ACCOUNT_URL` plus the Container App system-assigned managed identity with `Storage Blob Data Contributor`.
 - `AZURE_CLIENT_ID` is for GitHub Actions OIDC. Do not set it in the backend Container App to select storage identity; use `AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID` only when a user-assigned storage identity is intentionally attached.
 - The deploy smoke calls `/api/service-updates/storage-preflight` before traffic shift to prove the deployed revision can write, read, list, and delete service-catalog blobs through managed identity.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,7 @@ jobs:
       CONTAINER_APP_NAME: ${{ secrets.CONTAINER_APP_NAME }}
       CONTAINER_APP_ENV: ${{ secrets.CONTAINER_APP_ENV }}
       ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET || secrets.ADMIN_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -565,7 +566,8 @@ jobs:
             ACR_NAME \
             ACR_LOGIN_SERVER \
             CONTAINER_APP_NAME \
-            ADMIN_KEY; do
+            ADMIN_KEY \
+            JWT_SECRET; do
             value="${!name:-}"
             if [ -z "$value" ]; then
               echo "::error::Required backend deploy input ${name} is not set"
@@ -756,6 +758,7 @@ jobs:
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --secrets \
               admin-key="${{ env.ADMIN_KEY }}" \
+              jwt-secret="${{ env.JWT_SECRET }}" \
               storage-connection="${{ env.STORAGE_CONN }}" \
             2>/dev/null || true
 
@@ -769,6 +772,7 @@ jobs:
             --set-env-vars \
               ARCHMORPH_ADMIN_KEY=secretref:admin-key \
               ARCHMORPH_API_KEY=secretref:admin-key \
+              JWT_SECRET=secretref:jwt-secret \
               AZURE_STORAGE_ACCOUNT_URL="$STORAGE_ACCOUNT_URL" \
               AZURE_STORAGE_CONNECTION_STRING=secretref:storage-connection \
               AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,8 +759,7 @@ jobs:
             --secrets \
               admin-key="${{ env.ADMIN_KEY }}" \
               jwt-secret="${{ env.JWT_SECRET }}" \
-              storage-connection="${{ env.STORAGE_CONN }}" \
-            2>/dev/null || true
+              storage-connection="${{ env.STORAGE_CONN }}"
 
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:8}"

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -14,3 +14,18 @@ def test_post_deploy_smoke_passes_health_api_key_from_admin_secret():
     smoke_step = next(step for step in steps if step.get("name") == "Run deployed app smoke checks")
 
     assert smoke_step["env"]["HEALTH_API_KEY"] == "${{ secrets.ADMIN_KEY }}"
+
+
+def test_backend_deploy_wires_jwt_secret_to_container_app_revision():
+    workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+
+    deploy_job = workflow["jobs"]["deploy-backend"]
+    assert deploy_job["env"]["JWT_SECRET"] == "${{ secrets.JWT_SECRET || secrets.ADMIN_KEY }}"
+
+    deploy_step = next(step for step in deploy_job["steps"] if step.get("name") == "Deploy green revision")
+    deploy_script = deploy_step["run"]
+
+    assert 'jwt-secret="${{ env.JWT_SECRET }}"' in deploy_script
+    assert "JWT_SECRET=secretref:jwt-secret" in deploy_script
+    assert "2>/dev/null || true" not in deploy_script


### PR DESCRIPTION
## Summary
- map a JWT signing secret into backend Container App deployments
- use a dedicated JWT_SECRET repo secret when present, with ADMIN_KEY as a compatibility fallback
- document the production/staging JWT secret requirement

## Validation
- git diff --check
- actionlint unavailable locally

## Context
Main CI/CD run 25795424228 reached the new green revision readiness diagnostics, and the container log showed startup failing with: JWT_SECRET environment variable must be set in production/staging.