### PR TITLE
fix: discover deploy metrics storage via ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,27 +694,41 @@ jobs:
             echo "::error::Unable to parse storage account name from AZURE_STORAGE_ACCOUNT_URL=$CONTAINER_APP_STORAGE_ACCOUNT_URL"
             exit 1
           fi
-          TERRAFORM_STORAGE_NAME=""
-          if ! terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-storage.log 2>&1; then
-            echo "::error::Unable to initialize Terraform remote state for storage output discovery"
-            tail -n 40 /tmp/terraform-init-storage.log || true
+          TERRAFORM_STORAGE_CANDIDATES=$(az storage account list \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "[?tags.project=='archmorph' && tags.managed_by=='terraform' && tags.environment=='prod' && starts_with(name, 'archmorph')].name" \
+            -o tsv)
+          if [ -z "$TERRAFORM_STORAGE_CANDIDATES" ]; then
+            echo "::error::No Terraform-managed Archmorph storage accounts were found in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
             exit 1
           fi
 
-          TERRAFORM_OUTPUT_ERROR=$(mktemp)
-          set +e
-          TERRAFORM_STORAGE_NAME=$(terraform -chdir=infra output -raw storage_account_name 2>"$TERRAFORM_OUTPUT_ERROR")
-          TERRAFORM_OUTPUT_STATUS=$?
-          set -e
-          if [ "$TERRAFORM_OUTPUT_STATUS" -ne 0 ] || [ -z "$TERRAFORM_STORAGE_NAME" ]; then
-            echo "::error::Unable to read Terraform storage_account_name output for deploy storage validation"
-            sed 's/^/terraform output: /' "$TERRAFORM_OUTPUT_ERROR" >&2
-            rm -f "$TERRAFORM_OUTPUT_ERROR"
+          MATCHED_STORAGE_NAMES=()
+          for CANDIDATE_STORAGE_NAME in $TERRAFORM_STORAGE_CANDIDATES; do
+            CANDIDATE_STORAGE_ID=$(az storage account show \
+              --name "$CANDIDATE_STORAGE_NAME" \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --query id -o tsv)
+            CANDIDATE_METRICS_CONTAINER_ID="$CANDIDATE_STORAGE_ID/blobServices/default/containers/metrics"
+            set +e
+            CANDIDATE_METRICS_CONTAINER_RESOURCE=$(az rest \
+              --method get \
+              --uri "https://management.azure.com${CANDIDATE_METRICS_CONTAINER_ID}?api-version=2023-01-01" \
+              --query id -o tsv 2>/dev/null)
+            CANDIDATE_METRICS_CONTAINER_STATUS=$?
+            set -e
+            if [ "$CANDIDATE_METRICS_CONTAINER_STATUS" -eq 0 ] && [ "$CANDIDATE_METRICS_CONTAINER_RESOURCE" = "$CANDIDATE_METRICS_CONTAINER_ID" ]; then
+              MATCHED_STORAGE_NAMES+=("$CANDIDATE_STORAGE_NAME")
+            fi
+          done
+
+          if [ "${#MATCHED_STORAGE_NAMES[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Terraform-managed Archmorph storage account with a metrics container, found ${#MATCHED_STORAGE_NAMES[@]}"
+            printf 'Candidates: %s\n' $TERRAFORM_STORAGE_CANDIDATES
             exit 1
           fi
-          rm -f "$TERRAFORM_OUTPUT_ERROR"
 
-          STORAGE_NAME="$TERRAFORM_STORAGE_NAME"
+          STORAGE_NAME="${MATCHED_STORAGE_NAMES[0]}"
           STORAGE_ACCOUNT_URL="https://${STORAGE_NAME}.blob.core.windows.net"
           if [ "$CONTAINER_APP_STORAGE_NAME" != "$STORAGE_NAME" ]; then
             echo "::notice::Container App still references legacy storage account ${CONTAINER_APP_STORAGE_NAME}; deploying Terraform-managed storage account ${STORAGE_NAME} for metrics cutover."

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -163,9 +163,11 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
     assert "PRIVATE_ENDPOINT_STATUS=$?" in validate_script
     assert "Unable to query private endpoint connections" in validate_script
-    assert "terraform -chdir=infra output -raw storage_account_name" in validate_script
-    assert "Unable to initialize Terraform remote state for storage output discovery" in validate_script
-    assert "Unable to read Terraform storage_account_name output for deploy storage validation" in validate_script
+    assert "TERRAFORM_STORAGE_CANDIDATES=$(az storage account list" in validate_script
+    assert "tags.project=='archmorph'" in validate_script
+    assert "tags.managed_by=='terraform'" in validate_script
+    assert "CANDIDATE_METRICS_CONTAINER_ID" in validate_script
+    assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in validate_script
     assert "Container App still references legacy storage account" in validate_script
     assert "deploying Terraform-managed storage account" in validate_script
     assert "has public network access disabled but no approved private endpoint connection" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -274,8 +274,11 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in ci_workflow
     assert "PRIVATE_ENDPOINT_STATUS=$?" in ci_workflow
     assert 'ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER: "true"' in ci_workflow
-    assert "terraform -chdir=infra output -raw storage_account_name" in ci_workflow
-    assert "Unable to read Terraform storage_account_name output for deploy storage validation" in ci_workflow
+    assert "TERRAFORM_STORAGE_CANDIDATES=$(az storage account list" in ci_workflow
+    assert "tags.project=='archmorph'" in ci_workflow
+    assert "tags.managed_by=='terraform'" in ci_workflow
+    assert "CANDIDATE_METRICS_CONTAINER_ID" in ci_workflow
+    assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in ci_workflow
     assert "deploying Terraform-managed storage account" in ci_workflow
     assert "managed-identity blob preflight will prove RBAC data-plane access" in ci_workflow
     assert 'select(.name == "AZURE_CLIENT_ID")' in ci_workflow


### PR DESCRIPTION
## Summary
- replace deploy-backend Terraform remote-state output discovery with ARM storage-account discovery
- select the Terraform-managed Archmorph storage account by tags and the presence of the metrics container
- keep failing closed when no unique managed metrics storage account is found

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to #1096 after main deploy showed Terraform backend init is blocked by tfstate storage 403.