### PR TITLE
fix(ci): target live Terraform stack safely

### DIFF
--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -26,10 +26,15 @@ env:
   TF_WORKING_DIR: infra
   TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   TF_VAR_environment: prod
+  # The public production deployment currently lives in a legacy dev-named Azure stack.
+  # Keep resource names aligned with state until a reviewed prod RG migration exists.
+  TF_VAR_resource_group_environment: dev
+  TF_VAR_enable_production_infra_hardening: false
   TF_VAR_db_admin_username: ${{ secrets.DB_ADMIN_USERNAME }}
   TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}
   TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
   TF_VAR_frontend_url: ${{ secrets.FRONTEND_URL }}
+  TF_VAR_preserve_legacy_openai_key: true
   TF_VAR_openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY }}
 
 jobs:
@@ -139,6 +144,52 @@ jobs:
       - name: Terraform Init
         if: github.event_name == 'workflow_dispatch'
         run: terraform init -input=false -lockfile=readonly
+
+      - name: "Preflight: verify Terraform state stack contract"
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          STACK_ENVIRONMENT="${TF_VAR_resource_group_environment:-${TF_VAR_environment}}"
+          EXPECTED_RESOURCE_GROUP="archmorph-rg-${STACK_ENVIRONMENT}"
+
+          if [ "$(az group exists --name "${EXPECTED_RESOURCE_GROUP}" -o tsv)" != "true" ]; then
+            echo "::error::Expected Terraform target resource group ${EXPECTED_RESOURCE_GROUP} does not exist. Refusing to plan."
+            exit 1
+          fi
+
+          STATE_SNAPSHOT="$(mktemp)"
+          terraform state pull > "${STATE_SNAPSHOT}"
+          EXPECTED_RESOURCE_GROUP="${EXPECTED_RESOURCE_GROUP}" STATE_SNAPSHOT="${STATE_SNAPSHOT}" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          state = json.loads(Path(os.environ["STATE_SNAPSHOT"]).read_text(encoding="utf-8"))
+          expected_resource_group = os.environ["EXPECTED_RESOURCE_GROUP"]
+
+          managed_resources = state.get("resources", [])
+          resource_group = next(
+              (
+                  instance.get("attributes", {}).get("name")
+                  for resource in managed_resources
+                  if resource.get("type") == "azurerm_resource_group" and resource.get("name") == "main"
+                  for instance in resource.get("instances", [])
+              ),
+              None,
+          )
+
+          if resource_group is None:
+              raise SystemExit("::error::Terraform state does not contain azurerm_resource_group.main. Refusing to plan.")
+
+          if resource_group != expected_resource_group:
+              raise SystemExit(
+                  f"::error::Terraform state targets {resource_group}, but workflow stack settings "
+                  f"expects {expected_resource_group}. Refusing to plan because this would replace the stack."
+              )
+
+          print(f"Terraform state stack preflight succeeded for {resource_group}.")
+          PY
+          rm -f "${STATE_SNAPSHOT}"
 
       - name: Terraform Plan (production)
         if: github.event_name == 'workflow_dispatch'

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -68,6 +68,25 @@ def test_prod_plan_preflights_remote_state_blob_rbac_before_init():
     assert preflight_index < init_index
 
 
+def test_prod_plan_preflights_state_stack_contract_before_plan():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    plan_steps = workflow["jobs"]["prod-plan"]["steps"]
+
+    stack_preflight_step = _step_by_name(plan_steps, "Preflight: verify Terraform state stack contract")
+    stack_preflight_script = stack_preflight_step["run"]
+    assert "STACK_ENVIRONMENT=\"${TF_VAR_resource_group_environment:-${TF_VAR_environment}}\"" in stack_preflight_script
+    assert "EXPECTED_RESOURCE_GROUP=\"archmorph-rg-${STACK_ENVIRONMENT}\"" in stack_preflight_script
+    assert "az group exists" in stack_preflight_script
+    assert "terraform state pull" in stack_preflight_script
+    assert "azurerm_resource_group" in stack_preflight_script
+    assert "Refusing to plan because this would replace the stack" in stack_preflight_script
+
+    init_index = plan_steps.index(_step_by_name(plan_steps, "Terraform Init"))
+    stack_preflight_index = plan_steps.index(stack_preflight_step)
+    plan_index = plan_steps.index(_step_by_name(plan_steps, "Terraform Plan (production)"))
+    assert init_index < stack_preflight_index < plan_index
+
+
 def test_prod_plan_diagnoses_oidc_principal_without_blocking_init():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     plan_steps = workflow["jobs"]["prod-plan"]["steps"]
