### PR TITLE
fix: limit backend deploy workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,6 +780,7 @@ jobs:
               AZURE_OPENAI_API_VERSION="2025-04-01-preview" \
               ACS_CONNECTION_STRING="${{ secrets.ACS_CONNECTION_STRING }}" \
               ACS_SENDER_EMAIL="${{ secrets.ACS_SENDER_EMAIL }}" \
+              WEB_CONCURRENCY="1" \
             --revision-suffix "$REVISION_SUFFIX" \
             --no-wait
 

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -31,6 +31,19 @@ def test_backend_deploy_wires_jwt_secret_to_container_app_revision():
     assert "2>/dev/null || true" not in deploy_script
 
 
+def test_backend_deploy_limits_workers_for_fast_container_app_activation():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    deploy_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Deploy green revision"
+    )
+    deploy_script = deploy_step["run"]
+
+    assert 'WEB_CONCURRENCY="1"' in deploy_script
+
+
 def test_backend_readiness_accepts_azure_provisioned_state():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- set WEB_CONCURRENCY=1 on deployed backend Container Apps revisions
- add a workflow contract test for the deployment worker count

## Why
The main deploy reached the corrected /healthz URL but timed out for all 12 attempts. Diagnostics showed the revision was still Activating and the app only logged startup complete seconds after the smoke window ended, with multiple Gunicorn workers repeating startup work.

## Tests
- git diff --check
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py