### PR TITLE
fix(terraform): preserve legacy Redis name during import

### DIFF
--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -30,7 +30,7 @@ env:
   # Keep resource names aligned with state until a reviewed prod RG migration exists.
   TF_VAR_resource_group_environment: dev
   TF_VAR_enable_production_infra_hardening: false
-  # Preserve the live legacy Redis cache name until the state import is complete.
+  # Preserve the live legacy Redis cache name until a reviewed Redis migration/cutover is approved.
   TF_VAR_redis_name_override: archmorph-redis
   TF_VAR_db_admin_username: ${{ secrets.DB_ADMIN_USERNAME }}
   TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -30,6 +30,8 @@ env:
   # Keep resource names aligned with state until a reviewed prod RG migration exists.
   TF_VAR_resource_group_environment: dev
   TF_VAR_enable_production_infra_hardening: false
+  # Preserve the live legacy Redis cache name until the state import is complete.
+  TF_VAR_redis_name_override: archmorph-redis
   TF_VAR_db_admin_username: ${{ secrets.DB_ADMIN_USERNAME }}
   TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}
   TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
@@ -258,6 +260,8 @@ jobs:
                   "the legacy live resource IDs that must be imported before any reviewed apply."
               )
 
+          redis_name = os.environ.get("TF_VAR_redis_name_override") or f"archmorph-redis-{name_suffix}"
+
           live_resources = [
               {
                   "address": "azurerm_container_app_environment.main",
@@ -291,7 +295,7 @@ jobs:
                   "address": "azurerm_redis_cache.main",
                   "resource_id": (
                       f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
-                      f"/providers/Microsoft.Cache/Redis/archmorph-redis-{name_suffix}"
+                    f"/providers/Microsoft.Cache/Redis/{redis_name}"
                   ),
                   "legacy_resource_ids": [
                       (
@@ -301,7 +305,8 @@ jobs:
                   ],
                   "manual_reconciliation": (
                       "The live Redis cache uses the legacy unsuffixed name archmorph-redis, while "
-                      "Terraform currently targets archmorph-redis-${random_string.suffix.result}. "
+                      "Terraform may target archmorph-redis-${random_string.suffix.result} when "
+                      "TF_VAR_redis_name_override is not set. "
                       "Do not import blindly; either preserve the legacy name in Terraform or approve "
                       "a reviewed Redis migration before any apply."
                   ),

--- a/backend/tests/test_terraform_prod_workflow.py
+++ b/backend/tests/test_terraform_prod_workflow.py
@@ -104,6 +104,7 @@ def test_prod_plan_blocks_existing_live_resource_creates_until_imported():
     assert '"azurerm_user_assigned_identity.container_app"' in adoption_script
     assert '"azurerm_storage_account.main"' in adoption_script
     assert '"azurerm_redis_cache.main"' in adoption_script
+    assert 'redis_name = os.environ.get("TF_VAR_redis_name_override") or f"archmorph-redis-{name_suffix}"' in adoption_script
     assert '"legacy_resource_ids"' in adoption_script
     assert "/providers/Microsoft.Cache/Redis/archmorph-redis" in adoption_script
     assert "Do not import blindly" in adoption_script
@@ -174,6 +175,7 @@ def test_prod_workflow_uses_prod_runtime_with_legacy_live_stack_names():
     assert env["TF_VAR_environment"] == "prod"
     assert env["TF_VAR_resource_group_environment"] == "dev"
     assert env["TF_VAR_enable_production_infra_hardening"] is False
+    assert env["TF_VAR_redis_name_override"] == "archmorph-redis"
 
 
 def test_prod_apply_downloads_and_applies_reviewed_plan_only():

--- a/infra/README.md
+++ b/infra/README.md
@@ -58,7 +58,7 @@ for resource in state.get("resources", []):
 raise SystemExit("Unable to resolve random_string.suffix.result from Terraform state.")
 PY
 )"
-REDIS_NAME="${TF_VAR_redis_name_override:-archmorph-redis-${NAME_SUFFIX}}"
+REDIS_NAME="archmorph-redis"
 
 terraform import azurerm_container_app_environment.main \
   "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.App/managedEnvironments/archmorph-cae-${STACK_ENVIRONMENT}"

--- a/infra/README.md
+++ b/infra/README.md
@@ -58,6 +58,7 @@ for resource in state.get("resources", []):
 raise SystemExit("Unable to resolve random_string.suffix.result from Terraform state.")
 PY
 )"
+REDIS_NAME="${TF_VAR_redis_name_override:-archmorph-redis-${NAME_SUFFIX}}"
 
 terraform import azurerm_container_app_environment.main \
   "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.App/managedEnvironments/archmorph-cae-${STACK_ENVIRONMENT}"
@@ -67,11 +68,13 @@ terraform import azurerm_user_assigned_identity.container_app \
   "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/archmorph-api-identity"
 terraform import azurerm_storage_account.main \
   "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Storage/storageAccounts/archmorph${NAME_SUFFIX}"
+terraform import azurerm_redis_cache.main \
+  "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Cache/Redis/${REDIS_NAME}"
 ```
 
 Then re-run the plan-only workflow and confirm the resources above no longer appear as creates. `azurerm_static_web_app.frontend` is already in state when the plan shows an in-place update only, so it should stay a drift review item rather than an import gap.
 
-Do not blindly import Redis with the suffix-based name unless that exact Azure resource exists. The current live inventory contains the legacy cache `archmorph-redis`, while Terraform targets `archmorph-redis-${NAME_SUFFIX}`. Treat that as an explicit reconciliation decision: either preserve the legacy Redis name in Terraform before import, or approve a reviewed migration to a new suffix-based cache with session/cache cutover and rollback notes. The production workflow blocks the reviewed-plan artifact while that legacy Redis resource exists and `azurerm_redis_cache.main` is still planned as a create.
+The current production workflow sets `TF_VAR_redis_name_override=archmorph-redis` because live inventory contains the legacy unsuffixed cache. Do not remove that override until a reviewed Redis migration to `archmorph-redis-${NAME_SUFFIX}` or another target name has a session/cache cutover and rollback plan.
 
 If the plan still wants to destroy `azurerm_postgresql_flexible_server_firewall_rule.allow_azure[0]`, verify Azure still reports `publicNetworkAccess = Disabled` on the live PostgreSQL Flexible Server before approving any future apply:
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -59,6 +59,7 @@ locals {
   name_suffix                        = random_string.suffix.result
   stack_environment                  = coalesce(var.resource_group_environment, var.environment)
   production_infra_hardening_enabled = var.environment == "prod" && var.enable_production_infra_hardening
+  redis_cache_name                   = coalesce(var.redis_name_override, "archmorph-redis-${local.name_suffix}")
   paired_region_defaults = {
     westeurope    = "northeurope"
     northeurope   = "westeurope"
@@ -427,7 +428,7 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure" {
 # Azure Cache for Redis — session store & caching layer
 # ─────────────────────────────────────────────────────────────
 resource "azurerm_redis_cache" "main" {
-  name                          = "archmorph-redis-${local.name_suffix}"
+  name                          = local.redis_cache_name
   resource_group_name           = azurerm_resource_group.main.name
   location                      = azurerm_resource_group.main.location
   capacity                      = var.redis_capacity

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -112,6 +112,18 @@ variable "preserve_legacy_openai_key" {
 # ─────────────────────────────────────────────────────────────
 # Azure Cache for Redis
 # ─────────────────────────────────────────────────────────────
+variable "redis_name_override" {
+  description = "Optional existing Redis cache name to preserve during legacy live-stack import reconciliation. Leave null for suffix-based names on new stacks."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.redis_name_override == null || can(regex("^[a-zA-Z0-9-]{1,63}$", var.redis_name_override))
+    error_message = "redis_name_override must be null or a valid Azure Cache for Redis name."
+  }
+}
+
 variable "redis_capacity" {
   description = "Redis cache capacity (0 = 250MB, 1 = 1GB, 2 = 2.5GB). Basic C0 ~$16/mo, Standard C0 ~$40/mo."
   type        = number

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -119,7 +119,7 @@ variable "redis_name_override" {
   default     = null
 
   validation {
-    condition     = var.redis_name_override == null || can(regex("^[a-zA-Z0-9-]{1,63}$", var.redis_name_override))
+    condition     = var.redis_name_override == null || can(regex("^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$", var.redis_name_override))
     error_message = "redis_name_override must be null or a valid Azure Cache for Redis name."
   }
 }


### PR DESCRIPTION
## Summary
- add a `redis_name_override` Terraform variable so the legacy live cache `archmorph-redis` can be preserved during state import
- set the production Terraform workflow to use `TF_VAR_redis_name_override=archmorph-redis`
- update the live-resource guardrail and runbook so Redis becomes a normal import target instead of an accidental new cache migration

## Validation
- `terraform -chdir=infra fmt -check -recursive`
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_terraform_prod_workflow.py -q`
- embedded Terraform Production preflight Python syntax check
- `git diff --check`

Refs #1079
