### PR TITLE
fix: retry green revision healthz smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -926,10 +926,21 @@ jobs:
           }
 
           echo "Checking green revision liveness: $TEST_URL/healthz"
-          if ! HEALTHZ_CODE=$(curl -sS -o healthz-response.json -w "%{http_code}" \
-            --max-time 15 "$TEST_URL/healthz"); then
-            HEALTHZ_CODE="000"
-          fi
+          for attempt in 1 2 3 4 5 6; do
+            : > healthz-response.json
+            if ! HEALTHZ_CODE=$(curl -sS -o healthz-response.json -w "%{http_code}" \
+              --max-time 15 "$TEST_URL/healthz"); then
+              HEALTHZ_CODE="000"
+            fi
+            if [ "$HEALTHZ_CODE" = "200" ]; then
+              break
+            fi
+            echo "Green revision /healthz attempt ${attempt} returned HTTP ${HEALTHZ_CODE}"
+            [ -s healthz-response.json ] && head -c 2000 healthz-response.json || true
+            if [ "$attempt" -lt 6 ]; then
+              sleep 10
+            fi
+          done
           if [ "$HEALTHZ_CODE" != "200" ]; then
             echo "::error::Green revision /healthz returned HTTP ${HEALTHZ_CODE}"
             [ -s healthz-response.json ] && head -c 2000 healthz-response.json || true

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -44,3 +44,20 @@ def test_backend_readiness_accepts_azure_provisioned_state():
     assert '[ "$PROVISIONING_STATE" = "Provisioned" ]' in readiness_script
     assert '[ "$PROVISIONING_STATE" = "Succeeded" ]' in readiness_script
     assert '[ "$RUNNING_STATE" = "Running" ]' in readiness_script
+
+
+def test_backend_green_revision_healthz_is_retried_before_failure():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    smoke_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Smoke test green revision"
+    )
+    smoke_script = smoke_step["run"]
+
+    assert "for attempt in 1 2 3 4 5 6; do" in smoke_script
+    assert ": > healthz-response.json" in smoke_script
+    assert 'Green revision /healthz attempt ${attempt} returned HTTP ${HEALTHZ_CODE}' in smoke_script
+    assert 'if [ "$attempt" -lt 6 ]; then' in smoke_script
+    assert 'dump_green_revision_diagnostics "healthz-${HEALTHZ_CODE}"' in smoke_script


### PR DESCRIPTION
## Summary
- retry green revision /healthz during smoke to tolerate transient Container Apps routing warm-up
- keep diagnostics after retries are exhausted
- add a workflow contract test for healthz retry behavior

## Validation
- git diff --check
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py