### PR TITLE
fix: read storage network rules from account shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,14 +812,15 @@ jobs:
                 echo "::error::Storage account $STORAGE_NAME has public network access disabled but no approved private endpoint connection. Set ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=true only for the reviewed hardening-disabled cutover, or apply Terraform private endpoint networking before CI deploy."
                 exit 1
               fi
-              STORAGE_NETWORK_RULES=$(az storage account network-rule list \
-                --account-name "$STORAGE_NAME" \
+              STORAGE_NETWORK_RULES=$(az storage account show \
+                --name "$STORAGE_NAME" \
                 --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
                 --only-show-errors \
+                --query networkRuleSet \
                 -o json)
-              NETWORK_DEFAULT_ACTION=$(echo "$STORAGE_NETWORK_RULES" | jq -r '.defaultAction // ""')
-              NETWORK_IP_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '.ipRules // [] | length')
-              CONTAINER_APPS_VNET_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // [] | .[] | select(((.id // .virtualNetworkResourceId // "") | endswith("/subnets/container-apps-subnet")) and (.state == "Succeeded"))] | length')
+              NETWORK_DEFAULT_ACTION=$(echo "$STORAGE_NETWORK_RULES" | jq -r '.defaultAction // .default_action // ""')
+              NETWORK_IP_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '.ipRules // .ip_rules // [] | length')
+              CONTAINER_APPS_VNET_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")) and (.state == "Succeeded"))] | length')
               if [ "$NETWORK_DEFAULT_ACTION" != "Deny" ]; then
                 echo "::error::Storage account $STORAGE_NAME network rules must keep defaultAction=Deny before public network cutover; found ${NETWORK_DEFAULT_ACTION:-unset}"
                 exit 1

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -178,10 +178,15 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert '[ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]' in validate_script
     assert "Metrics container was not found on storage account" in validate_script
     assert "publicAccess\":\"None" in validate_script
-    assert "az storage account network-rule list" in validate_script
+    assert "STORAGE_NETWORK_RULES=$(az storage account show" in validate_script
+    assert "--query networkRuleSet" in validate_script
     assert 'NETWORK_DEFAULT_ACTION" != "Deny"' in validate_script
+    assert '.defaultAction // .default_action // ""' in validate_script
     assert 'NETWORK_IP_RULE_COUNT" != "0"' in validate_script
+    assert '.ipRules // .ip_rules // [] | length' in validate_script
     assert 'endswith("/subnets/container-apps-subnet")' in validate_script
+    assert '.virtualNetworkRules // .virtual_network_rules // []' in validate_script
+    assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in validate_script
     assert '.state == "Succeeded"' in validate_script
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in validate_script
     assert "for public_access_attempt in" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -289,10 +289,15 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert '[ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]' in ci_workflow
     assert "Metrics container was not found on storage account" in ci_workflow
     assert "publicAccess\":\"None" in ci_workflow
-    assert "az storage account network-rule list" in ci_workflow
+    assert "STORAGE_NETWORK_RULES=$(az storage account show" in ci_workflow
+    assert "--query networkRuleSet" in ci_workflow
     assert 'NETWORK_DEFAULT_ACTION" != "Deny"' in ci_workflow
+    assert '.defaultAction // .default_action // ""' in ci_workflow
     assert 'NETWORK_IP_RULE_COUNT" != "0"' in ci_workflow
+    assert '.ipRules // .ip_rules // [] | length' in ci_workflow
     assert 'endswith("/subnets/container-apps-subnet")' in ci_workflow
+    assert '.virtualNetworkRules // .virtual_network_rules // []' in ci_workflow
+    assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in ci_workflow
     assert '.state == "Succeeded"' in ci_workflow
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in ci_workflow
     assert "for public_access_attempt in" in ci_workflow


### PR DESCRIPTION
## Summary
- read storage firewall posture from az storage account show --query networkRuleSet instead of az storage account network-rule list
- keep the cutover fail-closed on defaultAction=Deny, zero IP allow rules, and exactly one succeeded container-apps-subnet VNet rule
- accept both camelCase and snake_case Azure CLI key shapes for robust parsing

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to the main deploy failure after #1103: networkRuleSet.defaultAction was read as unset from the network-rule list output.