### PR TITLE
fix(api): align storage health probe with blob data path

### DIFF
--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -111,19 +111,37 @@ def _run_dependency_checks() -> tuple[dict[str, str], bool, bool]:
 
     # ── Blob storage ──────────────────────────────────────
     try:
-        from usage_metrics import AZURE_STORAGE_ACCOUNT_URL, AZURE_STORAGE_CONNECTION_STRING
+        from usage_metrics import (
+            AZURE_STORAGE_ACCOUNT_URL,
+            AZURE_STORAGE_CONNECTION_STRING,
+            AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID,
+            METRICS_BLOB_CONTAINER,
+        )
         if AZURE_STORAGE_ACCOUNT_URL or AZURE_STORAGE_CONNECTION_STRING:
-            # Probe actual reachability — catch private-network misconfiguration early.
+            # Probe the actual container-level data path used by the app.
+            # Storage Blob Data Contributor can read/write blobs but may not read
+            # account-level service properties, so account-wide probes can fail
+            # even when the required runtime path is healthy.
             _bsc = None
             try:
                 from azure.storage.blob import BlobServiceClient
                 if AZURE_STORAGE_ACCOUNT_URL:
                     from azure.identity import DefaultAzureCredential
-                    _cred = DefaultAzureCredential()
-                    _bsc = BlobServiceClient(AZURE_STORAGE_ACCOUNT_URL, credential=_cred)
+                    _cred = DefaultAzureCredential(
+                        managed_identity_client_id=(
+                            AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID or None
+                        )
+                    )
+                    _bsc = BlobServiceClient(
+                        AZURE_STORAGE_ACCOUNT_URL,
+                        credential=_cred,
+                    )
                 else:
-                    _bsc = BlobServiceClient.from_connection_string(AZURE_STORAGE_CONNECTION_STRING)
-                _bsc.get_service_properties(timeout=4)
+                    _bsc = BlobServiceClient.from_connection_string(
+                        AZURE_STORAGE_CONNECTION_STRING
+                    )
+                container = _bsc.get_container_client(METRICS_BLOB_CONTAINER)
+                container.get_container_properties(timeout=4)
                 checks["storage"] = "ok"
             except Exception as exc:
                 logger.warning(

--- a/backend/tests/test_contract.py
+++ b/backend/tests/test_contract.py
@@ -14,7 +14,7 @@ import copy
 import io
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -143,6 +143,42 @@ class TestHealthContract:
     def test_health_checks_schema(self, client):
         checks = client.get("/api/health").json()["checks"]
         assert_fields(checks, {"openai": str, "storage": str})
+
+    def test_storage_health_probe_uses_metrics_container_path(self, monkeypatch):
+        import routers.health as health_router
+        import usage_metrics
+
+        monkeypatch.setattr(health_router, "_dep_checks_cache", None)
+        monkeypatch.setattr(health_router, "_dep_checks_ts", 0)
+        monkeypatch.setattr(
+            usage_metrics,
+            "AZURE_STORAGE_ACCOUNT_URL",
+            "https://example.blob.core.windows.net",
+        )
+        monkeypatch.setattr(usage_metrics, "AZURE_STORAGE_CONNECTION_STRING", "")
+        monkeypatch.setattr(
+            usage_metrics,
+            "AZURE_STORAGE_MANAGED_IDENTITY_CLIENT_ID",
+            "",
+        )
+        monkeypatch.setattr(usage_metrics, "METRICS_BLOB_CONTAINER", "metrics")
+
+        mock_container = MagicMock()
+        mock_blob_service = MagicMock()
+        mock_blob_service.get_container_client.return_value = mock_container
+        mock_blob_service.get_service_properties.side_effect = AssertionError(
+            "account-level service properties should not be probed"
+        )
+
+        with patch("azure.identity.DefaultAzureCredential"), patch(
+            "azure.storage.blob.BlobServiceClient", return_value=mock_blob_service
+        ):
+            checks, _, _ = health_router._run_dependency_checks()
+
+        assert checks["storage"] == "ok"
+        mock_blob_service.get_container_client.assert_called_once_with("metrics")
+        mock_container.get_container_properties.assert_called_once_with(timeout=4)
+        mock_blob_service.get_service_properties.assert_not_called()
 
     def test_optional_redis_is_explicitly_classified(self, client, monkeypatch):
         import routers.health as health_router


### PR DESCRIPTION
## Summary
- align the production health storage probe with the metrics container data path the app actually uses
- stop requiring account-level blob service properties for managed-identity health
- add a contract test proving the health check uses container-level storage access

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_contract.py::TestHealthContract::test_storage_health_probe_uses_metrics_container_path backend/tests/test_health_gate_script.py backend/tests/test_ci_workflow_post_deploy_smoke.py -q
- git diff --check
