### PR TITLE
fix: pass Front Door origin contract during CI deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,6 +755,29 @@ jobs:
       - name: Deploy green revision
         id: green
         run: |
+          FRONT_DOOR_PROFILE_NAME=$(az afd profile list \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "[?starts_with(name, 'archmorph-fd')].name | [0]" \
+            -o tsv 2>/dev/null || echo "")
+          if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
+            echo "::error::Unable to resolve owned Azure Front Door profile for origin-lock contract"
+            exit 1
+          fi
+
+          TRUSTED_FRONT_DOOR_FDID=$(az afd profile show \
+            --profile-name "$FRONT_DOOR_PROFILE_NAME" \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query resourceGuid -o tsv 2>/dev/null || echo "")
+          TRUSTED_FRONT_DOOR_HOSTS=$(az afd endpoint list \
+            --profile-name "$FRONT_DOOR_PROFILE_NAME" \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "[?starts_with(name, 'archmorph-api')].hostName | [0]" \
+            -o tsv 2>/dev/null || echo "")
+          if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
+            echo "::error::Unable to resolve Front Door FDID/hostname for origin-lock contract"
+            exit 1
+          fi
+
           az containerapp secret set \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
@@ -776,6 +799,8 @@ jobs:
             AZURE_OPENAI_API_VERSION="2025-04-01-preview"
             ACS_SENDER_EMAIL="${{ secrets.ACS_SENDER_EMAIL }}"
             WEB_CONCURRENCY="1"
+            TRUSTED_FRONT_DOOR_FDID="$TRUSTED_FRONT_DOOR_FDID"
+            TRUSTED_FRONT_DOOR_HOSTS="$TRUSTED_FRONT_DOOR_HOSTS"
           )
 
           if [ -n "${{ secrets.ACS_CONNECTION_STRING }}" ]; then
@@ -1092,7 +1117,16 @@ jobs:
             fi
           done
 
-          HEALTH_RETRIES=3 HEALTH_RETRY_SECONDS=15 HEALTH_API_KEY="$ARCHMORPH_API_KEY" ./scripts/health_gate.sh "$TEST_URL$HEALTH_PATH"
+          for attempt in 1 2 3; do
+            HEALTH_BODY=$(curl_health "$TEST_URL$HEALTH_PATH" || true)
+            if HEALTH_BODY="$HEALTH_BODY" HEALTH_RETRIES=1 HEALTH_RETRY_SECONDS=0 ./scripts/health_gate.sh; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 15
+          done
           VERSION=$(curl_health "$TEST_URL$HEALTH_PATH" | jq -r '.version' 2>/dev/null || echo 'unknown')
           echo "Green revision version: $VERSION — all smoke tests passed"
 

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -126,3 +126,22 @@ def test_backend_green_revision_smoke_checks_origin_lock_and_reuses_front_door_c
     assert 'DIRECT_ORIGIN_CODE=$(curl -sS -o direct-origin-response.json -w "%{http_code}"' in smoke_script
     assert 'echo "::error::Direct green revision origin-lock check returned HTTP ${DIRECT_ORIGIN_CODE}"' in smoke_script
     assert 'echo "Direct green revision access correctly blocked (${DIRECT_ORIGIN_CODE})"' in smoke_script
+    assert 'HEALTH_BODY=$(curl_health "$TEST_URL$HEALTH_PATH" || true)' in smoke_script
+    assert 'HEALTH_BODY="$HEALTH_BODY" HEALTH_RETRIES=1 HEALTH_RETRY_SECONDS=0 ./scripts/health_gate.sh' in smoke_script
+
+
+def test_backend_green_revision_deploy_wires_front_door_origin_lock_contract():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    deploy_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Deploy green revision"
+    )
+    deploy_script = deploy_step["run"]
+
+    assert "FRONT_DOOR_PROFILE_NAME=$(az afd profile list" in deploy_script
+    assert "TRUSTED_FRONT_DOOR_FDID=$(az afd profile show" in deploy_script
+    assert "TRUSTED_FRONT_DOOR_HOSTS=$(az afd endpoint list" in deploy_script
+    assert 'TRUSTED_FRONT_DOOR_FDID="$TRUSTED_FRONT_DOOR_FDID"' in deploy_script
+    assert 'TRUSTED_FRONT_DOOR_HOSTS="$TRUSTED_FRONT_DOOR_HOSTS"' in deploy_script


### PR DESCRIPTION
## Summary
- discover the owned Front Door profile and API endpoint during backend green-revision deploys
- pass TRUSTED_FRONT_DOOR_FDID and TRUSTED_FRONT_DOOR_HOSTS into the Container App revision env
- add workflow regression coverage so origin-lock smoke and deploy env wiring stay aligned

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_ci_workflow_post_deploy_smoke.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_ci_workflow_post_deploy_smoke.py tests/test_front_door_origin_lock.py tests/test_front_door_origin_lock_infra.py -q