### PR TITLE
fix: add PDF preview download fallback

### DIFF
--- a/frontend/src/components/DiagramTranslator/PdfPreviewPanel.jsx
+++ b/frontend/src/components/DiagramTranslator/PdfPreviewPanel.jsx
@@ -162,9 +162,14 @@ export default function PdfPreviewPanel({ file }) {
       )}
 
       {previewUrl && (
-        <a className="mt-2 inline-flex text-xs text-cta underline-offset-2 hover:underline" href={previewUrl} target="_blank" rel="noreferrer">
-          Open PDF in a new tab
-        </a>
+        <div className="mt-2 flex flex-wrap gap-3 text-xs">
+          <a className="inline-flex text-cta underline-offset-2 hover:underline" href={previewUrl} target="_blank" rel="noreferrer">
+            Open PDF in a new tab
+          </a>
+          <a className="inline-flex text-cta underline-offset-2 hover:underline" href={previewUrl} download={file.name || 'diagram.pdf'}>
+            Download PDF for inspection
+          </a>
+        </div>
       )}
 
       <Modal open={open} onClose={() => setOpen(false)} title="PDF Preview (First Page)" className="max-w-5xl">

--- a/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
@@ -249,6 +249,8 @@ describe('UploadStep', () => {
 
     expect(await screen.findByText(/Inline PDF preview is not supported/)).toBeInTheDocument()
     expect(await screen.findByRole('link', { name: 'Open PDF in a new tab' })).toBeInTheDocument()
+    const downloadLink = await screen.findByRole('link', { name: 'Download PDF for inspection' })
+    expect(downloadLink).toHaveAttribute('download', 'diagram.pdf')
   })
 
   it('shows encrypted PDF preview failure message', async () => {


### PR DESCRIPTION
## Summary\n- add a direct PDF download inspect fallback next to the new-tab preview link\n- keep the fallback available when inline PDF preview is unsupported\n- cover the fallback in UploadStep PDF preview tests\n\n## Testing\n- npm --prefix frontend test -- src/components/DiagramTranslator/__tests__/UploadStep.test.jsx --run\n\nAddresses #1028