### PR TITLE
fix(ci): rebuild Trivy scan images without cache

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -121,8 +121,8 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           load: true
           tags: ${{ matrix.image.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          pull: true
+          no-cache: true
 
       - name: Container healthcheck smoke (${{ matrix.image.name }})
         run: |

--- a/backend/tests/test_security_workflow_container_scans.py
+++ b/backend/tests/test_security_workflow_container_scans.py
@@ -36,6 +36,19 @@ def test_security_workflow_uses_distinct_sarif_category_per_runtime_image():
     assert upload_step["with"]["category"] == "trivy-container-${{ matrix.image.name }}"
 
 
+def test_security_workflow_builds_scan_images_without_layer_cache():
+    workflow = _load()
+    build_step = _step_by_name(
+        workflow["jobs"]["trivy-container"]["steps"],
+        "Build ${{ matrix.image.name }} image for scanning",
+    )
+
+    assert build_step["with"]["pull"] is True
+    assert build_step["with"]["no-cache"] is True
+    assert "cache-from" not in build_step["with"]
+    assert "cache-to" not in build_step["with"]
+
+
 def test_security_workflow_keeps_required_trivy_status_context():
     workflow = _load()
     required_job = workflow["jobs"]["trivy-container-required"]


### PR DESCRIPTION
## Description

Closes #1063.

The backend Trivy scan was failing on fixed Debian package CVEs even though the backend Dockerfile runs OS package upgrades. The scan workflow was reusing Docker layer cache, so the `apt-get upgrade` layer could stay stale across security database updates.

This PR makes the security scan image build fresh by enabling `pull: true` and `no-cache: true` for the Trivy matrix build, and removes the GHA layer cache from that scan-only path.

## Testing

- `/Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest tests/test_security_workflow_container_scans.py -q` -> `4 passed`
