### PR TITLE
fix: use API key for service catalog refresh

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -16,7 +16,8 @@ These secrets are required in `.github/workflows/ci.yml`:
 | `ACR_LOGIN_SERVER` | ACR login server URL | `myacrname.azurecr.io` |
 | `CONTAINER_APP_NAME` | Azure Container Apps name | `archmorph-api` |
 | `CONTAINER_APP_ENV` | Container Apps Environment name | `archmorph-cae-dev` |
-| `ADMIN_KEY` | Backend admin/API key used by deploy smoke to authenticate service catalog refresh | (strong random secret) |
+| `ARCHMORPH_API_KEY` | Backend API key used by authenticated API health checks and service catalog refresh triggers | (strong random secret) |
+| `ADMIN_KEY` | Backend admin key mapped to `ARCHMORPH_ADMIN_KEY` for admin-only operations and sessions | (strong random secret) |
 | `JWT_SECRET` | Recommended dedicated backend JWT signing secret for production user/session tokens. If omitted, deploy falls back to `ADMIN_KEY`; a distinct strong random value is strongly recommended. | (strong random secret) |
 | `SWA_NAME` | Static Web App name | `archmorph-frontend` |
 | `API_URL` | Backend API URL (with `/api` suffix) | `https://your-app.azurecontainerapps.io/api` |
@@ -95,7 +96,7 @@ az staticwebapp secrets list --name YOUR_SWA_NAME --query properties.apiKey -o t
 - Rotate secrets periodically
 - Use production GitHub environment secrets; Archmorph does not maintain a separate staging environment
 - Production Azure federated credentials should trust the GitHub Environment subject `repo:idokatz86/Archmorph:environment:production`.
-- Backend Container Apps deployments require `ARCHMORPH_API_KEY` and `ARCHMORPH_ADMIN_KEY` to reference the `ADMIN_KEY` secret in the deployed revision.
+- Backend Container Apps deployments require `ARCHMORPH_API_KEY` to reference the API key secret and `ARCHMORPH_ADMIN_KEY` to reference the admin-key secret in the deployed revision.
 - Backend Container Apps deployments require `JWT_SECRET` in production/staging. The workflow maps repository secret `JWT_SECRET` into a Container App secret named `jwt-secret`; if the repository secret is absent, it uses `ADMIN_KEY` as a compatibility fallback.
 - The `archmorphmetrics` storage account must keep shared-key access disabled; backend storage access is expected to use `AZURE_STORAGE_ACCOUNT_URL` plus the Container App system-assigned managed identity with `Storage Blob Data Contributor`.
 - `AZURE_CLIENT_ID` is for GitHub Actions OIDC. Do not set it in the backend Container App to select storage identity; use `AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID` only when a user-assigned storage identity is intentionally attached.

--- a/.github/workflows/service-catalog-refresh.yml
+++ b/.github/workflows/service-catalog-refresh.yml
@@ -46,12 +46,10 @@ jobs:
     steps:
       - name: Trigger refresh
         id: refresh
-        env:
-          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${API_URL:-}" ] || [ -z "${ADMIN_KEY:-}" ]; then
-            echo "::error::API_URL or ADMIN_KEY secret missing"
+          if [ -z "${API_URL:-}" ] || [ -z "${ARCHMORPH_API_KEY:-}" ]; then
+            echo "::error::API_URL or ARCHMORPH_API_KEY secret missing"
             exit 1
           fi
 
@@ -68,7 +66,7 @@ jobs:
             HTTP_CODE=$(curl -sS -o response.json -w "%{http_code}" \
               --max-time 600 \
               -X POST "${BASE}/api/service-updates/run-now" \
-              -H "X-API-Key: ${ADMIN_KEY}" \
+              -H "X-API-Key: ${ARCHMORPH_API_KEY}" \
               -H "Content-Type: application/json" \
               -d '{}' || echo "000")
 
@@ -112,23 +110,22 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify freshness via /api/health
-        env:
-          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
         run: |
           set -euo pipefail
           BASE="${API_URL%/}"
           BASE="${BASE%/api}"
