### PR TITLE
fix: discover Front Door profile from endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,10 +755,46 @@ jobs:
       - name: Deploy green revision
         id: green
         run: |
-          FRONT_DOOR_PROFILE_NAME=$(az afd profile list \
+          FRONT_DOOR_PROFILE_NAME=""
+          TRUSTED_FRONT_DOOR_HOSTS=""
+          FRONT_DOOR_PROFILE_NAMES=$(az afd profile list \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[?starts_with(name, 'archmorph-fd')].name | [0]" \
+            --query "[].name" \
             -o tsv 2>/dev/null || echo "")
+
+          while IFS= read -r candidate_profile; do
+            if [ -z "$candidate_profile" ]; then
+              continue
+            fi
+            candidate_host=$(az afd endpoint list \
+              --profile-name "$candidate_profile" \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --query "[?contains(name, 'api') || contains(hostName, 'api')].hostName | [0]" \
+              -o tsv 2>/dev/null || echo "")
+            if [ -n "$candidate_host" ]; then
+              FRONT_DOOR_PROFILE_NAME="$candidate_profile"
+              TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
+              break
+            fi
+          done <<< "$FRONT_DOOR_PROFILE_NAMES"
+
+          if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
+            while IFS= read -r candidate_profile; do
+              if [ -z "$candidate_profile" ]; then
+                continue
+              fi
+              candidate_host=$(az afd endpoint list \
+                --profile-name "$candidate_profile" \
+                --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+                --query "[0].hostName" \
+                -o tsv 2>/dev/null || echo "")
+              if [ -n "$candidate_host" ]; then
+                FRONT_DOOR_PROFILE_NAME="$candidate_profile"
+                TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
+                break
+              fi
+            done <<< "$FRONT_DOOR_PROFILE_NAMES"
+          fi
           if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
             echo "::error::Unable to resolve owned Azure Front Door profile for origin-lock contract"
             exit 1
@@ -768,11 +804,6 @@ jobs:
             --profile-name "$FRONT_DOOR_PROFILE_NAME" \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query resourceGuid -o tsv 2>/dev/null || echo "")
-          TRUSTED_FRONT_DOOR_HOSTS=$(az afd endpoint list \
-            --profile-name "$FRONT_DOOR_PROFILE_NAME" \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[?starts_with(name, 'archmorph-api')].hostName | [0]" \
-            -o tsv 2>/dev/null || echo "")
           if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
             echo "::error::Unable to resolve Front Door FDID/hostname for origin-lock contract"
             exit 1

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -140,8 +140,12 @@ def test_backend_green_revision_deploy_wires_front_door_origin_lock_contract():
     )
     deploy_script = deploy_step["run"]
 
-    assert "FRONT_DOOR_PROFILE_NAME=$(az afd profile list" in deploy_script
+    assert 'FRONT_DOOR_PROFILE_NAMES=$(az afd profile list' in deploy_script
+    assert 'candidate_host=$(az afd endpoint list' in deploy_script
+    assert "contains(name, 'api') || contains(hostName, 'api')" in deploy_script
+    assert 'if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then' in deploy_script
+    assert deploy_script.index("contains(name, 'api') || contains(hostName, 'api')") < deploy_script.index('if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then')
+    assert 'TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"' in deploy_script
     assert "TRUSTED_FRONT_DOOR_FDID=$(az afd profile show" in deploy_script
-    assert "TRUSTED_FRONT_DOOR_HOSTS=$(az afd endpoint list" in deploy_script
     assert 'TRUSTED_FRONT_DOOR_FDID="$TRUSTED_FRONT_DOOR_FDID"' in deploy_script
     assert 'TRUSTED_FRONT_DOOR_HOSTS="$TRUSTED_FRONT_DOOR_HOSTS"' in deploy_script


### PR DESCRIPTION
## Summary
- discover the owned Front Door profile by scanning profiles for an API-like endpoint instead of assuming the profile name starts with archmorph-fd
- keep the deploy fail-closed when no profile, endpoint host, or FDID can be resolved
- update workflow regression coverage for endpoint-based discovery

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_ci_workflow_post_deploy_smoke.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_ci_workflow_post_deploy_smoke.py tests/test_front_door_origin_lock.py tests/test_front_door_origin_lock_infra.py -q