### PR TITLE
fix: unblock SWA-authenticated diagram analysis

### DIFF
--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/assets/*", "/*.ico", "/*.svg", "/*.png", "/*.jpg"]
+    "exclude": ["/assets/*", "/*.ico", "/*.svg", "/*.png", "/*.jpg", "/api/*", "/.auth/*"]
   },
   "routes": [
     {

--- a/frontend/src/__tests__/staticwebappConfig.test.js
+++ b/frontend/src/__tests__/staticwebappConfig.test.js
@@ -30,9 +30,11 @@ describe('Static Web App security headers config', () => {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       const csp = config.globalHeaders['Content-Security-Policy'];
       const directives = parseCspDirectives(csp);
+      const fallbackExcludes = config.navigationFallback?.exclude || [];
 
       expect(config.globalHeaders['X-Frame-Options']).toBe('DENY');
       expect(config.globalHeaders['Permissions-Policy']).toBe('camera=(), microphone=(), geolocation=()');
+      expect(fallbackExcludes).toEqual(expect.arrayContaining(['/api/*', '/.auth/*']));
       expect(directives['default-src']).toContain("'self'");
       expect(directives['connect-src']).toEqual(expect.arrayContaining(["'self'", 'https://api.archmorphai.com']));
       expect(directives['img-src']).toEqual(expect.arrayContaining(["'self'", 'data:', 'blob:']));

--- a/frontend/src/stores/__tests__/useAuthStore.test.js
+++ b/frontend/src/stores/__tests__/useAuthStore.test.js
@@ -69,6 +69,30 @@ describe('useAuthStore', () => {
     expect(state.user).toMatchObject({ id: 'backend-user', name: 'Backend User' });
   });
 
+  it('falls back to SWA principal profile when /api/auth/me responds with HTML', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ clientPrincipal: principal }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'text/html' },
+        text: () => Promise.resolve('<!DOCTYPE html><html></html>'),
+      });
+
+    await useAuthStore.getState().initialize();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.user).toMatchObject({
+      id: 'aad_user-123',
+      name: 'Ido Katz',
+      email: 'ido@example.com',
+      provider: 'microsoft',
+    });
+  });
+
   it('preserves path, query string, and hash in SWA login redirects', () => {
     expect(buildPostLoginRedirectUri({
       pathname: '/workspace',

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -104,10 +104,16 @@ const useAuthStore = create((set, get) => ({
             credentials: 'include',
           });
           if (apiRes.ok) {
-            const user = await apiRes.json();
-            if (user && user.id) {
-              set({ user, isAuthenticated: true, isLoading: false });
-              return;
+            try {
+              const contentType = apiRes.headers?.get?.('content-type') || '';
+              const shouldParseJson = !contentType || contentType.includes('application/json');
+              const user = shouldParseJson ? await apiRes.json() : null;
+              if (user && user.id) {
+                set({ user, isAuthenticated: true, isLoading: false });
+                return;
+              }
+            } catch {
+              // Fall back to SWA principal-derived profile when API auth route is misconfigured.
             }
           }
           if (swaUser) {


### PR DESCRIPTION
## Summary
- preserve Azure Static Web Apps authenticated users when `/api/auth/me` returns SPA HTML instead of JSON
- exclude `/api/*` and `/.auth/*` from the Static Web Apps navigation fallback
- add regression coverage for the HTML auth fallback and SWA fallback exclusions

## Validation
- `npm --prefix frontend test -- --run src/stores/__tests__/useAuthStore.test.js src/__tests__/staticwebappConfig.test.js src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx src/services/__tests__/apiClient.test.js`

Fixes #1093.

Supersedes the Copilot app PR #1094, whose checks are stuck in `action_required` with no runnable jobs.