-          # Pass API key when configured — /api/health requires auth in production (#844).
-          HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"
+          # /api/health requires API-key auth in production (#844).
           _CURL_ARGS=(-sS --max-time 30)
-          if [ -n "${HEALTH_API_KEY}" ]; then
-            _CURL_ARGS+=(-H "X-API-Key: ${HEALTH_API_KEY}")
+          if [ -z "${ARCHMORPH_API_KEY:-}" ]; then
+            echo "::error::ARCHMORPH_API_KEY secret missing; cannot verify authenticated /api/health"
+            exit 1
           fi
+          _CURL_ARGS+=(-H "X-API-Key: ${ARCHMORPH_API_KEY}")
           HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}" "${BASE}/api/health" || echo "000")
           if [ "$HTTP_CODE" != "200" ]; then
             ERROR_CODE=$(jq -r '.error.code // empty' health.json 2>/dev/null || true)
             if [ -n "$ERROR_CODE" ]; then
-              echo "::error::/api/health returned HTTP ${HTTP_CODE} (${ERROR_CODE}); check ARCHMORPH_API_KEY/ADMIN_KEY secrets"
+              echo "::error::/api/health returned HTTP ${HTTP_CODE} (${ERROR_CODE}); check ARCHMORPH_API_KEY secret"
             else
               echo "::error::/api/health returned HTTP ${HTTP_CODE}; cannot verify refresh freshness"
             fi
@@ -170,9 +167,9 @@ jobs:
               '',
               '### Triage',
               '1. Check the workflow logs above for the failed HTTP code.',
-              '2. Hit `GET /api/health` and inspect `service_catalog_refresh`.',
-              '3. If the API is healthy, re-run the workflow with `workflow_dispatch`.',
-              '4. If the API is unreachable, this is a production outage — treat as P1.',
+              '2. Hit authenticated `GET /api/health` with `X-API-Key: ARCHMORPH_API_KEY` and inspect `service_catalog_refresh`.',
+              '3. If the API is healthy and the API key is valid, re-run the workflow with `workflow_dispatch`.',
+              '4. If the API is unreachable or the production API key is rejected, treat as P1.',
               '',
               '_Filed automatically by `.github/workflows/service-catalog-refresh.yml`._',
             ].join('\n');

--- a/backend/tests/test_service_catalog_refresh_workflow.py
+++ b/backend/tests/test_service_catalog_refresh_workflow.py
@@ -7,8 +7,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "service-catalog-refresh.yml"
 
 
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
 def _verify_freshness_step() -> dict:
-    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    workflow = _workflow()
     steps = workflow["jobs"]["refresh"]["steps"]
     for step in steps:
         if step.get("name") == "Verify freshness via /api/health":
@@ -16,21 +20,45 @@ def _verify_freshness_step() -> dict:
     raise AssertionError('Expected workflow step "Verify freshness via /api/health"')
 
 
-def test_verify_freshness_receives_admin_key_secret():
+def _trigger_refresh_step() -> dict:
+    workflow = _workflow()
+    steps = workflow["jobs"]["refresh"]["steps"]
+    for step in steps:
+        if step.get("name") == "Trigger refresh":
+            return step
+    raise AssertionError('Expected workflow step "Trigger refresh"')
+
+
+def test_workflow_wires_api_key_secret():
+    workflow = _workflow()
+
+    assert workflow["env"]["ARCHMORPH_API_KEY"] == "${{ secrets.ARCHMORPH_API_KEY }}"
+
+
+def test_trigger_refresh_uses_api_key_secret_for_api_auth():
+    run_script = _trigger_refresh_step()["run"]
+
+    assert "API_URL or ARCHMORPH_API_KEY secret missing" in run_script
+    assert 'X-API-Key: ${ARCHMORPH_API_KEY}' in run_script
+    assert 'X-API-Key: ${ADMIN_KEY}' not in run_script
+
+
+def test_verify_freshness_does_not_receive_admin_key_secret():
     step = _verify_freshness_step()
 
