### PR TITLE
fix(ci): allow system identity during backend deploy validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,10 +675,11 @@ jobs:
 
       - name: Validate Terraform-managed metrics storage
         run: |
-          ENV_JSON=$(az containerapp show \
+          CONTAINER_APP_JSON=$(az containerapp show \
             --name ${{ env.CONTAINER_APP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "properties.template.containers[0].env" -o json)
+            -o json)
+          ENV_JSON=$(echo "$CONTAINER_APP_JSON" | jq -c '.properties.template.containers[0].env // []')
 
           STORAGE_ACCOUNT_URL=$(echo "$ENV_JSON" | jq -r '.[] | select(.name == "AZURE_STORAGE_ACCOUNT_URL") | .value // ""')
           if [ -z "$STORAGE_ACCOUNT_URL" ]; then
@@ -754,18 +755,22 @@ jobs:
           fi
 
           CONTAINER_APP_CLIENT_ID=$(echo "$ENV_JSON" | jq -r '.[] | select(.name == "AZURE_CLIENT_ID") | .value // ""')
-          if [ -z "$CONTAINER_APP_CLIENT_ID" ]; then
-            echo "::error::Container App is missing AZURE_CLIENT_ID for its user-assigned managed identity"
-            exit 1
-          fi
-
-          CONTAINER_APP_PRINCIPAL_ID=$(az containerapp show \
-            --name ${{ env.CONTAINER_APP_NAME }} \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "identity.userAssignedIdentities.* | [?clientId=='$CONTAINER_APP_CLIENT_ID'].principalId | [0]" -o tsv)
-          if [ -z "$CONTAINER_APP_PRINCIPAL_ID" ]; then
-            echo "::error::Container App user-assigned identity principal is not available for AZURE_CLIENT_ID=$CONTAINER_APP_CLIENT_ID"
-            exit 1
+          if [ -n "$CONTAINER_APP_CLIENT_ID" ]; then
+            CONTAINER_APP_PRINCIPAL_ID=$(echo "$CONTAINER_APP_JSON" \
+              | jq -r --arg client_id "$CONTAINER_APP_CLIENT_ID" '.identity.userAssignedIdentities // {} | to_entries[] | select(.value.clientId == $client_id) | .value.principalId' \
+              | head -1)
+            if [ -z "$CONTAINER_APP_PRINCIPAL_ID" ]; then
+              echo "::error::Container App user-assigned identity principal is not available for AZURE_CLIENT_ID=$CONTAINER_APP_CLIENT_ID"
+              exit 1
+            fi
+            echo "Using Container App user-assigned managed identity for storage validation"
+          else
+            CONTAINER_APP_PRINCIPAL_ID=$(echo "$CONTAINER_APP_JSON" | jq -r '.identity.principalId // ""')
+            if [ -z "$CONTAINER_APP_PRINCIPAL_ID" ]; then
+              echo "::error::Container App is missing AZURE_CLIENT_ID and has no system-assigned identity principal for storage access"
+              exit 1
+            fi
+            echo "::notice::Container App AZURE_CLIENT_ID is not set; using the system-assigned managed identity for storage validation until Terraform user-assigned identity migration is applied."
           fi
           echo "CONTAINER_APP_PRINCIPAL_ID=$CONTAINER_APP_PRINCIPAL_ID" >> "$GITHUB_ENV"
 

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -145,6 +145,24 @@ def test_backend_storage_validation_classifies_pending_terraform_migration():
     assert "grant AZURE_CLIENT_ID Blob data-plane access on the tfstate storage account/container" in validate_script
 
 
+def test_backend_storage_validation_accepts_system_identity_until_user_identity_migration():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    validate_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Validate Terraform-managed metrics storage"
+    )
+    validate_script = validate_step["run"]
+
+    assert "CONTAINER_APP_JSON=$(az containerapp show" in validate_script
+    assert "Using Container App user-assigned managed identity for storage validation" in validate_script
+    assert "Container App AZURE_CLIENT_ID is not set; using the system-assigned managed identity" in validate_script
+    assert "Container App is missing AZURE_CLIENT_ID and has no system-assigned identity principal" in validate_script
+    assert 'jq -r \'.identity.principalId // ""\'' in validate_script
+    assert "Container App identity is missing Storage Blob Data Contributor" in validate_script
+
+
 def test_backend_green_revision_healthz_is_retried_before_failure():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary

The latest `main` CI/CD run failed in `deploy-backend` because the live Container App does not yet expose `AZURE_CLIENT_ID` in its runtime env. That is expected for the current live system-assigned identity path, and it should not block backend deploy validation as long as the Container App identity has `Storage Blob Data Contributor` on the Terraform-managed storage account.

This PR updates the deploy validation to:
- read the Container App once and validate env plus identity from the same payload
- use the Terraform user-assigned identity when `AZURE_CLIENT_ID` is present
- fall back to the system-assigned identity while the user-assigned Terraform migration is pending
- keep enforcing the storage role assignment before deploy

## Validation

- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py -q`
- parsed `.github/workflows/ci.yml` with PyYAML
- `git diff --check`
