### PR TITLE
fix: accept provisioned backend revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,7 +819,7 @@ jobs:
             REPLICAS=$(echo "$REVISION_JSON" | jq -r '.properties.replicas // "unknown"')
             echo "Green revision readiness attempt ${attempt}: provisioning=${PROVISIONING_STATE} running=${RUNNING_STATE} health=${HEALTH_STATE} replicas=${REPLICAS}"
 
-            if [ "$PROVISIONING_STATE" = "Succeeded" ] && { [ "$RUNNING_STATE" = "Running" ] || [ "$RUNNING_STATE" = "unknown" ]; }; then
+            if { [ "$PROVISIONING_STATE" = "Succeeded" ] || [ "$PROVISIONING_STATE" = "Provisioned" ]; } && { [ "$RUNNING_STATE" = "Running" ] || [ "$RUNNING_STATE" = "unknown" ]; }; then
               echo "Green revision is provisioned and running enough for smoke tests"
               exit 0
             fi

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -29,3 +29,18 @@ def test_backend_deploy_wires_jwt_secret_to_container_app_revision():
     assert 'jwt-secret="${{ env.JWT_SECRET }}"' in deploy_script
     assert "JWT_SECRET=secretref:jwt-secret" in deploy_script
     assert "2>/dev/null || true" not in deploy_script
+
+
+def test_backend_readiness_accepts_azure_provisioned_state():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    readiness_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Wait for green revision readiness"
+    )
+    readiness_script = readiness_step["run"]
+
+    assert '[ "$PROVISIONING_STATE" = "Provisioned" ]' in readiness_script
+    assert '[ "$PROVISIONING_STATE" = "Succeeded" ]' in readiness_script
+    assert '[ "$RUNNING_STATE" = "Running" ]' in readiness_script


### PR DESCRIPTION
## Summary
- accept Azure Container Apps revision provisioningState=Provisioned as ready for backend green revision gating
- keep the existing runningState guard before smoke tests
- add a workflow contract test for the observed Azure readiness state

## Validation
- git diff --check
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py