### PR TITLE
fix: gate diagram analysis on backend API session

### DIFF
--- a/frontend/src/components/DiagramTranslator/UploadStep.jsx
+++ b/frontend/src/components/DiagramTranslator/UploadStep.jsx
@@ -15,9 +15,11 @@ export default function UploadStep({
   dragOver, selectedFile, filePreviewUrl, fileInputRef,
   onDragOver, onDragLeave, onDrop, onFileSelect, onUpload, onRemoveFile, onLoadSample,
   isAuthenticated = true,
+  hasBackendSession = true,
   onSignIn,
 }) {
   const isPdf = !!selectedFile && (selectedFile.type === 'application/pdf' || /\.pdf$/i.test(selectedFile.name));
+  const canAnalyze = isAuthenticated && hasBackendSession;
 
   return (
     <Card className="p-6 pb-24 sm:p-12 sm:pb-12">
@@ -77,14 +79,23 @@ export default function UploadStep({
                   <p className="text-xs text-text-muted">{(selectedFile.size / 1024).toFixed(0)} KB</p>
                 </div>
                 <div className="flex flex-wrap items-center justify-center gap-2" data-testid="file-action-buttons">
-                  {isAuthenticated ? (
+                  {canAnalyze ? (
                     <Button onClick={(e) => { e.stopPropagation(); onUpload(selectedFile); }} variant="primary" size="md" icon={Upload}>
                       Analyze This Diagram
                     </Button>
-                  ) : (
+                  ) : !isAuthenticated ? (
                     <Button onClick={(e) => { e.stopPropagation(); onSignIn?.(); }} variant="primary" size="md" icon={LogIn}>
                       Sign in to analyze
                     </Button>
+                  ) : (
+                    <div className="flex flex-col items-center gap-2">
+                      <Button onClick={(e) => { e.stopPropagation(); }} variant="secondary" size="md" icon={LogIn} disabled>
+                        Analysis unavailable
+                      </Button>
+                      <p className="max-w-xs text-xs text-text-muted">
+                        Signed in, but the backend analysis session is not available yet.
+                      </p>
+                    </div>
                   )}
                   <Button onClick={(e) => { e.stopPropagation(); onRemoveFile(); }} variant="ghost" size="sm" icon={X}>
                     Remove

--- a/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
@@ -155,6 +155,17 @@ describe('UploadStep', () => {
     expect(onUpload).toHaveBeenCalledWith(file)
   })
 
+  it('disables analysis when the frontend has SWA auth but no backend session', async () => {
+    const onUpload = vi.fn()
+    const onSignIn = vi.fn()
+    const file = new File(['diagram.png'], 'diagram.png', { type: 'image/png' })
+    render(<UploadStep {...defaultProps} selectedFile={file} isAuthenticated={true} hasBackendSession={false} onUpload={onUpload} onSignIn={onSignIn} />)
+    expect(screen.getByRole('button', { name: /Analysis unavailable/i })).toBeDisabled()
+    expect(screen.getByText(/backend analysis session is not available/i)).toBeInTheDocument()
+    expect(onUpload).not.toHaveBeenCalled()
+    expect(onSignIn).not.toHaveBeenCalled()
+  })
+
   it('clicking Remove calls onRemoveFile', async () => {
     const user = userEvent.setup()
     const onRemoveFile = vi.fn()

--- a/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
@@ -71,9 +71,11 @@ vi.mock('../../../services/apiClient', () => ({
 
 // Mock useAuthStore so we can control isAuthenticated per test
 let mockIsAuthenticated = false
+let mockHasBackendSession = false
 vi.mock('../../../stores/useAuthStore', () => ({
   default: vi.fn((selector) => selector({
     isAuthenticated: mockIsAuthenticated,
+    hasBackendSession: mockHasBackendSession,
     isLoading: false,
     user: null,
     sessionToken: null,
@@ -84,6 +86,7 @@ describe('DiagramTranslator — Session UX Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsAuthenticated = false // signed-out by default for these tests
+    mockHasBackendSession = false
     mockLoadSession.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
   })
@@ -278,6 +281,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsAuthenticated = false // signed-out by default
+    mockHasBackendSession = false
     mockLoadSession.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
     localStorage.clear()
@@ -306,6 +310,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
   it('shows "Authentication required" card (not "Analysis Error") when upload returns 401 without token', async () => {
     // Set user as authenticated so the upload button is visible and upload can be triggered
     mockIsAuthenticated = true
+    mockHasBackendSession = true
 
     const { ApiError } = await import('../../../services/apiClient')
     const authErr = new ApiError(401, { detail: 'Not authenticated' }, { hadToken: false })
@@ -344,6 +349,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
 
   it('preserves selectedFile after 401 so user can retry after signing in', async () => {
     mockIsAuthenticated = true
+    mockHasBackendSession = true
 
     const { ApiError } = await import('../../../services/apiClient')
     const authErr = new ApiError(401, { detail: 'Not authenticated' }, { hadToken: false })
@@ -362,6 +368,24 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
 
     // After 401, the file should still be shown (not cleared)
     await waitFor(() => expect(screen.getByText('my-diagram.pdf')).toBeInTheDocument())
+  })
+
+  it('does not upload or analyze when user is SWA-only without a backend session', async () => {
+    mockIsAuthenticated = true
+    mockHasBackendSession = false
+
+    render(<DiagramTranslator />)
+    await screen.findByText('Upload Architecture Diagram')
+
+    const input = document.querySelector('input[type="file"]')
+    const pdfFile = new File(['%PDF-1.4'], 'swa-only.pdf', { type: 'application/pdf' })
+    await act(async () => { fireEvent.change(input, { target: { files: [pdfFile] } }) })
+    await waitFor(() => expect(screen.getByText('swa-only.pdf')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: /Analysis unavailable/i })).toBeDisabled()
+    expect(screen.getByText(/backend analysis session is not available/i)).toBeInTheDocument()
+    expect(screen.queryByText('Analyze This Diagram')).not.toBeInTheDocument()
+    expect(mockApi.post).not.toHaveBeenCalled()
   })
 
   it('uses "session has expired" copy when 401 had a token (expiry case)', async () => {

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -283,6 +283,7 @@ export default function DiagramTranslator() {
 
   // Auth state — used for proactive gate and 401 error differentiation
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const hasBackendSession = useAuthStore((s) => s.hasBackendSession);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [authUploadRecovery, setAuthUploadRecovery] = useState(null);
 
@@ -1367,6 +1368,7 @@ export default function DiagramTranslator() {
           onRemoveFile={clearSelectedUpload}
           onLoadSample={handleLoadSample}
           isAuthenticated={isAuthenticated}
+          hasBackendSession={hasBackendSession}
           onSignIn={() => setLoginModalOpen(true)}
         />
       )}

--- a/frontend/src/stores/__tests__/useAuthStore.test.js
+++ b/frontend/src/stores/__tests__/useAuthStore.test.js
@@ -16,6 +16,7 @@ function resetAuthStore() {
   useAuthStore.setState({
     user: null,
     isAuthenticated: false,
+    hasBackendSession: false,
     isLoading: true,
     sessionToken: null,
   });
@@ -43,6 +44,7 @@ describe('useAuthStore', () => {
 
     const state = useAuthStore.getState();
     expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(false);
     expect(state.user).toMatchObject({
       id: 'aad_user-123',
       name: 'Ido Katz',
@@ -66,6 +68,7 @@ describe('useAuthStore', () => {
 
     const state = useAuthStore.getState();
     expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(true);
     expect(state.user).toMatchObject({ id: 'backend-user', name: 'Backend User' });
   });
 
@@ -85,12 +88,88 @@ describe('useAuthStore', () => {
 
     const state = useAuthStore.getState();
     expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(false);
     expect(state.user).toMatchObject({
       id: 'aad_user-123',
       name: 'Ido Katz',
       email: 'ido@example.com',
       provider: 'microsoft',
     });
+  });
+
+  it('uses a stored backend session before falling back to SWA-only auth', async () => {
+    localStorage.setItem('archmorph_session_token', 'valid-backend-token');
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ clientPrincipal: principal }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ authenticated: false, tier: 'free' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'token-user', name: 'Token User', provider: 'microsoft' }),
+      });
+
+    await useAuthStore.getState().initialize();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(true);
+    expect(state.sessionToken).toBe('valid-backend-token');
+    expect(state.user).toMatchObject({ id: 'token-user', name: 'Token User' });
+  });
+
+  it('clears a rejected stored backend token before falling back to SWA-only auth', async () => {
+    localStorage.setItem('archmorph_session_token', 'stale-backend-token');
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ clientPrincipal: principal }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ authenticated: false, tier: 'free' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ authenticated: false, tier: 'free' }),
+      });
+
+    await useAuthStore.getState().initialize();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(false);
+    expect(state.sessionToken).toBeNull();
+    expect(localStorage.getItem('archmorph_session_token')).toBeNull();
+    expect(state.user).toMatchObject({ id: 'aad_user-123' });
+  });
+
+  it('preserves a stored backend token when backend validation is indeterminate', async () => {
+    localStorage.setItem('archmorph_session_token', 'recoverable-backend-token');
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ clientPrincipal: principal }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ authenticated: false, tier: 'free' }),
+      })
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await useAuthStore.getState().initialize();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.hasBackendSession).toBe(false);
+    expect(state.sessionToken).toBeNull();
+    expect(localStorage.getItem('archmorph_session_token')).toBe('recoverable-backend-token');
+    expect(state.user).toMatchObject({ id: 'aad_user-123' });
   });
 
   it('preserves path, query string, and hash in SWA login redirects', () => {

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -83,6 +83,7 @@ const useAuthStore = create((set, get) => ({
   // ── State ──
   user: null,
   isAuthenticated: false,
+  hasBackendSession: false,
   isLoading: true,
   sessionToken: getStoredToken(),
 
@@ -109,15 +110,45 @@ const useAuthStore = create((set, get) => ({
               const shouldParseJson = !contentType || contentType.includes('application/json');
               const user = shouldParseJson ? await apiRes.json() : null;
               if (user && user.id) {
-                set({ user, isAuthenticated: true, isLoading: false });
+                set({ user, isAuthenticated: true, hasBackendSession: true, isLoading: false });
                 return;
               }
             } catch {
               // Fall back to SWA principal-derived profile when API auth route is misconfigured.
             }
           }
+          const token = getStoredToken();
+          if (token) {
+            let shouldClearStoredToken = false;
+            try {
+              const tokenRes = await fetch(`${API_BASE}/auth/me`, {
+                headers: {
+                  'Authorization': `Bearer ${token}`,
+                  'Content-Type': 'application/json',
+                },
+              });
+              if (tokenRes.ok) {
+                const user = await tokenRes.json();
+                if (user && user.id) {
+                  set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
+                  return;
+                }
+                const refreshed = await get()._tryRefresh();
+                if (refreshed) return;
+                shouldClearStoredToken = true;
+              }
+              else if (tokenRes.status >= 400 && tokenRes.status < 500) {
+                const refreshed = await get()._tryRefresh();
+                if (refreshed) return;
+                shouldClearStoredToken = true;
+              }
+            } catch {
+              // Preserve the token when validation failed for an indeterminate reason.
+            }
+            if (shouldClearStoredToken) clearTokens();
+          }
           if (swaUser) {
-            set({ user: swaUser, isAuthenticated: true, isLoading: false, sessionToken: null });
+            set({ user: swaUser, isAuthenticated: true, hasBackendSession: false, isLoading: false, sessionToken: null });
             return;
           }
         }
@@ -139,7 +170,7 @@ const useAuthStore = create((set, get) => ({
         if (res.ok) {
           const user = await res.json();
           if (user && user.id) {
-            set({ user, isAuthenticated: true, sessionToken: token, isLoading: false });
+            set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
             return;
           }
         }
@@ -152,7 +183,7 @@ const useAuthStore = create((set, get) => ({
     }
 
     // 3. Anonymous
-    set({ user: null, isAuthenticated: false, isLoading: false, sessionToken: null });
+    set({ user: null, isAuthenticated: false, hasBackendSession: false, isLoading: false, sessionToken: null });
   },
 
   // ── Login via provider (Azure SWA redirect) ──
@@ -183,6 +214,7 @@ const useAuthStore = create((set, get) => ({
       set({
         user: data.user,
         isAuthenticated: true,
+        hasBackendSession: true,
         sessionToken: data.session_token,
       });
       return true;
@@ -203,7 +235,7 @@ const useAuthStore = create((set, get) => ({
     } catch { /* best-effort */ }
 
     clearTokens();
-    set({ user: null, isAuthenticated: false, sessionToken: null });
+    set({ user: null, isAuthenticated: false, hasBackendSession: false, sessionToken: null });
 
     // Also try SWA logout
     try {
@@ -242,6 +274,7 @@ const useAuthStore = create((set, get) => ({
           set({
             user,
             isAuthenticated: true,
+            hasBackendSession: true,
             sessionToken: data.session_token,
             isLoading: false,
           });


### PR DESCRIPTION
## Summary
- distinguish frontend/SWA authentication from a usable backend API session
- block diagram analysis when the user is signed in to the SWA shell but the external API still reports no authenticated backend session
- add regression coverage so SWA-only auth cannot call upload/analyze and surface another misleading `Authentication required` result

## Production retest evidence
After #1095 deployed:
- `/.auth/me` is authenticated for the Google SWA session
- deployed frontend uses `https://api.archmorphai.com/api`
- `https://api.archmorphai.com/api/auth/me` returns JSON with `authenticated:false` from the browser context
- infra intentionally sets `TRUST_SWA_PRINCIPAL_HEADER=false` and Front Door blocks client-supplied `x-ms-client-principal`
- ActOne PDF Analyze still produced `Authentication required` with no upload/analyze fetch events

This PR is a truthful frontend guardrail. The remaining P0 architecture work in #1093 is to add a trusted SWA-to-backend session exchange or same-origin API path.

## Validation
- `npm --prefix frontend test -- --run src/stores/__tests__/useAuthStore.test.js src/components/DiagramTranslator/__tests__/UploadStep.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx`

Refs #1093.