### PR TITLE
fix(ci): validate storage network cutover path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ permissions:
 env:
   API_URL: ${{ secrets.API_URL }}
   FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+  # Temporary cutover flag while production hardening is disabled and the live app
+  # still uses managed-identity RBAC over the public Blob endpoint.
+  ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER: "true"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -723,17 +726,33 @@ jobs:
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query publicNetworkAccess -o tsv)
           if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then
+            PRIVATE_ENDPOINT_ERROR=$(mktemp)
+            set +e
             APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list \
               --id "$STORAGE_ID" \
               --query "[?properties.privateLinkServiceConnectionState.status=='Approved'] | length(@)" \
-              -o tsv 2>/dev/null || echo "0")
+              -o tsv 2>"$PRIVATE_ENDPOINT_ERROR")
+            PRIVATE_ENDPOINT_STATUS=$?
+            set -e
+            if [ "$PRIVATE_ENDPOINT_STATUS" -ne 0 ]; then
+              echo "::error::Unable to query private endpoint connections for storage account $STORAGE_NAME"
+              sed 's/^/az network private-endpoint-connection list: /' "$PRIVATE_ENDPOINT_ERROR" >&2
+              rm -f "$PRIVATE_ENDPOINT_ERROR"
+              exit 1
+            fi
+            rm -f "$PRIVATE_ENDPOINT_ERROR"
             if [ "${APPROVED_PRIVATE_ENDPOINT_COUNT:-0}" = "0" ]; then
               echo "::error::Storage account $STORAGE_NAME has public network access disabled but no approved private endpoint connection. Enable public access for the hardening-disabled cutover or apply Terraform private endpoint networking before CI deploy."
               exit 1
             fi
             echo "Storage account $STORAGE_NAME uses disabled public network access with approved private endpoint connectivity"
           else
-            echo "::notice::Storage account $STORAGE_NAME has public network access ${PUBLIC_NETWORK_ACCESS}; managed-identity blob preflight will prove RBAC data-plane access before traffic shift."
+            ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=$(echo "${ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER:-false}" | tr '[:upper:]' '[:lower:]')
+            if [ "$ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER" != "true" ]; then
+              echo "::error::Storage account $STORAGE_NAME has public network access ${PUBLIC_NETWORK_ACCESS}. Set ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=true only for the reviewed hardening-disabled cutover, or apply Terraform private endpoint networking before CI deploy."
+              exit 1
+            fi
+            echo "::notice::Storage account $STORAGE_NAME has public network access ${PUBLIC_NETWORK_ACCESS} under ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=true; managed-identity blob preflight will prove RBAC data-plane access before traffic shift."
             if [ "$STORAGE_NAME" = "archmorphmetrics" ]; then
               echo "::notice::Container App still references legacy storage account $STORAGE_NAME until Terraform storage migration is applied."
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,16 @@ jobs:
             exit 1
           fi
 
+          STORAGE_ID=$(az storage account show \
+            --name "$STORAGE_NAME" \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query id -o tsv)
+          if [ -z "$STORAGE_ID" ]; then
+            echo "::error::Unable to resolve storage account resource ID for $STORAGE_NAME"
+            exit 1
+          fi
+          echo "STORAGE_ID=$STORAGE_ID" >> "$GITHUB_ENV"
+
           ALLOW_SHARED_KEY=$(az storage account show \
             --name "$STORAGE_NAME" \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
@@ -712,26 +722,22 @@ jobs:
             --name "$STORAGE_NAME" \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query publicNetworkAccess -o tsv)
-          if [ "$PUBLIC_NETWORK_ACCESS" != "Disabled" ]; then
-            if [ "$STORAGE_NAME" = "archmorphmetrics" ]; then
-              echo "::error::Terraform storage migration pending: Container App still references legacy storage account $STORAGE_NAME with public network access ${PUBLIC_NETWORK_ACCESS}."
-              echo "::notice::Run the Terraform Production workflow (workflow_dispatch) with apply=true to migrate production to Terraform-managed storage/private endpoints."
-              echo "::notice::If Terraform Production fails during init, grant AZURE_CLIENT_ID Blob data-plane access on the tfstate storage account/container and rerun."
-            else
-              echo "::error::Production storage account $STORAGE_NAME must have public network access disabled to match Terraform configuration"
+          if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then
+            APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list \
+              --id "$STORAGE_ID" \
+              --query "[?properties.privateLinkServiceConnectionState.status=='Approved'] | length(@)" \
+              -o tsv 2>/dev/null || echo "0")
+            if [ "${APPROVED_PRIVATE_ENDPOINT_COUNT:-0}" = "0" ]; then
+              echo "::error::Storage account $STORAGE_NAME has public network access disabled but no approved private endpoint connection. Enable public access for the hardening-disabled cutover or apply Terraform private endpoint networking before CI deploy."
+              exit 1
             fi
