### PR TITLE
fix: discover untagged deploy metrics storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,7 +699,14 @@ jobs:
             --query "[?tags.project=='archmorph' && tags.managed_by=='terraform' && tags.environment=='prod' && starts_with(name, 'archmorph')].name" \
             -o tsv)
           if [ -z "$TERRAFORM_STORAGE_CANDIDATES" ]; then
-            echo "::error::No Terraform-managed Archmorph storage accounts were found in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
+            echo "::notice::No tagged Terraform-managed Archmorph storage accounts were found; falling back to Archmorph storage name discovery."
+            TERRAFORM_STORAGE_CANDIDATES=$(az storage account list \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --query "[?starts_with(name, 'archmorph') && name!='archmorphmetrics'].name" \
+              -o tsv)
+          fi
+          if [ -z "$TERRAFORM_STORAGE_CANDIDATES" ]; then
+            echo "::error::No Terraform-managed Archmorph storage account candidates were found in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
             exit 1
           fi
 

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -166,6 +166,9 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "TERRAFORM_STORAGE_CANDIDATES=$(az storage account list" in validate_script
     assert "tags.project=='archmorph'" in validate_script
     assert "tags.managed_by=='terraform'" in validate_script
+    assert "No tagged Terraform-managed Archmorph storage accounts were found" in validate_script
+    assert "name!='archmorphmetrics'" in validate_script
+    assert "No Terraform-managed Archmorph storage account candidates were found" in validate_script
     assert "CANDIDATE_METRICS_CONTAINER_ID" in validate_script
     assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in validate_script
     assert "Container App still references legacy storage account" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -277,6 +277,9 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "TERRAFORM_STORAGE_CANDIDATES=$(az storage account list" in ci_workflow
     assert "tags.project=='archmorph'" in ci_workflow
     assert "tags.managed_by=='terraform'" in ci_workflow
+    assert "No tagged Terraform-managed Archmorph storage accounts were found" in ci_workflow
+    assert "name!='archmorphmetrics'" in ci_workflow
+    assert "No Terraform-managed Archmorph storage account candidates were found" in ci_workflow
     assert "CANDIDATE_METRICS_CONTAINER_ID" in ci_workflow
     assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in ci_workflow
     assert "deploying Terraform-managed storage account" in ci_workflow


### PR DESCRIPTION
## Summary
- add a fallback for deploy storage discovery when Terraform-managed storage is missing expected tags
- scan Archmorph-named storage accounts while excluding the known legacy `archmorphmetrics` account
- still require exactly one candidate with a `metrics` container before deployment proceeds

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to #1096/#1100 after main deploy showed no tagged Terraform-managed storage accounts in the resource group.