### PR TITLE
ci: identify Terraform production OIDC principal

### DIFF
--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -65,6 +65,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Diagnose Azure OIDC principal
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          SIGNED_IN_APP_ID=$(az account show --query user.name -o tsv)
+          az ad sp show \
+            --id "${SIGNED_IN_APP_ID}" \
+            --query '{displayName:displayName, objectId:id, servicePrincipalType:servicePrincipalType}' \
+            -o json
+
       - name: "Preflight: verify remote-state Blob data-plane RBAC"
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -68,13 +68,17 @@ jobs:
       - name: Diagnose Azure OIDC principal
         if: github.event_name == 'workflow_dispatch'
         run: |
-          set -euo pipefail
-          SIGNED_IN_APP_ID=$(az account show --query user.name -o tsv)
+          set -uo pipefail
+          SIGNED_IN_APP_ID=$(az account show --query user.name -o tsv 2>/dev/null || true)
+          if [ -z "${SIGNED_IN_APP_ID}" ]; then
+            echo "::notice::Unable to resolve signed-in Azure service principal app id for diagnostics. Continuing to remote-state preflight."
+            exit 0
+          fi
           az ad sp show \
             --id "${SIGNED_IN_APP_ID}" \
             --query '{displayName:displayName, objectId:id, servicePrincipalType:servicePrincipalType}' \
-            -o json
-
+            -o json \
+            || echo "::notice::Unable to resolve signed-in Azure service principal directory object. Continuing to remote-state preflight."
       - name: "Preflight: verify remote-state Blob data-plane RBAC"
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -68,6 +68,25 @@ def test_prod_plan_preflights_remote_state_blob_rbac_before_init():
     assert preflight_index < init_index
 
 
+def test_prod_plan_diagnoses_oidc_principal_without_blocking_init():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    plan_steps = workflow["jobs"]["prod-plan"]["steps"]
+
+    diagnostic_step = _step_by_name(plan_steps, "Diagnose Azure OIDC principal")
+    diagnostic_script = diagnostic_step["run"]
+    assert "az account show --query user.name" in diagnostic_script
+    assert "az ad sp show" in diagnostic_script
+    assert "objectId:id" in diagnostic_script
+    assert "AZURE_CLIENT_ID" not in diagnostic_script
+    assert "|| true" in diagnostic_script
+
+    login_index = plan_steps.index(_step_by_name(plan_steps, "Azure Login (OIDC)"))
+    diagnostic_index = plan_steps.index(diagnostic_step)
+    preflight_index = plan_steps.index(_step_by_name(plan_steps, "Preflight: verify remote-state Blob data-plane RBAC"))
+    init_index = plan_steps.index(_step_by_name(plan_steps, "Terraform Init"))
+    assert login_index < diagnostic_index < preflight_index < init_index
+
+
 def test_prod_apply_downloads_and_applies_reviewed_plan_only():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     apply_steps = workflow["jobs"]["prod-apply"]["steps"]


### PR DESCRIPTION
Adds a non-secret diagnostic step after Azure OIDC login in the Terraform Production workflow. It prints only the signed-in service principal display name and object ID so tfstate RBAC failures can be remediated precisely without exposing AZURE_CLIENT_ID.\n\nTesting: /Users/idokatz/VSCode/Archmorph/backend/.venv/bin/python -m pytest backend/tests/test_terraform_prod_workflow.py -q