### PR TITLE
fix: discover Front Door contract through ARM resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,54 +756,55 @@ jobs:
         id: green
         run: |
           FRONT_DOOR_PROFILE_NAME=""
+          TRUSTED_FRONT_DOOR_FDID=""
           TRUSTED_FRONT_DOOR_HOSTS=""
-          FRONT_DOOR_PROFILE_NAMES=$(az afd profile list \
+          FRONT_DOOR_PROFILES_JSON=$(az resource list \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[].name" \
-            -o tsv 2>/dev/null || echo "")
+            --resource-type Microsoft.Cdn/profiles \
+            -o json 2>/dev/null || echo "[]")
+          FRONT_DOOR_ENDPOINTS_JSON=$(az resource list \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --resource-type Microsoft.Cdn/profiles/afdEndpoints \
+            -o json 2>/dev/null || echo "[]")
 
-          while IFS= read -r candidate_profile; do
-            if [ -z "$candidate_profile" ]; then
+          while IFS= read -r candidate_profile_json; do
+            if [ -z "$candidate_profile_json" ]; then
               continue
             fi
-            candidate_host=$(az afd endpoint list \
-              --profile-name "$candidate_profile" \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --query "[?contains(name, 'api') || contains(hostName, 'api')].hostName | [0]" \
-              -o tsv 2>/dev/null || echo "")
-            if [ -n "$candidate_host" ]; then
-              FRONT_DOOR_PROFILE_NAME="$candidate_profile"
+            candidate_profile_id=$(echo "$candidate_profile_json" | jq -r '.id // ""')
+            candidate_profile_name=$(echo "$candidate_profile_json" | jq -r '.name // ""')
+            candidate_fdid=$(echo "$candidate_profile_json" | jq -r '.properties.frontDoorId // .properties.resourceGuid // ""')
+            candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | select(((.name // "") | ascii_downcase | contains("api")) or (((.properties.hostName // "") | ascii_downcase) | contains("api"))) | .properties.hostName][0] // ""')
+            if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then
+              FRONT_DOOR_PROFILE_NAME="$candidate_profile_name"
+              TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"
               TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
               break
             fi
-          done <<< "$FRONT_DOOR_PROFILE_NAMES"
+          done < <(echo "$FRONT_DOOR_PROFILES_JSON" | jq -c '.[]')
 
           if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
-            while IFS= read -r candidate_profile; do
-              if [ -z "$candidate_profile" ]; then
+            while IFS= read -r candidate_profile_json; do
+              if [ -z "$candidate_profile_json" ]; then
                 continue
               fi
-              candidate_host=$(az afd endpoint list \
-                --profile-name "$candidate_profile" \
-                --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-                --query "[0].hostName" \
-                -o tsv 2>/dev/null || echo "")
-              if [ -n "$candidate_host" ]; then
-                FRONT_DOOR_PROFILE_NAME="$candidate_profile"
+              candidate_profile_id=$(echo "$candidate_profile_json" | jq -r '.id // ""')
+              candidate_profile_name=$(echo "$candidate_profile_json" | jq -r '.name // ""')
+              candidate_fdid=$(echo "$candidate_profile_json" | jq -r '.properties.frontDoorId // .properties.resourceGuid // ""')
+              candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | .properties.hostName][0] // ""')
+              if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then
+                FRONT_DOOR_PROFILE_NAME="$candidate_profile_name"
+                TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"
                 TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
                 break
               fi
-            done <<< "$FRONT_DOOR_PROFILE_NAMES"
+            done < <(echo "$FRONT_DOOR_PROFILES_JSON" | jq -c '.[]')
           fi
           if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
             echo "::error::Unable to resolve owned Azure Front Door profile for origin-lock contract"
             exit 1
           fi
 
-          TRUSTED_FRONT_DOOR_FDID=$(az afd profile show \
-            --profile-name "$FRONT_DOOR_PROFILE_NAME" \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query resourceGuid -o tsv 2>/dev/null || echo "")
           if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
             echo "::error::Unable to resolve Front Door FDID/hostname for origin-lock contract"
             exit 1

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -140,12 +140,15 @@ def test_backend_green_revision_deploy_wires_front_door_origin_lock_contract():
     )
     deploy_script = deploy_step["run"]
 
-    assert 'FRONT_DOOR_PROFILE_NAMES=$(az afd profile list' in deploy_script
-    assert 'candidate_host=$(az afd endpoint list' in deploy_script
-    assert "contains(name, 'api') || contains(hostName, 'api')" in deploy_script
+    assert 'FRONT_DOOR_PROFILES_JSON=$(az resource list' in deploy_script
+    assert '--resource-type Microsoft.Cdn/profiles' in deploy_script
+    assert '--resource-type Microsoft.Cdn/profiles/afdEndpoints' in deploy_script
+    assert 'candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq' in deploy_script
+    assert 'contains("api")' in deploy_script
     assert 'if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then' in deploy_script
-    assert deploy_script.index("contains(name, 'api') || contains(hostName, 'api')") < deploy_script.index('if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then')
+    assert deploy_script.index('contains("api")') < deploy_script.index('if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then')
+    assert 'TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"' in deploy_script
     assert 'TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"' in deploy_script
-    assert "TRUSTED_FRONT_DOOR_FDID=$(az afd profile show" in deploy_script
+    assert deploy_script.count('if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then') == 2
     assert 'TRUSTED_FRONT_DOOR_FDID="$TRUSTED_FRONT_DOOR_FDID"' in deploy_script
     assert 'TRUSTED_FRONT_DOOR_HOSTS="$TRUSTED_FRONT_DOOR_HOSTS"' in deploy_script


### PR DESCRIPTION
## Summary
- query Front Door profiles and AFD endpoints through generic ARM resources instead of az afd list commands
- preserve two-pass endpoint selection: API-like endpoints first, fallback only after all profiles are scanned
- keep deploy fail-closed if FDID or host cannot be resolved

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_ci_workflow_post_deploy_smoke.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_ci_workflow_post_deploy_smoke.py tests/test_front_door_origin_lock.py tests/test_front_door_origin_lock_infra.py -q