### PR TITLE
fix: extend backend healthz warmup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -925,11 +925,13 @@ jobs:
             fi
           }
 
-          echo "Checking green revision liveness: $TEST_URL/healthz"
-          for attempt in 1 2 3 4 5 6; do
+          HEALTHZ_URL="${TEST_URL%/api}/healthz"
+          echo "Checking green revision liveness: $HEALTHZ_URL"
+          HEALTHZ_MAX_ATTEMPTS=12
+          for attempt in $(seq 1 "$HEALTHZ_MAX_ATTEMPTS"); do
             : > healthz-response.json
             if ! HEALTHZ_CODE=$(curl -sS -o healthz-response.json -w "%{http_code}" \
-              --max-time 15 "$TEST_URL/healthz"); then
+              --max-time 20 "$HEALTHZ_URL"); then
               HEALTHZ_CODE="000"
             fi
             if [ "$HEALTHZ_CODE" = "200" ]; then
@@ -937,8 +939,8 @@ jobs:
             fi
             echo "Green revision /healthz attempt ${attempt} returned HTTP ${HEALTHZ_CODE}"
             [ -s healthz-response.json ] && head -c 2000 healthz-response.json || true
-            if [ "$attempt" -lt 6 ]; then
-              sleep 10
+            if [ "$attempt" -lt "$HEALTHZ_MAX_ATTEMPTS" ]; then
+              sleep 15
             fi
           done
           if [ "$HEALTHZ_CODE" != "200" ]; then

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -56,8 +56,13 @@ def test_backend_green_revision_healthz_is_retried_before_failure():
     )
     smoke_script = smoke_step["run"]
 
-    assert "for attempt in 1 2 3 4 5 6; do" in smoke_script
+    assert "HEALTHZ_MAX_ATTEMPTS=12" in smoke_script
+    assert 'HEALTHZ_URL="${TEST_URL%/api}/healthz"' in smoke_script
+    assert 'echo "Checking green revision liveness: $HEALTHZ_URL"' in smoke_script
+    assert 'for attempt in $(seq 1 "$HEALTHZ_MAX_ATTEMPTS"); do' in smoke_script
     assert ": > healthz-response.json" in smoke_script
+    assert '--max-time 20 "$HEALTHZ_URL"' in smoke_script
     assert 'Green revision /healthz attempt ${attempt} returned HTTP ${HEALTHZ_CODE}' in smoke_script
-    assert 'if [ "$attempt" -lt 6 ]; then' in smoke_script
+    assert 'if [ "$attempt" -lt "$HEALTHZ_MAX_ATTEMPTS" ]; then' in smoke_script
+    assert "sleep 15" in smoke_script
     assert 'dump_green_revision_diagnostics "healthz-${HEALTHZ_CODE}"' in smoke_script


### PR DESCRIPTION
## Summary
- extend green revision /healthz retry window to tolerate Container Apps activation lag
- keep response truncation and skip final sleep behavior
- update workflow contract coverage

## Validation
- git diff --check
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py