### PR TITLE
fix: apply reviewed terraform production plan

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -31,6 +31,14 @@ These secrets are required in `.github/workflows/monitoring.yml`:
 | `API_URL` | Backend API URL | `https://your-app.azurecontainerapps.io/api` |
 | `FRONTEND_URL` | Frontend Static Web App URL | `https://your-swa.azurestaticapps.net` |
 
+## Production Terraform Workflow Secrets
+
+These secrets are required in `.github/workflows/terraform-prod.yml`:
+
+| Secret Name | Description | Example Value |
+|-------------|-------------|---------------|
+| `TFPLAN_ARTIFACT_PASSPHRASE` | High-entropy passphrase used to encrypt reviewed binary Terraform plan artifacts before upload and decrypt them inside the approved production apply job. | (strong random secret) |
+
 ## E2E Test Environment Variables
 
 When running E2E tests locally or in CI, set these environment variables:

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -126,19 +126,37 @@ jobs:
           Path("plan-metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
           PY
 
+      - name: Encrypt reviewed production plan bundle
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TFPLAN_ARTIFACT_PASSPHRASE: ${{ secrets.TFPLAN_ARTIFACT_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TFPLAN_ARTIFACT_PASSPHRASE:-}" ]; then
+            echo "::error::TFPLAN_ARTIFACT_PASSPHRASE secret is required to encrypt the reviewed Terraform plan artifact."
+            exit 1
+          fi
+          tar -czf prod-reviewed-plan.tar.gz \
+            tfplan \
+            tfplan.sha256 \
+            .terraform.lock.hcl \
+            provider_lock.sha256 \
+            plan-metadata.json
+          openssl enc -aes-256-cbc -pbkdf2 -salt \
+            -in prod-reviewed-plan.tar.gz \
+            -out prod-reviewed-plan.tar.gz.enc \
+            -pass env:TFPLAN_ARTIFACT_PASSPHRASE
+          rm -f prod-reviewed-plan.tar.gz
+
       - name: Upload reviewed production plan artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: prod-reviewed-plan
           path: |
-            infra/tfplan
-            infra/tfplan.sha256
             infra/tfplan.txt
-            infra/.terraform.lock.hcl
-            infra/provider_lock.sha256
-            infra/plan-metadata.json
-          retention-days: 14
+            infra/prod-reviewed-plan.tar.gz.enc
+          retention-days: 1
 
   prod-apply:
     name: prod-apply
@@ -151,6 +169,29 @@ jobs:
         working-directory: ${{ env.TF_WORKING_DIR }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download reviewed production plan artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: prod-reviewed-plan
+          path: infra/reviewed-plan
+
+      - name: Decrypt reviewed production plan bundle
+        env:
+          TFPLAN_ARTIFACT_PASSPHRASE: ${{ secrets.TFPLAN_ARTIFACT_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TFPLAN_ARTIFACT_PASSPHRASE:-}" ]; then
+            echo "::error::TFPLAN_ARTIFACT_PASSPHRASE secret is required to decrypt the reviewed Terraform plan artifact."
+            exit 1
+          fi
+          openssl enc -d -aes-256-cbc -pbkdf2 \
+            -in reviewed-plan/prod-reviewed-plan.tar.gz.enc \
+            -out reviewed-plan/prod-reviewed-plan.tar.gz \
+            -pass env:TFPLAN_ARTIFACT_PASSPHRASE
+          tar -xzf reviewed-plan/prod-reviewed-plan.tar.gz -C reviewed-plan
+          rm -f reviewed-plan/prod-reviewed-plan.tar.gz
+          cp reviewed-plan/.terraform.lock.hcl .terraform.lock.hcl
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -167,12 +208,6 @@ jobs:
       - name: Terraform Init
         run: terraform init -input=false
 
-      - name: Download reviewed production plan artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: prod-reviewed-plan
-          path: infra
-
       - name: Verify reviewed plan artifact integrity and assumptions
         run: |
           set -euo pipefail
@@ -188,9 +223,9 @@ jobs:
               print(f"::error::{message}")
               sys.exit(1)
 
-          metadata_path = Path("plan-metadata.json")
-          plan_path = Path("tfplan")
-          plan_hash_path = Path("tfplan.sha256")
+          metadata_path = Path("reviewed-plan/plan-metadata.json")
+          plan_path = Path("reviewed-plan/tfplan")
+          plan_hash_path = Path("reviewed-plan/tfplan.sha256")
 
           if not metadata_path.exists():
               fail("Missing plan-metadata.json from reviewed plan artifact.")
@@ -249,14 +284,15 @@ jobs:
           import os
           from pathlib import Path
 
-          metadata = json.loads(Path("plan-metadata.json").read_text(encoding="utf-8"))
+          metadata = json.loads(Path("reviewed-plan/plan-metadata.json").read_text(encoding="utf-8"))
           metadata["approval"] = {
-              "approved_by": os.environ["GITHUB_ACTOR"],
-              "approved_at": os.environ["APPROVED_AT"],
+              "workflow_actor": os.environ["GITHUB_ACTOR"],
+              "environment": "production",
+              "recorded_at": os.environ["APPROVED_AT"],
               "workflow_run_id": os.environ["GITHUB_RUN_ID"],
               "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
           }
-          Path("approval-metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+          Path("reviewed-plan/approval-metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
           PY
 
       - name: Upload approval metadata artifact
@@ -264,8 +300,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: prod-reviewed-plan-approval
-          path: infra/approval-metadata.json
+          path: infra/reviewed-plan/approval-metadata.json
           retention-days: 14
 
       - name: Terraform Apply (reviewed plan artifact)
-        run: terraform apply -input=false tfplan
+        run: terraform apply -input=false reviewed-plan/tfplan

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -84,12 +84,60 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: terraform show -no-color tfplan | tee tfplan.txt
 
-      - name: Upload redacted plan artifact
+      - name: Collect plan integrity metadata
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+
+          if [ ! -f .terraform.lock.hcl ]; then
+            echo "::error::.terraform.lock.hcl missing after terraform init."
+            exit 1
+          fi
+
+          terraform state pull > tfstate.snapshot.json
+          PLAN_CREATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          PLAN_CREATED_AT="$PLAN_CREATED_AT" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def sha256_file(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          plan_sha = sha256_file(Path("tfplan"))
+          provider_lock_sha = sha256_file(Path(".terraform.lock.hcl"))
+          Path("tfplan.sha256").write_text(plan_sha + "\n", encoding="utf-8")
+          Path("provider_lock.sha256").write_text(provider_lock_sha + "\n", encoding="utf-8")
+
+          state = json.loads(Path("tfstate.snapshot.json").read_text(encoding="utf-8"))
+          metadata = {
+              "artifact_schema_version": 1,
+              "plan_commit_sha": os.environ["GITHUB_SHA"],
+              "plan_sha256": plan_sha,
+              "provider_lock_sha256": provider_lock_sha,
+              "state_lineage": state.get("lineage"),
+              "state_serial": state.get("serial"),
+              "planned_by": os.environ["GITHUB_ACTOR"],
+              "planned_at": os.environ["PLAN_CREATED_AT"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+          }
+          Path("plan-metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload reviewed production plan artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: prod-tfplan
-          path: infra/tfplan.txt
+          name: prod-reviewed-plan
+          path: |
+            infra/tfplan
+            infra/tfplan.sha256
+            infra/tfplan.txt
+            infra/.terraform.lock.hcl
+            infra/provider_lock.sha256
+            infra/plan-metadata.json
           retention-days: 14
 
   prod-apply:
@@ -119,8 +167,105 @@ jobs:
       - name: Terraform Init
         run: terraform init -input=false
 
-      - name: Terraform Plan (post-approval)
-        run: terraform plan -input=false -out=tfplan
+      - name: Download reviewed production plan artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: prod-reviewed-plan
+          path: infra
 
-      - name: Terraform Apply (post-approval plan)
+      - name: Verify reviewed plan artifact integrity and assumptions
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          from pathlib import Path
+          from subprocess import CalledProcessError, run
+
+          def fail(message: str) -> None:
+              print(f"::error::{message}")
+              sys.exit(1)
+
+          metadata_path = Path("plan-metadata.json")
+          plan_path = Path("tfplan")
+          plan_hash_path = Path("tfplan.sha256")
+
+          if not metadata_path.exists():
+              fail("Missing plan-metadata.json from reviewed plan artifact.")
+          if not plan_path.exists():
+              fail("Missing binary tfplan from reviewed plan artifact.")
+          if not plan_hash_path.exists():
+              fail("Missing tfplan.sha256 from reviewed plan artifact.")
+
+          metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+          if metadata.get("plan_commit_sha") != os.environ.get("GITHUB_SHA"):
+              fail("Source revision changed since plan approval. Re-run plan and approval.")
+
+          lock_path = Path(".terraform.lock.hcl")
+          if not lock_path.exists():
+              fail("Current .terraform.lock.hcl missing after terraform init.")
+          current_lock_hash = hashlib.sha256(lock_path.read_bytes()).hexdigest()
+          if current_lock_hash != metadata.get("provider_lock_sha256"):
+              fail("Provider lock data changed since plan approval. Re-run plan and approval.")
+
+          current_plan_hash = hashlib.sha256(plan_path.read_bytes()).hexdigest()
+          expected_plan_hash = metadata.get("plan_sha256")
+          if current_plan_hash != expected_plan_hash:
+              fail("Downloaded plan hash does not match reviewed plan metadata.")
+
+          declared_plan_hash = plan_hash_path.read_text(encoding="utf-8").strip()
+          if declared_plan_hash != current_plan_hash:
+              fail("Downloaded plan hash file does not match binary plan.")
+
+          try:
+              state_pull = run(
+                  ["terraform", "state", "pull"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+          except CalledProcessError as exc:
+              fail(
+                  "Unable to pull remote state for reviewed-plan verification. "
+                  f"terraform state pull exited with code {exc.returncode}."
+              )
+
+          state = json.loads(state_pull.stdout)
+          if state.get("lineage") != metadata.get("state_lineage"):
+              fail("Remote state lineage changed since plan approval. Re-run plan and approval.")
+          if state.get("serial") != metadata.get("state_serial"):
+              fail("Remote state serial changed since plan approval. Re-run plan and approval.")
+          PY
+
+      - name: Record approval metadata
+        run: |
+          set -euo pipefail
+          APPROVED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          APPROVED_AT="$APPROVED_AT" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          metadata = json.loads(Path("plan-metadata.json").read_text(encoding="utf-8"))
+          metadata["approval"] = {
+              "approved_by": os.environ["GITHUB_ACTOR"],
+              "approved_at": os.environ["APPROVED_AT"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+          }
+          Path("approval-metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload approval metadata artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: prod-reviewed-plan-approval
+          path: infra/approval-metadata.json
+          retention-days: 14
+
+      - name: Terraform Apply (reviewed plan artifact)
         run: terraform apply -input=false tfplan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit P2 supply-chain hygiene (#919)** — added a Docker base-image guard that rejects future Node frontend images unless they pin a full patch tag and `sha256` digest.
 - **Service catalog refresh health verification (#941)** — daily refresh now verifies `/api/health` with the production API key or admin-key fallback, preventing false critical alerts when the refresh succeeds but the public health endpoint requires authentication.
 - **Audit P2 release safety (#889 #890)** — added a rollback runbook for Container Apps revision recovery, ACR image pinning, Static Web Apps rollback, Alembic downgrade caveats, and teardown-command guardrails; CI now smoke-tests the full PostgreSQL plus pgvector Alembic migration cycle.
+- **Terraform production plan artifact integrity** — `.github/workflows/terraform-prod.yml` now uploads a reviewed binary `tfplan` artifact with hash + commit/provider-lock/state metadata and blocks apply when those assumptions drift, so production apply uses exactly the approved plan artifact without re-planning.
 
 #### QA guardrails
 

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "terraform-prod.yml"
+
+
+def _step_by_name(steps: list[dict], name: str) -> dict:
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f'Expected workflow step "{name}"')
+
+
+def test_prod_plan_uploads_binary_plan_and_integrity_metadata():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    plan_steps = workflow["jobs"]["prod-plan"]["steps"]
+
+    collect_step = _step_by_name(plan_steps, "Collect plan integrity metadata")
+    collect_script = collect_step["run"]
+    assert "hashlib.sha256" in collect_script
+    assert 'Path("tfplan.sha256").write_text' in collect_script
+    assert "terraform state pull > tfstate.snapshot.json" in collect_script
+    assert "provider_lock_sha256" in collect_script
+
+    upload_step = _step_by_name(plan_steps, "Upload reviewed production plan artifact")
+    upload_paths = upload_step["with"]["path"]
+    assert "infra/tfplan\n" in upload_paths
+    assert "infra/tfplan.sha256" in upload_paths
+    assert "infra/.terraform.lock.hcl" in upload_paths
+    assert "infra/plan-metadata.json" in upload_paths
+
+
+def test_prod_apply_downloads_and_applies_reviewed_plan_only():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    apply_steps = workflow["jobs"]["prod-apply"]["steps"]
+
+    download_step = _step_by_name(apply_steps, "Download reviewed production plan artifact")
+    assert download_step["uses"] == "actions/download-artifact@v8"
+    assert download_step["with"]["name"] == "prod-reviewed-plan"
+
+    verify_step = _step_by_name(apply_steps, "Verify reviewed plan artifact integrity and assumptions")
+    verify_script = verify_step["run"]
+    assert 'metadata.get("plan_commit_sha") != os.environ.get("GITHUB_SHA")' in verify_script
+    assert 'metadata.get("provider_lock_sha256")' in verify_script
+    assert 'state.get("serial") != metadata.get("state_serial")' in verify_script
+
+    apply_step = _step_by_name(apply_steps, "Terraform Apply (reviewed plan artifact)")
+    assert apply_step["run"] == "terraform apply -input=false tfplan"
+
+    assert all(step.get("name") != "Terraform Plan (post-approval)" for step in apply_steps)

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -14,7 +14,7 @@ def _step_by_name(steps: list[dict], name: str) -> dict:
     raise AssertionError(f'Expected workflow step "{name}"')
 
 
-def test_prod_plan_uploads_binary_plan_and_integrity_metadata():
+def test_prod_plan_encrypts_binary_plan_and_uploads_integrity_metadata():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     plan_steps = workflow["jobs"]["prod-plan"]["steps"]
 
@@ -25,12 +25,28 @@ def test_prod_plan_uploads_binary_plan_and_integrity_metadata():
     assert "terraform state pull > tfstate.snapshot.json" in collect_script
     assert "provider_lock_sha256" in collect_script
 
-    upload_step = _step_by_name(plan_steps, "Upload reviewed production plan artifact")
+    encrypt_step = _step_by_name(plan_steps, "Encrypt reviewed production plan bundle")
+    encrypt_script = encrypt_step["run"]
+    assert "TFPLAN_ARTIFACT_PASSPHRASE" in encrypt_step["env"]
+    assert "tar -czf prod-reviewed-plan.tar.gz" in encrypt_script
+    assert "openssl enc -aes-256-cbc -pbkdf2 -salt" in encrypt_script
+    assert "tfplan" in encrypt_script
+    assert ".terraform.lock.hcl" in encrypt_script
+
+    upload_steps = [
+        step
+        for step in plan_steps
+        if step.get("name") == "Upload reviewed production plan artifact"
+        and step.get("uses") == "actions/upload-artifact@v7"
+    ]
+    assert len(upload_steps) == 1
+    upload_step = upload_steps[0]
     upload_paths = upload_step["with"]["path"]
-    assert "infra/tfplan\n" in upload_paths
-    assert "infra/tfplan.sha256" in upload_paths
-    assert "infra/.terraform.lock.hcl" in upload_paths
-    assert "infra/plan-metadata.json" in upload_paths
+    assert "infra/prod-reviewed-plan.tar.gz.enc" in upload_paths
+    assert "infra/tfplan.txt" in upload_paths
+    assert "infra/tfplan\n" not in upload_paths
+    assert "infra/.terraform.lock.hcl" not in upload_paths
+    assert upload_step["with"]["retention-days"] == 1
 
 
 def test_prod_apply_downloads_and_applies_reviewed_plan_only():
@@ -40,14 +56,33 @@ def test_prod_apply_downloads_and_applies_reviewed_plan_only():
     download_step = _step_by_name(apply_steps, "Download reviewed production plan artifact")
     assert download_step["uses"] == "actions/download-artifact@v8"
     assert download_step["with"]["name"] == "prod-reviewed-plan"
+    assert download_step["with"]["path"] == "infra/reviewed-plan"
+
+    decrypt_step = _step_by_name(apply_steps, "Decrypt reviewed production plan bundle")
+    decrypt_script = decrypt_step["run"]
+    assert "TFPLAN_ARTIFACT_PASSPHRASE" in decrypt_step["env"]
+    assert "openssl enc -d -aes-256-cbc -pbkdf2" in decrypt_script
+    assert "tar -xzf reviewed-plan/prod-reviewed-plan.tar.gz -C reviewed-plan" in decrypt_script
+    assert "cp reviewed-plan/.terraform.lock.hcl .terraform.lock.hcl" in decrypt_script
+
+    decrypt_index = apply_steps.index(decrypt_step)
+    init_index = apply_steps.index(_step_by_name(apply_steps, "Terraform Init"))
+    assert decrypt_index < init_index
 
     verify_step = _step_by_name(apply_steps, "Verify reviewed plan artifact integrity and assumptions")
     verify_script = verify_step["run"]
+    assert 'Path("reviewed-plan/plan-metadata.json")' in verify_script
+    assert 'Path("reviewed-plan/tfplan")' in verify_script
+    assert 'Path(".terraform.lock.hcl")' in verify_script
     assert 'metadata.get("plan_commit_sha") != os.environ.get("GITHUB_SHA")' in verify_script
     assert 'metadata.get("provider_lock_sha256")' in verify_script
     assert 'state.get("serial") != metadata.get("state_serial")' in verify_script
 
     apply_step = _step_by_name(apply_steps, "Terraform Apply (reviewed plan artifact)")
-    assert apply_step["run"] == "terraform apply -input=false tfplan"
+    assert apply_step["run"] == "terraform apply -input=false reviewed-plan/tfplan"
+
+    approval_step = _step_by_name(apply_steps, "Record approval metadata")
+    assert '"workflow_actor": os.environ["GITHUB_ACTOR"]' in approval_step["run"]
+    assert "approved_by" not in approval_step["run"]
 
     assert all(step.get("name") != "Terraform Plan (post-approval)" for step in apply_steps)


### PR DESCRIPTION
## Summary
- replaces stale draft #990 on a clean branch from current `main`
- binds production Terraform apply to the reviewed binary plan artifact instead of re-planning after approval
- records and verifies plan hash, source revision, provider lock hash, and remote state identity before apply
- downloads reviewed artifacts into `infra/reviewed-plan` so the current checked-out `.terraform.lock.hcl` remains the value being verified
- adds workflow contract tests for the reviewed-plan handoff and no post-approval re-plan path

## Validation
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_terraform_prod_workflow.py`

## Notes
- Supersedes #990, whose branch no longer has a merge-base with current `main`.