### PR TITLE
fix(frontend): clarify sign-in modal analysis requirement

### DIFF
--- a/e2e/login-modal-focus.spec.ts
+++ b/e2e/login-modal-focus.spec.ts
@@ -35,7 +35,7 @@ test.describe('Accessibility: Login modal keyboard focus order', () => {
     const microsoftButton = dialog.getByRole('button', { name: /continue with microsoft/i });
     const googleButton = dialog.getByRole('button', { name: /continue with google/i });
     const githubButton = dialog.getByRole('button', { name: /continue with github/i });
-    const guestButton = dialog.getByRole('button', { name: /continue as guest/i });
+    const guestButton = dialog.getByRole('button', { name: /continue browsing/i });
 
     await expect(closeButton).toBeFocused();
     await page.keyboard.press('Tab');

--- a/e2e/login-modal-focus.spec.ts
+++ b/e2e/login-modal-focus.spec.ts
@@ -35,7 +35,7 @@ test.describe('Accessibility: Login modal keyboard focus order', () => {
     const microsoftButton = dialog.getByRole('button', { name: /continue with microsoft/i });
     const googleButton = dialog.getByRole('button', { name: /continue with google/i });
     const githubButton = dialog.getByRole('button', { name: /continue with github/i });
-    const guestButton = dialog.getByRole('button', { name: /continue browsing/i });
+    const continueBrowsingButton = dialog.getByRole('button', { name: /continue browsing/i });
 
     await expect(closeButton).toBeFocused();
     await page.keyboard.press('Tab');
@@ -45,12 +45,12 @@ test.describe('Accessibility: Login modal keyboard focus order', () => {
     await page.keyboard.press('Tab');
     await expect(githubButton).toBeFocused();
     await page.keyboard.press('Tab');
-    await expect(guestButton).toBeFocused();
+    await expect(continueBrowsingButton).toBeFocused();
     await page.keyboard.press('Tab');
     await expect(closeButton).toBeFocused();
 
     await page.keyboard.press('Shift+Tab');
-    await expect(guestButton).toBeFocused();
+    await expect(continueBrowsingButton).toBeFocused();
 
     await page.keyboard.press('Escape');
     await expect(dialog).toBeHidden();

--- a/frontend/src/components/Auth/LoginModal.jsx
+++ b/frontend/src/components/Auth/LoginModal.jsx
@@ -2,7 +2,7 @@
  * LoginModal — Social sign-in modal (#246).
  *
  * Offers Microsoft, Google, GitHub sign-in buttons
- * plus "Continue as Guest" — all using Azure SWA auth redirects.
+ * plus a browsing-only guest dismissal.
  */
 
 import React, { useEffect, useId } from 'react';
@@ -146,16 +146,16 @@ export default function LoginModal({ isOpen, onClose }) {
           <div className="flex-1 h-px bg-border" />
         </div>
 
-        {/* Continue as Guest */}
+        {/* Browsing-only dismissal */}
         <button
           onClick={onClose}
           className="w-full px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-secondary transition-colors cursor-pointer"
         >
-          Continue as Guest
+          Continue Browsing
         </button>
 
         <p className="text-[11px] text-text-muted text-center mt-4">
-          No account needed to use the translator. Sign in to save your work.
+          Sign in is required to analyze diagrams. You can keep browsing without an account.
         </p>
       </div>
     </div>,

--- a/frontend/src/components/__tests__/LoginModal.test.jsx
+++ b/frontend/src/components/__tests__/LoginModal.test.jsx
@@ -3,7 +3,7 @@
  * #818 #819 #820 #821 #822 #853 #854 #907 #908).
  *
  * Covers: portal rendering, ARIA semantics, Escape close, backdrop click,
- * body scroll lock, focus trap, and Continue-as-Guest.
+ * body scroll lock, focus trap, and browsing-only dismissal.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -79,11 +79,17 @@ describe('LoginModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClose when Continue as Guest is clicked', async () => {
+  it('calls onClose when Continue Browsing is clicked', async () => {
     const onClose = vi.fn();
     render(<LoginModal isOpen={true} onClose={onClose} />);
-    await userEvent.click(screen.getByRole('button', { name: /continue as guest/i }));
+    await userEvent.click(screen.getByRole('button', { name: /continue browsing/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes clear that diagram analysis requires sign-in', () => {
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/sign in is required to analyze diagrams/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no account needed to use the translator/i)).not.toBeInTheDocument();
   });
 
   it('locks body scroll when open and restores on close', () => {


### PR DESCRIPTION
## Summary
- Replace the misleading guest translator copy with auth-required analysis copy
- Rename the modal dismissal action to `Continue Browsing`
- Update LoginModal unit coverage and the modal focus-order Playwright selector

## Validation
- `npx vitest run src/components/__tests__/LoginModal.test.jsx`
- `npm run build` from `frontend`
- `FRONTEND_URL=http://127.0.0.1:5173 npm run test:e2e -- e2e/login-modal-focus.spec.ts`

Note: the same Playwright spec was also run once without `FRONTEND_URL`, which correctly hit production and failed because production still has the old deployed modal copy until this PR ships.