### PR TITLE
fix: resolve Front Door contract from Terraform outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,10 @@ jobs:
       ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
       ARCHMORPH_API_KEY: ${{ secrets.ARCHMORPH_API_KEY || secrets.API_KEY }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      ARM_USE_OIDC: true
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     steps:
       - uses: actions/checkout@v6
 
@@ -555,6 +559,12 @@ jobs:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.9.x"
+          terraform_wrapper: false
 
       - name: Validate backend deploy secret inputs
         run: |
@@ -758,12 +768,22 @@ jobs:
           FRONT_DOOR_PROFILE_NAME=""
           TRUSTED_FRONT_DOOR_FDID=""
           TRUSTED_FRONT_DOOR_HOSTS=""
+          if terraform -chdir=infra init -input=false >/tmp/terraform-init-front-door.log 2>&1; then
+            TRUSTED_FRONT_DOOR_FDID=$(terraform -chdir=infra output -raw front_door_profile_resource_guid 2>/dev/null || echo "")
+            TRUSTED_FRONT_DOOR_HOSTS=$(terraform -chdir=infra output -raw front_door_api_hostname 2>/dev/null || echo "")
+          else
+            echo "::warning::Unable to initialize Terraform remote state for Front Door outputs"
+            tail -n 40 /tmp/terraform-init-front-door.log || true
+          fi
+
           EXISTING_ENV_JSON=$(az containerapp show \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query "properties.template.containers[0].env" -o json 2>/dev/null || echo "[]")
-          TRUSTED_FRONT_DOOR_FDID=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_FDID") | .value // ""' | head -1)
-          TRUSTED_FRONT_DOOR_HOSTS=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_HOSTS") | .value // ""' | head -1)
+          if [ -z "$TRUSTED_FRONT_DOOR_FDID" ] || [ -z "$TRUSTED_FRONT_DOOR_HOSTS" ]; then
+            TRUSTED_FRONT_DOOR_FDID=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_FDID") | .value // ""' | head -1)
+            TRUSTED_FRONT_DOOR_HOSTS=$(echo "$EXISTING_ENV_JSON" | jq -r '.[] | select(.name == "TRUSTED_FRONT_DOOR_HOSTS") | .value // ""' | head -1)
+          fi
           CONTAINER_APP_FQDN=$(az containerapp show \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -32,6 +32,22 @@ def test_backend_deploy_wires_jwt_secret_to_container_app_revision():
     assert "2>/dev/null || true" not in deploy_script
 
 
+def test_backend_deploy_can_read_terraform_front_door_outputs():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    deploy_job = workflow["jobs"]["deploy-backend"]
+    assert deploy_job["env"]["ARM_USE_OIDC"] is True
+    assert deploy_job["env"]["ARM_CLIENT_ID"] == "${{ secrets.AZURE_CLIENT_ID }}"
+    assert deploy_job["env"]["ARM_TENANT_ID"] == "${{ secrets.AZURE_TENANT_ID }}"
+    assert deploy_job["env"]["ARM_SUBSCRIPTION_ID"] == "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+    assert any(
+        step.get("name") == "Set up Terraform"
+        and step.get("uses") == "hashicorp/setup-terraform@v4"
+        and step.get("with", {}).get("terraform_wrapper") is False
+        for step in deploy_job["steps"]
+    )
+
+
 def test_backend_deploy_uses_distinct_api_key_secret_reference():
     workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
     workflow = yaml.safe_load(workflow_text)
@@ -140,6 +156,9 @@ def test_backend_green_revision_deploy_wires_front_door_origin_lock_contract():
     )
     deploy_script = deploy_step["run"]
 
+    assert 'terraform -chdir=infra init -input=false' in deploy_script
+    assert 'terraform -chdir=infra output -raw front_door_profile_resource_guid' in deploy_script
+    assert 'terraform -chdir=infra output -raw front_door_api_hostname' in deploy_script
     assert 'EXISTING_ENV_JSON=$(az containerapp show' in deploy_script
     assert 'select(.name == "TRUSTED_FRONT_DOOR_FDID")' in deploy_script
     assert 'select(.name == "TRUSTED_FRONT_DOOR_HOSTS")' in deploy_script


### PR DESCRIPTION
## Summary
- configure deploy-backend with Terraform/OIDC so it can read production remote-state outputs
- resolve TRUSTED_FRONT_DOOR_FDID and TRUSTED_FRONT_DOOR_HOSTS from Terraform outputs before falling back to existing app env or constrained ARM discovery
- keep deploy fail-closed if no trusted Front Door contract can be resolved

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m ruff check tests/test_ci_workflow_post_deploy_smoke.py
- /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_ci_workflow_post_deploy_smoke.py tests/test_front_door_origin_lock.py tests/test_front_door_origin_lock_infra.py -q