@@ -91,14 +110,17 @@ def test_prod_workflow_supplies_legacy_openai_secret_variable():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     env = workflow["env"]
 
+    assert env["TF_VAR_preserve_legacy_openai_key"] is True
     assert env["TF_VAR_openai_api_key"] == "${{ secrets.AZURE_OPENAI_API_KEY }}"
 
 
-def test_prod_workflow_sets_terraform_environment_to_prod():
+def test_prod_workflow_uses_prod_runtime_with_legacy_live_stack_names():
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     env = workflow["env"]
 
     assert env["TF_VAR_environment"] == "prod"
+    assert env["TF_VAR_resource_group_environment"] == "dev"
+    assert env["TF_VAR_enable_production_infra_hardening"] is False
 
 
 def test_prod_apply_downloads_and_applies_reviewed_plan_only():

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -56,7 +56,9 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  name_suffix = random_string.suffix.result
+  name_suffix                        = random_string.suffix.result
+  stack_environment                  = coalesce(var.resource_group_environment, var.environment)
+  production_infra_hardening_enabled = var.environment == "prod" && var.enable_production_infra_hardening
   paired_region_defaults = {
     westeurope    = "northeurope"
     northeurope   = "westeurope"
@@ -81,7 +83,7 @@ locals {
 # Resource Group
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_resource_group" "main" {
-  name     = "archmorph-rg-${var.environment}"
+  name     = "archmorph-rg-${local.stack_environment}"
   location = var.location
   tags     = local.tags
 }
@@ -262,7 +264,7 @@ resource "azurerm_log_analytics_workspace" "main" {
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   sku                 = "PerGB2018"
-  retention_in_days   = var.environment == "prod" ? 90 : 30 # 90 days for compliance (#105 — I-011)
+  retention_in_days   = local.production_infra_hardening_enabled ? 90 : 30 # 90 days for compliance (#105 — I-011)
   tags                = local.tags
 }
 
@@ -274,11 +276,11 @@ resource "azurerm_storage_account" "main" {
   resource_group_name               = azurerm_resource_group.main.name
   location                          = azurerm_resource_group.main.location
   account_tier                      = "Standard"
-  account_replication_type          = var.environment == "prod" ? "GRS" : "LRS" # Geo-redundant in prod (#105 — I-012)
+  account_replication_type          = local.production_infra_hardening_enabled ? "GRS" : "LRS" # Geo-redundant in prod (#105 — I-012)
   min_tls_version                   = "TLS1_2"
   shared_access_key_enabled         = false # Use RBAC instead of shared keys
   allow_nested_items_to_be_public   = false
-  public_network_access_enabled     = var.environment == "prod" ? false : true # Private endpoint / VNet service endpoint in prod
+  public_network_access_enabled     = local.production_infra_hardening_enabled ? false : true # Private endpoint / VNet service endpoint in prod
   https_traffic_only_enabled        = true
   infrastructure_encryption_enabled = true # Double encryption at rest
 
@@ -306,16 +308,16 @@ resource "azurerm_storage_account" "main" {
   # In prod: deny-by-default with VNet service endpoint path from Container Apps subnet.
   # A private endpoint is also required (enable_storage_private_endpoint must be true).
   network_rules {
-    default_action             = var.environment == "prod" ? "Deny" : "Allow"
+    default_action             = local.production_infra_hardening_enabled ? "Deny" : "Allow"
     bypass                     = ["AzureServices"]
     ip_rules                   = []
-    virtual_network_subnet_ids = var.environment == "prod" ? [azurerm_subnet.container_apps.id] : []
+    virtual_network_subnet_ids = local.production_infra_hardening_enabled ? [azurerm_subnet.container_apps.id] : []
   }
 
   lifecycle {
     prevent_destroy = true
     precondition {
-      condition     = !(var.environment == "prod" && !var.enable_storage_private_endpoint)
+      condition     = !(local.production_infra_hardening_enabled && !var.enable_storage_private_endpoint)
       error_message = "Production Storage uses a deny-by-default firewall but enable_storage_private_endpoint is false. Set enable_storage_private_endpoint = true to guarantee private endpoint connectivity from the Container Apps runtime."
     }
   }
@@ -361,15 +363,15 @@ resource "azurerm_container_registry" "main" {
   name                          = "archmorph${local.name_suffix}"
   resource_group_name           = azurerm_resource_group.main.name
   location                      = azurerm_resource_group.main.location
-  sku                           = var.environment == "prod" ? var.acr_prod_sku : "Basic"
-  admin_enabled                 = false                                    # Use managed identity — never admin credentials (#98 — I-002)
-  public_network_access_enabled = var.environment == "prod" ? false : true # Disable public access in prod (#289)
-  zone_redundancy_enabled       = var.environment == "prod"
+  sku                           = local.production_infra_hardening_enabled ? var.acr_prod_sku : "Basic"
+  admin_enabled                 = false                                                   # Use managed identity — never admin credentials (#98 — I-002)
+  public_network_access_enabled = local.production_infra_hardening_enabled ? false : true # Disable public access in prod (#289)
+  zone_redundancy_enabled       = local.production_infra_hardening_enabled
   anonymous_pull_enabled        = false
-  data_endpoint_enabled         = var.environment == "prod"
+  data_endpoint_enabled         = local.production_infra_hardening_enabled
 
   # Enable content trust in production
-  trust_policy_enabled = var.environment == "prod"
+  trust_policy_enabled = local.production_infra_hardening_enabled
 
   tags = local.tags
 }
@@ -385,15 +387,15 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_login           = var.db_admin_username
   administrator_password        = var.db_admin_password
   storage_mb                    = 32768
-  sku_name                      = var.environment == "prod" ? "GP_Standard_D2s_v3" : "B_Standard_B1ms"
+  sku_name                      = local.production_infra_hardening_enabled ? "GP_Standard_D2s_v3" : "B_Standard_B1ms"
   zone                          = "1"
-  backup_retention_days         = var.environment == "prod" ? 35 : 7
-  geo_redundant_backup_enabled  = var.environment == "prod"
+  backup_retention_days         = local.production_infra_hardening_enabled ? 35 : 7
+  geo_redundant_backup_enabled  = local.production_infra_hardening_enabled
   public_network_access_enabled = false
 
   authentication {
     password_auth_enabled         = true
-    active_directory_auth_enabled = var.environment == "prod" # Enable AAD auth in prod
+    active_directory_auth_enabled = local.production_infra_hardening_enabled # Enable AAD auth in prod
   }
 
   # Require SSL/TLS for all connections
@@ -429,11 +431,11 @@ resource "azurerm_redis_cache" "main" {
   resource_group_name           = azurerm_resource_group.main.name
   location                      = azurerm_resource_group.main.location
   capacity                      = var.redis_capacity
-  family                        = var.environment == "prod" ? "C" : "C"
-  sku_name                      = var.environment == "prod" ? "Standard" : "Basic"
+  family                        = local.production_infra_hardening_enabled ? "C" : "C"
+  sku_name                      = local.production_infra_hardening_enabled ? "Standard" : "Basic"
   non_ssl_port_enabled          = false # TLS-only (port 6380)
   minimum_tls_version           = "1.2"
-  public_network_access_enabled = var.environment == "prod" ? false : true
+  public_network_access_enabled = local.production_infra_hardening_enabled ? false : true
   # access_key_authentication_disabled = false # Required for REDIS_URL access key auth (#320)
 
   redis_configuration {
@@ -450,7 +452,7 @@ resource "azurerm_redis_cache" "main" {
 
   lifecycle {
     precondition {
-      condition     = !(var.environment == "prod" && !var.enable_redis_private_endpoint)
+      condition     = !(local.production_infra_hardening_enabled && !var.enable_redis_private_endpoint)
       error_message = "Production Redis disables public network access but enable_redis_private_endpoint is false. Set enable_redis_private_endpoint = true to guarantee private endpoint connectivity from the Container Apps runtime."
     }
   }
@@ -467,14 +469,14 @@ resource "azurerm_key_vault" "main" {
   location                   = azurerm_resource_group.main.location
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_retention_days = var.environment == "prod" ? 90 : 7
-  purge_protection_enabled   = var.environment == "prod" # Enable in production
-  rbac_authorization_enabled = var.environment == "prod" # Use RBAC in production
+  soft_delete_retention_days = local.production_infra_hardening_enabled ? 90 : 7
+  purge_protection_enabled   = local.production_infra_hardening_enabled # Enable in production
+  rbac_authorization_enabled = local.production_infra_hardening_enabled # Use RBAC in production
 
   # Network ACLs - restrict in production
   network_acls {
     bypass                     = "AzureServices"
-    default_action             = var.environment == "prod" ? "Deny" : "Allow"
+    default_action             = local.production_infra_hardening_enabled ? "Deny" : "Allow"
     ip_rules                   = []
     virtual_network_subnet_ids = []
   }
@@ -518,11 +520,11 @@ resource "azurerm_key_vault_secret" "appinsights_connection" {
 
 moved {
   from = azurerm_key_vault_secret.openai_key
-  to   = azurerm_key_vault_secret.openai_key["prod"]
+  to   = azurerm_key_vault_secret.openai_key["legacy"]
 }
 
 resource "azurerm_key_vault_secret" "openai_key" {
-  for_each = var.environment == "prod" ? toset(["prod"]) : toset([])
+  for_each = var.preserve_legacy_openai_key ? toset(["legacy"]) : toset([])
 
   name         = "openai-api-key"
   value        = var.openai_api_key
@@ -586,7 +588,7 @@ resource "azurerm_cognitive_deployment" "gpt4_vision" {
 # Container Apps Environment
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_container_app_environment" "main" {
-  name                       = "archmorph-cae-${var.environment}"
+  name                       = "archmorph-cae-${local.stack_environment}"
   resource_group_name        = azurerm_resource_group.main.name
   location                   = var.location # West Europe (same as other resources)
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
@@ -672,14 +674,14 @@ resource "azurerm_container_app" "backend" {
 
   template {
     min_replicas = 1
-    max_replicas = var.environment == "prod" ? var.prod_max_replicas : 3
+    max_replicas = local.production_infra_hardening_enabled ? var.prod_max_replicas : 3
 
     # ── Scaling rules (#180) ──
     # HTTP concurrency: GPT vision calls block ~5-30s each, so keep
     # concurrent_requests low to trigger scale-out before thread exhaustion.
     http_scale_rule {
       name                = "http-concurrency"
-      concurrent_requests = var.environment == "prod" ? tostring(var.prod_http_concurrent_requests) : "15"
+      concurrent_requests = local.production_infra_hardening_enabled ? tostring(var.prod_http_concurrent_requests) : "15"
     }
 
     # CPU-based scaling: scale out when sustained CPU > 70%
@@ -695,8 +697,8 @@ resource "azurerm_container_app" "backend" {
     container {
       name   = "api"
       image  = local.backend_image
-      cpu    = var.environment == "prod" ? 1.0 : 0.5
-      memory = var.environment == "prod" ? "2Gi" : "1Gi"
+      cpu    = local.production_infra_hardening_enabled ? 1.0 : 0.5
+      memory = local.production_infra_hardening_enabled ? "2Gi" : "1Gi"
 
       env {
         name        = "DATABASE_URL"
@@ -770,12 +772,12 @@ resource "azurerm_container_app" "backend" {
 
       env {
         name  = "OTEL_TRACES_SAMPLER"
-        value = var.environment == "prod" ? "traceidratio" : "always_on"
+        value = local.production_infra_hardening_enabled ? "traceidratio" : "always_on"
       }
 
       env {
         name  = "OTEL_TRACES_SAMPLER_ARG"
-        value = var.environment == "prod" ? tostring(var.app_insights_sampling_percentage_prod / 100) : "1.0"
+        value = local.production_infra_hardening_enabled ? tostring(var.app_insights_sampling_percentage_prod / 100) : "1.0"
       }
 
       env {
@@ -824,8 +826,8 @@ resource "azurerm_static_web_app" "frontend" {
   name                = "archmorph-frontend"
   resource_group_name = azurerm_resource_group.main.name
   location            = "westeurope"
-  sku_tier            = var.environment == "prod" ? "Standard" : "Free"
-  sku_size            = var.environment == "prod" ? "Standard" : "Free"
+  sku_tier            = local.production_infra_hardening_enabled ? "Standard" : "Free"
+  sku_size            = local.production_infra_hardening_enabled ? "Standard" : "Free"
   tags                = local.tags
 }
 
@@ -988,8 +990,8 @@ resource "azurerm_application_insights" "main" {
   location            = azurerm_resource_group.main.location
   workspace_id        = azurerm_log_analytics_workspace.main.id
   application_type    = "web"
-  retention_in_days   = var.environment == "prod" ? 90 : 30 # 90 days in prod for compliance (#105 — I-011)
-  sampling_percentage = var.environment == "prod" ? var.app_insights_sampling_percentage_prod : 100
+  retention_in_days   = local.production_infra_hardening_enabled ? 90 : 30 # 90 days in prod for compliance (#105 — I-011)
+  sampling_percentage = local.production_infra_hardening_enabled ? var.app_insights_sampling_percentage_prod : 100
 
   # Enable distributed tracing
   disable_ip_masking = false # GDPR compliance
@@ -2288,51 +2290,51 @@ resource "azurerm_application_insights_workbook" "dashboard" {
 # ─────────────────────────────────────────────────────────────
 # Uncomment to enable Defender for key resources in production
 resource "azurerm_security_center_subscription_pricing" "storage" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "StorageAccounts"
 }
 
 resource "azurerm_security_center_subscription_pricing" "keyvault" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "KeyVaults"
 }
 
 resource "azurerm_security_center_subscription_pricing" "containers" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "Containers"
 }
 
 resource "azurerm_security_center_subscription_pricing" "container_registry" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "ContainerRegistry"
 }
 
 resource "azurerm_security_center_subscription_pricing" "databases" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "OpenSourceRelationalDatabases"
 }
 
 resource "azurerm_security_center_subscription_pricing" "app_service" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "AppServices"
 }
 
 # Defender for Azure Resource Manager — detects suspicious management operations (#289)
 resource "azurerm_security_center_subscription_pricing" "arm" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "Arm"
 }
 
 # Defender for DNS — detects malicious DNS queries (#289)
 resource "azurerm_security_center_subscription_pricing" "dns" {
-  count         = var.environment == "prod" ? 1 : 0
+  count         = local.production_infra_hardening_enabled ? 1 : 0
   tier          = "Standard"
   resource_type = "Dns"
 }
@@ -2341,14 +2343,14 @@ resource "azurerm_security_center_subscription_pricing" "dns" {
 # PostgreSQL Private Endpoint (Issue #110 — CISO-003)
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_private_dns_zone" "postgresql" {
-  count               = var.environment == "prod" ? 1 : 0
+  count               = local.production_infra_hardening_enabled ? 1 : 0
   name                = "privatelink.postgres.database.azure.com"
   resource_group_name = azurerm_resource_group.main.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "postgresql" {
-  count                 = var.environment == "prod" ? 1 : 0
+  count                 = local.production_infra_hardening_enabled ? 1 : 0
   name                  = "archmorph-pg-dns-link"
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.postgresql[0].name
@@ -2358,7 +2360,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "postgresql" {
 }
 
 resource "azurerm_private_endpoint" "postgresql" {
-  count               = var.environment == "prod" ? 1 : 0
+  count               = local.production_infra_hardening_enabled ? 1 : 0
   name                = "archmorph-pg-pe-${local.name_suffix}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -2379,14 +2381,14 @@ resource "azurerm_private_endpoint" "postgresql" {
 }
 
 resource "azurerm_private_dns_zone" "redis" {
-  count               = var.environment == "prod" && var.enable_redis_private_endpoint ? 1 : 0
+  count               = local.production_infra_hardening_enabled && var.enable_redis_private_endpoint ? 1 : 0
   name                = "privatelink.redis.cache.windows.net"
   resource_group_name = azurerm_resource_group.main.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
-  count                 = var.environment == "prod" && var.enable_redis_private_endpoint ? 1 : 0
+  count                 = local.production_infra_hardening_enabled && var.enable_redis_private_endpoint ? 1 : 0
   name                  = "archmorph-redis-dns-link"
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.redis[0].name
@@ -2396,7 +2398,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
 }
 
 resource "azurerm_private_endpoint" "redis" {
-  count               = var.environment == "prod" && var.enable_redis_private_endpoint ? 1 : 0
+  count               = local.production_infra_hardening_enabled && var.enable_redis_private_endpoint ? 1 : 0
   name                = "archmorph-redis-pe-${local.name_suffix}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -2420,14 +2422,14 @@ resource "azurerm_private_endpoint" "redis" {
 # Blob Storage Private Endpoint — deterministic private connectivity
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_private_dns_zone" "storage" {
-  count               = var.environment == "prod" && var.enable_storage_private_endpoint ? 1 : 0
+  count               = local.production_infra_hardening_enabled && var.enable_storage_private_endpoint ? 1 : 0
   name                = "privatelink.blob.core.windows.net"
   resource_group_name = azurerm_resource_group.main.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
-  count                 = var.environment == "prod" && var.enable_storage_private_endpoint ? 1 : 0
+  count                 = local.production_infra_hardening_enabled && var.enable_storage_private_endpoint ? 1 : 0
   name                  = "archmorph-storage-dns-link"
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.storage[0].name
@@ -2437,7 +2439,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
 }
 
 resource "azurerm_private_endpoint" "storage" {
-  count               = var.environment == "prod" && var.enable_storage_private_endpoint ? 1 : 0
+  count               = local.production_infra_hardening_enabled && var.enable_storage_private_endpoint ? 1 : 0
   name                = "archmorph-storage-pe-${local.name_suffix}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -2468,14 +2470,14 @@ resource "azurerm_subnet" "private_endpoints" {
 }
 
 resource "azurerm_private_dns_zone" "keyvault" {
-  count               = var.environment == "prod" ? 1 : 0
+  count               = local.production_infra_hardening_enabled ? 1 : 0
   name                = "privatelink.vaultcore.azure.net"
   resource_group_name = azurerm_resource_group.main.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
-  count                 = var.environment == "prod" ? 1 : 0
+  count                 = local.production_infra_hardening_enabled ? 1 : 0
   name                  = "archmorph-kv-dns-link"
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.keyvault[0].name
@@ -2485,7 +2487,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
 }
 
 resource "azurerm_private_endpoint" "keyvault" {
-  count               = var.environment == "prod" ? 1 : 0
+  count               = local.production_infra_hardening_enabled ? 1 : 0
   name                = "archmorph-kv-pe-${local.name_suffix}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -2509,7 +2511,7 @@ resource "azurerm_private_endpoint" "keyvault" {
 # OpenAI Network Restrictions (Issue #110 — CISO-005)
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_cognitive_account_customer_managed_key" "openai" {
-  count                = var.environment == "prod" ? 0 : 0 # Enable when CMK key is provisioned
+  count                = local.production_infra_hardening_enabled ? 0 : 0 # Enable when CMK key is provisioned
   cognitive_account_id = azurerm_cognitive_account.openai.id
   key_vault_key_id     = "https://test/keys/dummy/001" # Populate with CMK key ID
 }
@@ -2518,7 +2520,7 @@ resource "azurerm_cognitive_account_customer_managed_key" "openai" {
 # Resource Locks (Issue #110 — CISO-006, prevent accidental deletion)
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_management_lock" "database" {
-  count      = var.environment == "prod" ? 1 : 0
+  count      = local.production_infra_hardening_enabled ? 1 : 0
   name       = "archmorph-db-lock"
   scope      = azurerm_postgresql_flexible_server.main.id
   lock_level = "CanNotDelete"
@@ -2526,7 +2528,7 @@ resource "azurerm_management_lock" "database" {
 }
 
 resource "azurerm_management_lock" "keyvault" {
-  count      = var.environment == "prod" ? 1 : 0
+  count      = local.production_infra_hardening_enabled ? 1 : 0
   name       = "archmorph-kv-lock"
   scope      = azurerm_key_vault.main.id
   lock_level = "CanNotDelete"
@@ -2534,7 +2536,7 @@ resource "azurerm_management_lock" "keyvault" {
 }
 
 resource "azurerm_management_lock" "storage" {
-  count      = var.environment == "prod" ? 1 : 0
+  count      = local.production_infra_hardening_enabled ? 1 : 0
   name       = "archmorph-storage-lock"
   scope      = azurerm_storage_account.main.id
   lock_level = "CanNotDelete"
@@ -2553,7 +2555,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "waf" {
   resource_group_name               = azurerm_resource_group.main.name
   sku_name                          = "Premium_AzureFrontDoor"
   enabled                           = true
-  mode                              = var.environment == "prod" ? "Prevention" : "Detection"
+  mode                              = local.production_infra_hardening_enabled ? "Prevention" : "Detection"
   custom_block_response_status_code = 403
   custom_block_response_body        = base64encode("{\"error\":\"Request blocked by WAF policy\"}")
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -38,6 +38,24 @@ variable "environment" {
   }
 }
 
+variable "resource_group_environment" {
+  description = "Optional legacy environment suffix used for Azure resource names/resource group while runtime environment remains production."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.resource_group_environment == null || contains(["dev", "staging", "prod"], var.resource_group_environment)
+    error_message = "resource_group_environment must be null, dev, staging, or prod."
+  }
+}
+
+variable "enable_production_infra_hardening" {
+  description = "Enable production SKU, network, DR, and private endpoint hardening. Keep false for the legacy live-stack identity cutover until the migration plan is reviewed."
+  type        = bool
+  default     = true
+}
+
 variable "db_admin_username" {
   description = "PostgreSQL administrator username"
   type        = string
@@ -75,8 +93,19 @@ variable "openai_api_key" {
   default     = null
 
   validation {
-    condition     = var.environment != "prod" || (var.openai_api_key != null && length(var.openai_api_key) > 0)
-    error_message = "openai_api_key must be provided for production to preserve the existing Key Vault secret during apply."
+    condition     = var.openai_api_key == null || length(var.openai_api_key) > 0
+    error_message = "openai_api_key must be null or a non-empty string."
+  }
+}
+
+variable "preserve_legacy_openai_key" {
+  description = "Manage the existing legacy openai-api-key Key Vault secret during the production managed identity cutover."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.preserve_legacy_openai_key || (var.openai_api_key != null && length(var.openai_api_key) > 0)
+    error_message = "openai_api_key must be provided when preserve_legacy_openai_key is true."
   }
 }
 


### PR DESCRIPTION
## Summary
- target the Terraform Production workflow at the current live legacy stack (`TF_VAR_environment=dev`) instead of the nonexistent `archmorph-rg-prod` stack
- preserve the legacy OpenAI Key Vault secret whenever the workflow supplies `AZURE_OPENAI_API_KEY`, independent of the environment label
- add a pre-plan state/resource-group contract preflight so future environment mismatches fail before Terraform plans destructive replacements

## Validation
- `terraform -chdir=infra fmt -check -recursive`
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_terraform_prod_workflow.py -q`

Note: local `terraform validate` could not complete on this macOS clone because readonly init installed provider packages whose checksums were not recorded for this platform in `.terraform.lock.hcl`; the lockfile was left unchanged and CI Linux validation should remain authoritative.

Closes #1076