### PR TITLE
fix(ci): retry transient container app update conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,13 +1093,34 @@ jobs:
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:8}"
           REVISION_SUFFIX="sha-${SHORT_SHA}-run-${{ github.run_attempt }}"
-          az containerapp update \
-            --name ${{ env.CONTAINER_APP_NAME }} \
-            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --image "${IMAGE_REF}" \
-            --set-env-vars "${SET_ENV_VARS[@]}" \
-            --revision-suffix "$REVISION_SUFFIX" \
-            --no-wait
+          UPDATE_ERROR=$(mktemp)
+          for update_attempt in 1 2 3 4; do
+            : > "$UPDATE_ERROR"
+            set +e
+            az containerapp update \
+              --name ${{ env.CONTAINER_APP_NAME }} \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --image "${IMAGE_REF}" \
+              --set-env-vars "${SET_ENV_VARS[@]}" \
+              --revision-suffix "$REVISION_SUFFIX" \
+              --no-wait \
+              2>"$UPDATE_ERROR"
+            UPDATE_STATUS=$?
+            set -e
+            if [ "$UPDATE_STATUS" -eq 0 ]; then
+              break
+            fi
+            if grep -q "ConflictingConcurrentWriteNotAllowed" "$UPDATE_ERROR" && [ "$update_attempt" -lt 4 ]; then
+              echo "::warning::Container App update hit a concurrent write on attempt ${update_attempt}; retrying"
+              sleep $((update_attempt * 20))
+              continue
+            fi
+            echo "::error::Container App update failed on attempt ${update_attempt}"
+            sed 's/^/az containerapp update: /' "$UPDATE_ERROR" >&2
+            rm -f "$UPDATE_ERROR"
+            exit "$UPDATE_STATUS"
+          done
+          rm -f "$UPDATE_ERROR"
 
           echo "Waiting for green revision to provision..."
           sleep 45

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -114,6 +114,23 @@ def test_backend_deploy_limits_workers_for_fast_container_app_activation():
     assert 'WEB_CONCURRENCY="1"' in deploy_script
 
 
+def test_backend_deploy_retries_transient_container_app_update_conflicts():
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    deploy_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Deploy green revision"
+    )
+    deploy_script = deploy_step["run"]
+
+    assert "for update_attempt in 1 2 3 4; do" in deploy_script
+    assert "ConflictingConcurrentWriteNotAllowed" in deploy_script
+    assert "Container App update hit a concurrent write" in deploy_script
+    assert "Container App update failed on attempt" in deploy_script
+    assert "sed 's/^/az containerapp update: /'" in deploy_script
+
+
 def test_backend_readiness_accepts_azure_provisioned_state():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- retry az containerapp update when Azure Container Apps returns ConflictingConcurrentWriteNotAllowed
- preserve failure output for non-retryable update errors
- add workflow contract coverage for the retry guard

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py -q
- workflow YAML parse check