-            exit 1
+            echo "Storage account $STORAGE_NAME uses disabled public network access with approved private endpoint connectivity"
+          else
+            echo "::notice::Storage account $STORAGE_NAME has public network access ${PUBLIC_NETWORK_ACCESS}; managed-identity blob preflight will prove RBAC data-plane access before traffic shift."
+            if [ "$STORAGE_NAME" = "archmorphmetrics" ]; then
+              echo "::notice::Container App still references legacy storage account $STORAGE_NAME until Terraform storage migration is applied."
+            fi
           fi
-
-          STORAGE_ID=$(az storage account show \
-            --name "$STORAGE_NAME" \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query id -o tsv)
-          if [ -z "$STORAGE_ID" ]; then
-            echo "::error::Unable to resolve storage account resource ID for $STORAGE_NAME"
-            exit 1
-          fi
-          echo "STORAGE_ID=$STORAGE_ID" >> "$GITHUB_ENV"
 
           METRICS_CONTAINER_ID="$STORAGE_ID/blobServices/default/containers/metrics"
           METRICS_CONTAINER_ERROR=$(mktemp)

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -129,7 +129,7 @@ def test_backend_readiness_accepts_azure_provisioned_state():
     assert '[ "$RUNNING_STATE" = "Running" ]' in readiness_script
 
 
-def test_backend_storage_validation_classifies_pending_terraform_migration():
+def test_backend_storage_validation_requires_private_endpoint_when_public_access_disabled():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 
     validate_step = next(
@@ -139,10 +139,11 @@ def test_backend_storage_validation_classifies_pending_terraform_migration():
     )
     validate_script = validate_step["run"]
 
-    assert 'if [ "$STORAGE_NAME" = "archmorphmetrics" ]; then' in validate_script
-    assert "Terraform storage migration pending" in validate_script
-    assert "Run the Terraform Production workflow" in validate_script
-    assert "grant AZURE_CLIENT_ID Blob data-plane access on the tfstate storage account/container" in validate_script
+    assert 'if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then' in validate_script
+    assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
+    assert "has public network access disabled but no approved private endpoint connection" in validate_script
+    assert "managed-identity blob preflight will prove RBAC data-plane access" in validate_script
+    assert "Container App still references legacy storage account" in validate_script
 
 
 def test_backend_storage_validation_accepts_system_identity_until_user_identity_migration():

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -141,7 +141,10 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
 
     assert 'if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then' in validate_script
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
+    assert "PRIVATE_ENDPOINT_STATUS=$?" in validate_script
+    assert "Unable to query private endpoint connections" in validate_script
     assert "has public network access disabled but no approved private endpoint connection" in validate_script
+    assert "ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER" in validate_script
     assert "managed-identity blob preflight will prove RBAC data-plane access" in validate_script
     assert "Container App still references legacy storage account" in validate_script
 

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -270,7 +270,9 @@ def test_ci_and_prod_workflows_enforce_readonly_terraform_lockfiles():
 def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert '[ "$PUBLIC_NETWORK_ACCESS" != "Disabled" ]' in ci_workflow
+    assert '[ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]' in ci_workflow
+    assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in ci_workflow
+    assert "managed-identity blob preflight will prove RBAC data-plane access" in ci_workflow
     assert 'select(.name == "AZURE_CLIENT_ID")' in ci_workflow
     assert "identity.userAssignedIdentities" in ci_workflow
     assert "Storage Blob Data Contributor" in ci_workflow

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -272,6 +272,8 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
 
     assert '[ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]' in ci_workflow
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in ci_workflow
+    assert "PRIVATE_ENDPOINT_STATUS=$?" in ci_workflow
+    assert 'ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER: "true"' in ci_workflow
     assert "managed-identity blob preflight will prove RBAC data-plane access" in ci_workflow
     assert 'select(.name == "AZURE_CLIENT_ID")' in ci_workflow
     assert "identity.userAssignedIdentities" in ci_workflow


### PR DESCRIPTION
## Summary
- allow the hardening-disabled storage cutover path to use public network access with shared keys disabled
- fail early when public network access is disabled without an approved private endpoint
- keep the managed-identity blob preflight as the final data-plane proof before traffic shift

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py -q
- workflow YAML parse check