### PR TITLE
fix: ensure deploy metrics container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,31 +711,49 @@ jobs:
           fi
 
           MATCHED_STORAGE_NAMES=()
+          CANDIDATE_STORAGE_NAMES=()
+          NOT_FOUND_STORAGE_NAMES=()
           for CANDIDATE_STORAGE_NAME in $TERRAFORM_STORAGE_CANDIDATES; do
+            CANDIDATE_STORAGE_NAMES+=("$CANDIDATE_STORAGE_NAME")
             CANDIDATE_STORAGE_ID=$(az storage account show \
               --name "$CANDIDATE_STORAGE_NAME" \
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --query id -o tsv)
             CANDIDATE_METRICS_CONTAINER_ID="$CANDIDATE_STORAGE_ID/blobServices/default/containers/metrics"
+            CANDIDATE_METRICS_CONTAINER_ERROR=$(mktemp)
             set +e
             CANDIDATE_METRICS_CONTAINER_RESOURCE=$(az rest \
               --method get \
               --uri "https://management.azure.com${CANDIDATE_METRICS_CONTAINER_ID}?api-version=2023-01-01" \
-              --query id -o tsv 2>/dev/null)
+              --query id -o tsv 2>"$CANDIDATE_METRICS_CONTAINER_ERROR")
             CANDIDATE_METRICS_CONTAINER_STATUS=$?
             set -e
             if [ "$CANDIDATE_METRICS_CONTAINER_STATUS" -eq 0 ] && [ "$CANDIDATE_METRICS_CONTAINER_RESOURCE" = "$CANDIDATE_METRICS_CONTAINER_ID" ]; then
               MATCHED_STORAGE_NAMES+=("$CANDIDATE_STORAGE_NAME")
+            elif grep -Eiq 'StatusCode=404|ResourceNotFound|ContainerNotFound|NotFound' "$CANDIDATE_METRICS_CONTAINER_ERROR"; then
+              NOT_FOUND_STORAGE_NAMES+=("$CANDIDATE_STORAGE_NAME")
+            else
+              echo "::error::Unable to query metrics container for storage account $CANDIDATE_STORAGE_NAME through Azure Resource Manager"
+              sed 's/^/az rest: /' "$CANDIDATE_METRICS_CONTAINER_ERROR" >&2
+              rm -f "$CANDIDATE_METRICS_CONTAINER_ERROR"
+              exit 1
             fi
+            rm -f "$CANDIDATE_METRICS_CONTAINER_ERROR"
           done
 
-          if [ "${#MATCHED_STORAGE_NAMES[@]}" -ne 1 ]; then
+          CREATE_METRICS_CONTAINER=false
+          if [ "${#MATCHED_STORAGE_NAMES[@]}" -eq 1 ]; then
+            STORAGE_NAME="${MATCHED_STORAGE_NAMES[0]}"
+          elif [ "${#MATCHED_STORAGE_NAMES[@]}" -eq 0 ] && [ "${#CANDIDATE_STORAGE_NAMES[@]}" -eq 1 ] && [ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]; then
+            STORAGE_NAME="${CANDIDATE_STORAGE_NAMES[0]}"
+            CREATE_METRICS_CONTAINER=true
+            echo "::notice::Metrics container was not found on storage account $STORAGE_NAME; creating it through Azure Resource Manager before validation."
+          else
             echo "::error::Expected exactly one Terraform-managed Archmorph storage account with a metrics container, found ${#MATCHED_STORAGE_NAMES[@]}"
             printf 'Candidates: %s\n' $TERRAFORM_STORAGE_CANDIDATES
             exit 1
           fi
 
-          STORAGE_NAME="${MATCHED_STORAGE_NAMES[0]}"
           STORAGE_ACCOUNT_URL="https://${STORAGE_NAME}.blob.core.windows.net"
           if [ "$CONTAINER_APP_STORAGE_NAME" != "$STORAGE_NAME" ]; then
             echo "::notice::Container App still references legacy storage account ${CONTAINER_APP_STORAGE_NAME}; deploying Terraform-managed storage account ${STORAGE_NAME} for metrics cutover."
@@ -805,6 +823,14 @@ jobs:
           fi
 
           METRICS_CONTAINER_ID="$STORAGE_ID/blobServices/default/containers/metrics"
+          if [ "$CREATE_METRICS_CONTAINER" = "true" ]; then
+            az rest \
+              --method put \
+              --uri "https://management.azure.com${METRICS_CONTAINER_ID}?api-version=2023-01-01" \
+              --body '{"properties":{"publicAccess":"None"}}' \
+              --only-show-errors >/dev/null
+          fi
+
           METRICS_CONTAINER_ERROR=$(mktemp)
           set +e
           METRICS_CONTAINER_RESOURCE=$(az rest \

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -170,6 +170,14 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "name!='archmorphmetrics'" in validate_script
     assert "No Terraform-managed Archmorph storage account candidates were found" in validate_script
     assert "CANDIDATE_METRICS_CONTAINER_ID" in validate_script
+    assert "NOT_FOUND_STORAGE_NAMES=()" in validate_script
+    assert "StatusCode=404|ResourceNotFound|ContainerNotFound|NotFound" in validate_script
+    assert "Unable to query metrics container for storage account" in validate_script
+    assert "CREATE_METRICS_CONTAINER=true" in validate_script
+    assert '[ "${#CANDIDATE_STORAGE_NAMES[@]}" -eq 1 ]' in validate_script
+    assert '[ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]' in validate_script
+    assert "Metrics container was not found on storage account" in validate_script
+    assert "publicAccess\":\"None" in validate_script
     assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in validate_script
     assert "Container App still references legacy storage account" in validate_script
     assert "deploying Terraform-managed storage account" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -281,6 +281,14 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "name!='archmorphmetrics'" in ci_workflow
     assert "No Terraform-managed Archmorph storage account candidates were found" in ci_workflow
     assert "CANDIDATE_METRICS_CONTAINER_ID" in ci_workflow
+    assert "NOT_FOUND_STORAGE_NAMES=()" in ci_workflow
+    assert "StatusCode=404|ResourceNotFound|ContainerNotFound|NotFound" in ci_workflow
+    assert "Unable to query metrics container for storage account" in ci_workflow
+    assert "CREATE_METRICS_CONTAINER=true" in ci_workflow
+    assert '[ "${#CANDIDATE_STORAGE_NAMES[@]}" -eq 1 ]' in ci_workflow
+    assert '[ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]' in ci_workflow
+    assert "Metrics container was not found on storage account" in ci_workflow
+    assert "publicAccess\":\"None" in ci_workflow
     assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in ci_workflow
     assert "deploying Terraform-managed storage account" in ci_workflow
     assert "managed-identity blob preflight will prove RBAC data-plane access" in ci_workflow


### PR DESCRIPTION
## Summary
- allow deploy storage discovery to select a single non-legacy Archmorph storage candidate even before `metrics` exists
- create the private `metrics` blob container through ARM in that unambiguous case
- keep failing closed when candidate selection is ambiguous

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to #1096/#1101 after main deploy found candidates but no visible `metrics` container.