### PR TITLE
fix: upgrade mcp gateway image pip

### DIFF
--- a/backend/tests/test_security_workflow_container_scans.py
+++ b/backend/tests/test_security_workflow_container_scans.py
@@ -5,6 +5,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
+BACKEND_DOCKERFILE = REPO_ROOT / "backend" / "Dockerfile"
+MCP_GATEWAY_DOCKERFILE = REPO_ROOT / "mcp-gateway" / "Dockerfile"
 
 
 def _load() -> dict:
@@ -55,3 +57,12 @@ def test_security_workflow_keeps_required_trivy_status_context():
 
     assert required_job["name"] == "Container Scan — Trivy"
     assert required_job["needs"] == "trivy-container"
+
+
+def test_runtime_images_upgrade_pip_before_dependency_install():
+    for dockerfile in (BACKEND_DOCKERFILE, MCP_GATEWAY_DOCKERFILE):
+        content = dockerfile.read_text(encoding="utf-8")
+        assert 'pip install --no-cache-dir --upgrade "pip>=26.0"' in content
+        assert content.index('pip install --no-cache-dir --upgrade "pip>=26.0"') < content.index(
+            "pip install --no-cache-dir -r requirements.txt"
+        )

--- a/mcp-gateway/Dockerfile
+++ b/mcp-gateway/Dockerfile
@@ -4,7 +4,8 @@ COPY requirements.txt .
 RUN apt-get update && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade "pip>=26.0" setuptools wheel && \
+    pip install --no-cache-dir -r requirements.txt
 RUN addgroup --system --gid 1000 appgroup && \
     adduser --system --uid 1000 --ingroup appgroup appuser
 COPY . .


### PR DESCRIPTION
## Summary
- Upgrade pip, setuptools, and wheel in the MCP gateway image before installing runtime requirements
- Match backend image hardening so Trivy no longer reports pip 25.0.1 in mcp-gateway
- Add a container security contract test that both runtime images upgrade pip before dependency installation

## Fixes
- Code scanning alert #306 / CVE-2026-6357
- Code scanning alert #163 / CVE-2025-8869
- Code scanning alert #164 / CVE-2026-1703

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_security_workflow_container_scans.py -q
- git diff --check

Note: local Docker daemon is not running, so image build/Trivy validation is delegated to the PR Security Scanning workflow.