### PR TITLE
fix: remove tainted values from security logs

### DIFF
--- a/backend/routers/collaboration_routes.py
+++ b/backend/routers/collaboration_routes.py
@@ -222,7 +222,7 @@ async def join_session(
     existing_participant = _find_participant_by_user_id(session, user.id)
     if existing_participant:
         if not existing_participant.get("participant_token"):
-            logger.warning("Participant %s missing collaboration token in session %s", safe(user.id), safe(session_id))
+            logger.warning("Participant missing collaboration token; regenerating token")
             existing_participant["participant_token"] = secrets.token_urlsafe(24)
             _session_store[session_id] = session
         return {
@@ -236,7 +236,7 @@ async def join_session(
     session["participants"].append(participant)
     _session_store[session_id] = session
 
-    logger.info("User %s joined session %s as %s", safe(user.id), safe(session_id), safe(body.role))
+    logger.info("Collaboration participant joined session")
     return {
         "status": "joined",
         "session_id": session_id,

--- a/backend/routers/iac_routes.py
+++ b/backend/routers/iac_routes.py
@@ -29,7 +29,6 @@ from usage_metrics import record_event, record_funnel_step
 from iac_chat import process_iac_chat, get_iac_chat_history, clear_iac_chat
 from iac_generator import generate_iac_code
 from iac_scaffold import generate_scaffold
-from log_sanitizer import safe
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +86,8 @@ def _check_architecture_blockers(diagram_id: str, session: dict, force: bool) ->
 
     if force:
         logger.warning(
-            "iac_blockers_overridden diagram=%s blocker_count=%d ids=%s",
-            safe(diagram_id),
+            "iac_blockers_overridden blocker_count=%d",
             len(blockers),
-            ",".join(safe(b.get("rule_id", "?")) for b in blockers),
         )
         record_event(
             "iac_blockers_overridden",

--- a/backend/session_store.py
+++ b/backend/session_store.py
@@ -29,7 +29,6 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 from cachetools import TTLCache
-from log_sanitizer import safe
 
 logger = logging.getLogger(__name__)
 
@@ -428,7 +427,10 @@ class RedisStore(SessionStore):
         try:
             raw = redis_breaker.call(self._redis.get, self._key(key))
         except Exception as exc:
-            logger.warning("Redis GET failed for '%s': %s — returning default", safe(key), safe(exc))
+            logger.warning(
+                "Redis GET failed; returning default (error_type=%s)",
+                type(exc).__name__,
+            )
             return default
         if raw is None:
             return default
@@ -448,14 +450,17 @@ class RedisStore(SessionStore):
             payload = self._json.dumps(value, default=str)
             redis_breaker.call(self._redis.setex, self._key(key), ttl or self._ttl, payload)
         except Exception as exc:
-            logger.warning("Redis SET failed for '%s': %s — data not persisted", safe(key), safe(exc))
+            logger.warning(
+                "Redis SET failed; data not persisted (error_type=%s)",
+                type(exc).__name__,
+            )
 
     def delete(self, key: str) -> None:
         from circuit_breakers import redis_breaker
         try:
             redis_breaker.call(self._redis.delete, self._key(key))
         except Exception as exc:
-            logger.warning("Redis DELETE failed for '%s': %s", safe(key), safe(exc))
+            logger.warning("Redis DELETE failed (error_type=%s)", type(exc).__name__)
 
     def keys(self, pattern: str = "*") -> List[str]:
         full_pattern = f"{self._prefix}:{pattern}"

--- a/backend/tests/test_iac_blocker_gate.py
+++ b/backend/tests/test_iac_blocker_gate.py
@@ -219,5 +219,8 @@ def test_force_override_log_sanitizes_diagram_and_rule_ids(caplog):
     message = warning_records[0].getMessage()
     assert "\n" not in message
     assert "\r" not in message
-    assert "diagid" in message
-    assert "rule-1INJECT,rule-2INJECT" in message
+    assert "blocker_count=2" in message
+    assert "diag" not in message
+    assert "rule-1" not in message
+    assert "rule-2" not in message
+    assert "INJECT" not in message

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -209,4 +209,7 @@ def test_redisstore_warning_logs_are_sanitized(monkeypatch, caplog):
         message = record.getMessage()
         assert "\n" not in message
         assert "\r" not in message
-        assert "breakerfailurepayload" in message
+        assert "error_type=RuntimeError" in message
+        assert "badkey" not in message
+        assert "breaker" not in message
+        assert "payload" not in message


### PR DESCRIPTION
## Summary
- remove user-controlled identifiers from CodeQL-flagged log sinks in collaboration, IaC blocker override, and Redis session-store paths
- keep operational signal via fixed event names, counts, and exception type names
- update log safety tests to assert tainted payloads are omitted rather than sanitized into logs

## Validation
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_collaboration_routes_security.py backend/tests/test_iac_blocker_gate.py backend/tests/test_session_store.py`

## Security
- Targets open CodeQL `py/log-injection` alerts #215-#221.