### PR TITLE
fix: unblock backend deploy storage cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,15 +684,40 @@ jobs:
             -o json)
           ENV_JSON=$(echo "$CONTAINER_APP_JSON" | jq -c '.properties.template.containers[0].env // []')
 
-          STORAGE_ACCOUNT_URL=$(echo "$ENV_JSON" | jq -r '.[] | select(.name == "AZURE_STORAGE_ACCOUNT_URL") | .value // ""')
-          if [ -z "$STORAGE_ACCOUNT_URL" ]; then
+          CONTAINER_APP_STORAGE_ACCOUNT_URL=$(echo "$ENV_JSON" | jq -r '.[] | select(.name == "AZURE_STORAGE_ACCOUNT_URL") | .value // ""')
+          if [ -z "$CONTAINER_APP_STORAGE_ACCOUNT_URL" ]; then
             echo "::error::Container App is missing AZURE_STORAGE_ACCOUNT_URL. Configure it via Terraform-managed env vars before CI deploy."
             exit 1
           fi
-          STORAGE_NAME=$(echo "$STORAGE_ACCOUNT_URL" | sed -E 's#^https://([^.]+)\.blob\.core\.windows\.net/?$#\1#')
-          if [ -z "$STORAGE_NAME" ] || [ "$STORAGE_NAME" = "$STORAGE_ACCOUNT_URL" ]; then
-            echo "::error::Unable to parse storage account name from AZURE_STORAGE_ACCOUNT_URL=$STORAGE_ACCOUNT_URL"
+          CONTAINER_APP_STORAGE_NAME=$(echo "$CONTAINER_APP_STORAGE_ACCOUNT_URL" | sed -E 's#^https://([^.]+)\.blob\.core\.windows\.net/?$#\1#')
+          if [ -z "$CONTAINER_APP_STORAGE_NAME" ] || [ "$CONTAINER_APP_STORAGE_NAME" = "$CONTAINER_APP_STORAGE_ACCOUNT_URL" ]; then
+            echo "::error::Unable to parse storage account name from AZURE_STORAGE_ACCOUNT_URL=$CONTAINER_APP_STORAGE_ACCOUNT_URL"
             exit 1
+          fi
+          TERRAFORM_STORAGE_NAME=""
+          if ! terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-storage.log 2>&1; then
+            echo "::error::Unable to initialize Terraform remote state for storage output discovery"
+            tail -n 40 /tmp/terraform-init-storage.log || true
+            exit 1
+          fi
+
+          TERRAFORM_OUTPUT_ERROR=$(mktemp)
+          set +e
+          TERRAFORM_STORAGE_NAME=$(terraform -chdir=infra output -raw storage_account_name 2>"$TERRAFORM_OUTPUT_ERROR")
+          TERRAFORM_OUTPUT_STATUS=$?
+          set -e
+          if [ "$TERRAFORM_OUTPUT_STATUS" -ne 0 ] || [ -z "$TERRAFORM_STORAGE_NAME" ]; then
+            echo "::error::Unable to read Terraform storage_account_name output for deploy storage validation"
+            sed 's/^/terraform output: /' "$TERRAFORM_OUTPUT_ERROR" >&2
+            rm -f "$TERRAFORM_OUTPUT_ERROR"
+            exit 1
+          fi
+          rm -f "$TERRAFORM_OUTPUT_ERROR"
+
+          STORAGE_NAME="$TERRAFORM_STORAGE_NAME"
+          STORAGE_ACCOUNT_URL="https://${STORAGE_NAME}.blob.core.windows.net"
+          if [ "$CONTAINER_APP_STORAGE_NAME" != "$STORAGE_NAME" ]; then
+            echo "::notice::Container App still references legacy storage account ${CONTAINER_APP_STORAGE_NAME}; deploying Terraform-managed storage account ${STORAGE_NAME} for metrics cutover."
           fi
           echo "STORAGE_NAME=$STORAGE_NAME" >> "$GITHUB_ENV"
           echo "STORAGE_ACCOUNT_URL=$STORAGE_ACCOUNT_URL" >> "$GITHUB_ENV"
@@ -753,8 +778,8 @@ jobs:
               exit 1
             fi
             echo "::notice::Storage account $STORAGE_NAME has public network access ${PUBLIC_NETWORK_ACCESS} under ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=true; managed-identity blob preflight will prove RBAC data-plane access before traffic shift."
-            if [ "$STORAGE_NAME" = "archmorphmetrics" ]; then
-              echo "::notice::Container App still references legacy storage account $STORAGE_NAME until Terraform storage migration is applied."
+            if [ "$CONTAINER_APP_STORAGE_NAME" != "$STORAGE_NAME" ]; then
+              echo "::notice::Container App still references legacy storage account ${CONTAINER_APP_STORAGE_NAME} until Terraform storage migration is applied."
             fi
           fi
 

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -163,10 +163,14 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
     assert "PRIVATE_ENDPOINT_STATUS=$?" in validate_script
     assert "Unable to query private endpoint connections" in validate_script
+    assert "terraform -chdir=infra output -raw storage_account_name" in validate_script
+    assert "Unable to initialize Terraform remote state for storage output discovery" in validate_script
+    assert "Unable to read Terraform storage_account_name output for deploy storage validation" in validate_script
+    assert "Container App still references legacy storage account" in validate_script
+    assert "deploying Terraform-managed storage account" in validate_script
     assert "has public network access disabled but no approved private endpoint connection" in validate_script
     assert "ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER" in validate_script
     assert "managed-identity blob preflight will prove RBAC data-plane access" in validate_script
-    assert "Container App still references legacy storage account" in validate_script
 
 
 def test_backend_storage_validation_accepts_system_identity_until_user_identity_migration():

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -274,6 +274,9 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in ci_workflow
     assert "PRIVATE_ENDPOINT_STATUS=$?" in ci_workflow
     assert 'ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER: "true"' in ci_workflow
+    assert "terraform -chdir=infra output -raw storage_account_name" in ci_workflow
+    assert "Unable to read Terraform storage_account_name output for deploy storage validation" in ci_workflow
+    assert "deploying Terraform-managed storage account" in ci_workflow
     assert "managed-identity blob preflight will prove RBAC data-plane access" in ci_workflow
     assert 'select(.name == "AZURE_CLIENT_ID")' in ci_workflow
     assert "identity.userAssignedIdentities" in ci_workflow


### PR DESCRIPTION
## Summary
- discover the Terraform-managed metrics storage account during backend deploy validation
- validate the Terraform-managed storage account instead of failing on the legacy Container App storage URL during cutover
- preserve the private endpoint/public-network guardrail and add workflow contract coverage

## Validation
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py`

Fixes #1096.

Supersedes the Copilot app PR #1097, whose checks are stuck in `action_required` with no runnable jobs.