-    assert step["env"]["ADMIN_KEY"] == "${{ secrets.ADMIN_KEY }}"
+    assert "ADMIN_KEY" not in step.get("env", {})
 
 
-def test_verify_freshness_falls_back_to_admin_key_for_health_auth():
+def test_verify_freshness_uses_api_key_for_health_auth():
     run_script = _verify_freshness_step()["run"]
 
-    assert 'HEALTH_API_KEY="${ARCHMORPH_API_KEY:-${ADMIN_KEY:-}}"' in run_script
-    assert 'X-API-Key: ${HEALTH_API_KEY}' in run_script
+    assert "ARCHMORPH_API_KEY secret missing" in run_script
+    assert 'X-API-Key: ${ARCHMORPH_API_KEY}' in run_script
+    assert "ADMIN_KEY" not in run_script
 
 
 def test_verify_freshness_reports_health_http_status():
     run_script = _verify_freshness_step()["run"]
 
     assert 'HTTP_CODE=$(curl "${_CURL_ARGS[@]}" -o health.json -w "%{http_code}"' in run_script
-    assert "check ARCHMORPH_API_KEY/ADMIN_KEY secrets" in run_script
+    assert "check ARCHMORPH_API_KEY secret" in run_script

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -26,6 +26,7 @@ Core deployment secrets:
 - `ACR_LOGIN_SERVER`
 - `CONTAINER_APP_NAME`
 - `CONTAINER_APP_ENV`
+- `ARCHMORPH_API_KEY`
 - `ADMIN_KEY`
 
 Application secrets:
@@ -83,7 +84,7 @@ After deployment, verify:
 - `/#translator` opens the translator workflow.
 - `/#playground` opens the sample playground.
 - `${API_URL}/health` passes `scripts/health_gate.sh`: status must be `healthy`, scheduled jobs must be fresh, and Redis must report either `ok` or `disabled_optional`. `missing_required` is release-blocking.
-- The green backend revision must successfully run `/api/service-updates/storage-preflight` and `/api/service-updates/run-now` with `X-API-Key: ADMIN_KEY` before traffic shift; this validates `ARCHMORPH_API_KEY`, `AZURE_STORAGE_ACCOUNT_URL`, and the managed-identity Blob Storage read/write/list path.
+- The green backend revision must successfully run `/api/service-updates/storage-preflight` and `/api/service-updates/run-now` with `X-API-Key: ARCHMORPH_API_KEY` before traffic shift; this validates API authentication, `AZURE_STORAGE_ACCOUNT_URL`, and the managed-identity Blob Storage read/write/list path.
 - `${API_ROOT}/openapi.json` loads and reports `Archmorph API`.
 - Run the [Production Architecture Package Smoke](PRODUCTION_SMOKE_ARCHITECTURE_PACKAGE.md) workflow with `strict_freshness=true`; retain the summary and artifact bundle for release evidence.
 - Confirm each changed generated artifact has an owner, validation command or explicit gap note, fixture, release evidence location, and gap tracking entry in the [Generated Artifact Validation Matrix](GENERATED_ARTIFACT_VALIDATION_MATRIX.md).


### PR DESCRIPTION
## Summary
- fixes the daily service catalog refresh workflow to send `ARCHMORPH_API_KEY` to API-key-protected endpoints instead of `ADMIN_KEY`
- updates the post-refresh health verification and generated alert triage text for authenticated `/api/health`
- updates workflow tests and release/secrets docs to reflect separated API and admin keys

## Root cause
Issue #1046 shows the scheduled refresh failed three times with HTTP 401 from `/api/service-updates/run-now`. That route depends on `verify_api_key`, which validates `ARCHMORPH_API_KEY`; the workflow was sending `secrets.ADMIN_KEY` as `X-API-Key` after deploys began mapping API and admin keys separately.

## Validation
- `cd backend && /Users/idokatz/VSCode/.venv/bin/python -m pytest tests/test_service_catalog_refresh_workflow.py tests/test_release_safety_workflows.py -q`
- workflow YAML parse smoke for `.github/workflows/service-catalog-refresh.yml`
- `git diff --check`

Addresses #1046.