### PR TITLE
fix(ci): run Terraform Production with prod environment

### DIFF
--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -25,6 +25,7 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   TF_WORKING_DIR: infra
   TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  TF_VAR_environment: prod
   TF_VAR_db_admin_username: ${{ secrets.DB_ADMIN_USERNAME }}
   TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}
   TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -94,6 +94,13 @@ def test_prod_workflow_supplies_legacy_openai_secret_variable():
     assert env["TF_VAR_openai_api_key"] == "${{ secrets.AZURE_OPENAI_API_KEY }}"
 
 
+def test_prod_workflow_sets_terraform_environment_to_prod():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    env = workflow["env"]
+
+    assert env["TF_VAR_environment"] == "prod"
+
+
 def test_prod_apply_downloads_and_applies_reviewed_plan_only():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     apply_steps = workflow["jobs"]["prod-apply"]["steps"]


### PR DESCRIPTION
## Summary\n- set TF_VAR_environment=prod in the Terraform Production workflow\n- add workflow contract coverage so production plans cannot silently fall back to the dev default\n\n## Validation\n- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_terraform_prod_workflow.py -q\n- terraform -chdir=infra fmt -check\n- terraform -chdir=infra init -backend=false -input=false\n- terraform -chdir=infra validate -no-color\n\n## Context\nThe plan-only production run after #1066 failed because Terraform was still using the variable default environment=dev. That caused the production-scoped OpenAI secret resource to be counted out and protected by prevent_destroy, which correctly blocked the plan. This PR makes the production workflow explicit.