### PR TITLE
fix: preserve Container App Front Door contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,32 +758,30 @@ jobs:
           FRONT_DOOR_PROFILE_NAME=""
           TRUSTED_FRONT_DOOR_FDID=""
           TRUSTED_FRONT_DOOR_HOSTS=""
-          FRONT_DOOR_PROFILES_JSON=$(az resource list \
+          EXISTING_ENV_JSON=$(az containerapp show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "properties.template.containers[0].env" -o json 2>/dev/null || echo "[]")
+          TRUSTED_FRONT_DOOR_FDID=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_FDID") | .value // ""' | head -1)
+          TRUSTED_FRONT_DOOR_HOSTS=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_HOSTS") | .value // ""' | head -1)
+          CONTAINER_APP_FQDN=$(az containerapp show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null || echo "")
+
+          FRONT_DOOR_PROFILES_JSON=$(az resource list \
             --resource-type Microsoft.Cdn/profiles \
             -o json 2>/dev/null || echo "[]")
           FRONT_DOOR_ENDPOINTS_JSON=$(az resource list \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --resource-type Microsoft.Cdn/profiles/afdEndpoints \
             -o json 2>/dev/null || echo "[]")
+          FRONT_DOOR_ORIGINS_JSON=$(az resource list \
+            --resource-type Microsoft.Cdn/profiles/originGroups/origins \
+            -o json 2>/dev/null || echo "[]")
 
-          while IFS= read -r candidate_profile_json; do
-            if [ -z "$candidate_profile_json" ]; then
-              continue
-            fi
-            candidate_profile_id=$(echo "$candidate_profile_json" | jq -r '.id // ""')
-            candidate_profile_name=$(echo "$candidate_profile_json" | jq -r '.name // ""')
-            candidate_fdid=$(echo "$candidate_profile_json" | jq -r '.properties.frontDoorId // .properties.resourceGuid // ""')
-            candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | select(((.name // "") | ascii_downcase | contains("api")) or (((.properties.hostName // "") | ascii_downcase) | contains("api"))) | .properties.hostName][0] // ""')
-            if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then
-              FRONT_DOOR_PROFILE_NAME="$candidate_profile_name"
-              TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"
-              TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
-              break
-            fi
-          done < <(echo "$FRONT_DOOR_PROFILES_JSON" | jq -c '.[]')
-
-          if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
+          if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
+            TRUSTED_FRONT_DOOR_FDID=""
+            TRUSTED_FRONT_DOOR_HOSTS=""
             while IFS= read -r candidate_profile_json; do
               if [ -z "$candidate_profile_json" ]; then
                 continue
@@ -791,7 +789,11 @@ jobs:
               candidate_profile_id=$(echo "$candidate_profile_json" | jq -r '.id // ""')
               candidate_profile_name=$(echo "$candidate_profile_json" | jq -r '.name // ""')
               candidate_fdid=$(echo "$candidate_profile_json" | jq -r '.properties.frontDoorId // .properties.resourceGuid // ""')
-              candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | .properties.hostName][0] // ""')
+              origin_matches_container=$(echo "$FRONT_DOOR_ORIGINS_JSON" | jq -r --arg profile_id "$candidate_profile_id" --arg container_host "$CONTAINER_APP_FQDN" 'any(.[]; ((.id // "") | startswith($profile_id + "/")) and ((.properties.hostName // "") == $container_host))')
+              if [ "$origin_matches_container" != "true" ]; then
+                continue
+              fi
+              candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | select(((.name // "") | ascii_downcase | contains("api")) or (((.properties.hostName // "") | ascii_downcase) | contains("api"))) | .properties.hostName][0] // ""')
               if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then
                 FRONT_DOOR_PROFILE_NAME="$candidate_profile_name"
                 TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"
@@ -800,9 +802,27 @@ jobs:
               fi
             done < <(echo "$FRONT_DOOR_PROFILES_JSON" | jq -c '.[]')
           fi
-          if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then
-            echo "::error::Unable to resolve owned Azure Front Door profile for origin-lock contract"
-            exit 1
+
+          if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
+            while IFS= read -r candidate_profile_json; do
+              if [ -z "$candidate_profile_json" ]; then
+                continue
+              fi
+              candidate_profile_id=$(echo "$candidate_profile_json" | jq -r '.id // ""')
+              candidate_profile_name=$(echo "$candidate_profile_json" | jq -r '.name // ""')
+              candidate_fdid=$(echo "$candidate_profile_json" | jq -r '.properties.frontDoorId // .properties.resourceGuid // ""')
+              origin_matches_container=$(echo "$FRONT_DOOR_ORIGINS_JSON" | jq -r --arg profile_id "$candidate_profile_id" --arg container_host "$CONTAINER_APP_FQDN" 'any(.[]; ((.id // "") | startswith($profile_id + "/")) and ((.properties.hostName // "") == $container_host))')
+              if [ "$origin_matches_container" != "true" ]; then
+                continue
+              fi
+              candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq -r --arg profile_id "$candidate_profile_id" '[.[] | select((.id // "") | startswith($profile_id + "/")) | .properties.hostName][0] // ""')
+              if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then
+                FRONT_DOOR_PROFILE_NAME="$candidate_profile_name"
+                TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"
+                TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"
+                break
+              fi
+            done < <(echo "$FRONT_DOOR_PROFILES_JSON" | jq -c '.[]')
           fi
 
           if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -140,13 +140,22 @@ def test_backend_green_revision_deploy_wires_front_door_origin_lock_contract():
     )
     deploy_script = deploy_step["run"]
 
+    assert 'EXISTING_ENV_JSON=$(az containerapp show' in deploy_script
+    assert 'select(.name == "TRUSTED_FRONT_DOOR_FDID")' in deploy_script
+    assert 'select(.name == "TRUSTED_FRONT_DOOR_HOSTS")' in deploy_script
+    assert 'CONTAINER_APP_FQDN=$(az containerapp show' in deploy_script
     assert 'FRONT_DOOR_PROFILES_JSON=$(az resource list' in deploy_script
     assert '--resource-type Microsoft.Cdn/profiles' in deploy_script
     assert '--resource-type Microsoft.Cdn/profiles/afdEndpoints' in deploy_script
+    assert '--resource-type Microsoft.Cdn/profiles/originGroups/origins' in deploy_script
+    assert '--resource-group ${{ env.AZURE_RESOURCE_GROUP }}' not in deploy_script.split('FRONT_DOOR_PROFILES_JSON=$(az resource list', 1)[1].split('FRONT_DOOR_ENDPOINTS_JSON=', 1)[0]
+    assert '--resource-group ${{ env.AZURE_RESOURCE_GROUP }}' not in deploy_script.split('FRONT_DOOR_ENDPOINTS_JSON=$(az resource list', 1)[1].split('FRONT_DOOR_ORIGINS_JSON=', 1)[0]
+    assert 'origin_matches_container=$(echo "$FRONT_DOOR_ORIGINS_JSON" | jq' in deploy_script
+    assert '(.properties.hostName // "") == $container_host' in deploy_script
     assert 'candidate_host=$(echo "$FRONT_DOOR_ENDPOINTS_JSON" | jq' in deploy_script
     assert 'contains("api")' in deploy_script
-    assert 'if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then' in deploy_script
-    assert deploy_script.index('contains("api")') < deploy_script.index('if [ -z "$FRONT_DOOR_PROFILE_NAME" ]; then')
+    assert 'if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then' in deploy_script
+    assert deploy_script.index('contains("api")') < deploy_script.index('[.[] | select((.id // "") | startswith($profile_id + "/")) | .properties.hostName][0] // ""')
     assert 'TRUSTED_FRONT_DOOR_FDID="$candidate_fdid"' in deploy_script
     assert 'TRUSTED_FRONT_DOOR_HOSTS="$candidate_host"' in deploy_script
     assert deploy_script.count('if [ -n "$candidate_host" ] && [ -n "$candidate_fdid" ]; then') == 2


### PR DESCRIPTION
## Summary
- preserve existing Container App TRUSTED_FRONT_DOOR_FDID and TRUSTED_FRONT_DOOR_HOSTS values before creating a green revision
- broaden ARM Front Door fallback discovery to subscription scope
- keep API endpoint preference and require both FDID and host before accepting a candidate

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_ci_workflow_post_deploy_smoke.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_ci_workflow_post_deploy_smoke.py tests/test_front_door_origin_lock.py tests/test_front_door_origin_lock_infra.py -q