### PR TITLE
fix: harden storage default action during cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,10 +821,6 @@ jobs:
               NETWORK_DEFAULT_ACTION=$(echo "$STORAGE_NETWORK_RULES" | jq -r '.defaultAction // .default_action // ""')
               NETWORK_IP_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '.ipRules // .ip_rules // [] | length')
               CONTAINER_APPS_VNET_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")) and (.state == "Succeeded"))] | length')
-              if [ "$NETWORK_DEFAULT_ACTION" != "Deny" ]; then
-                echo "::error::Storage account $STORAGE_NAME network rules must keep defaultAction=Deny before public network cutover; found ${NETWORK_DEFAULT_ACTION:-unset}"
-                exit 1
-              fi
               if [ "$NETWORK_IP_RULE_COUNT" != "0" ]; then
                 echo "::error::Storage account $STORAGE_NAME must not have IP firewall allow rules before public network cutover; found $NETWORK_IP_RULE_COUNT"
                 exit 1
@@ -832,6 +828,34 @@ jobs:
               if [ "$CONTAINER_APPS_VNET_RULE_COUNT" != "1" ]; then
                 echo "::error::Storage account $STORAGE_NAME must have exactly one succeeded container-apps-subnet virtual network rule before public network cutover; found $CONTAINER_APPS_VNET_RULE_COUNT"
                 exit 1
+              fi
+              if [ "$NETWORK_DEFAULT_ACTION" != "Deny" ]; then
+                if [ "$NETWORK_DEFAULT_ACTION" != "Allow" ]; then
+                  echo "::error::Storage account $STORAGE_NAME network rules must keep defaultAction=Deny before public network cutover; found ${NETWORK_DEFAULT_ACTION:-unset}"
+                  exit 1
+                fi
+                echo "::notice::Storage account $STORAGE_NAME has defaultAction=Allow; hardening to Deny before enabling public network access."
+                az storage account update \
+                  --name "$STORAGE_NAME" \
+                  --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                  --default-action Deny \
+                  --only-show-errors >/dev/null
+                for default_action_attempt in 1 2 3 4 5; do
+                  NETWORK_DEFAULT_ACTION=$(az storage account show \
+                    --name "$STORAGE_NAME" \
+                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                    --only-show-errors \
+                    --query "networkRuleSet.defaultAction" -o tsv)
+                  if [ "$NETWORK_DEFAULT_ACTION" = "Deny" ]; then
+                    break
+                  fi
+                  echo "Storage account $STORAGE_NAME network defaultAction is ${NETWORK_DEFAULT_ACTION:-unset}; waiting for Deny propagation (attempt $default_action_attempt/5)"
+                  sleep 5
+                done
+                if [ "$NETWORK_DEFAULT_ACTION" != "Deny" ]; then
+                  echo "::error::Storage account $STORAGE_NAME defaultAction hardening did not reach Deny; found ${NETWORK_DEFAULT_ACTION:-unset}"
+                  exit 1
+                fi
               fi
               echo "::notice::Storage account $STORAGE_NAME has public network access disabled and no approved private endpoint; enabling public network access under ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER=true for this deploy cutover."
               az storage account update \

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -188,6 +188,11 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert '.virtualNetworkRules // .virtual_network_rules // []' in validate_script
     assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in validate_script
     assert '.state == "Succeeded"' in validate_script
+    assert "has defaultAction=Allow; hardening to Deny before enabling public network access" in validate_script
+    assert "--default-action Deny" in validate_script
+    assert "for default_action_attempt in" in validate_script
+    assert "waiting for Deny propagation" in validate_script
+    assert "defaultAction hardening did not reach Deny" in validate_script
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in validate_script
     assert "for public_access_attempt in" in validate_script
     assert "waiting for update propagation" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -299,6 +299,11 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert '.virtualNetworkRules // .virtual_network_rules // []' in ci_workflow
     assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in ci_workflow
     assert '.state == "Succeeded"' in ci_workflow
+    assert "has defaultAction=Allow; hardening to Deny before enabling public network access" in ci_workflow
+    assert "--default-action Deny" in ci_workflow
+    assert "for default_action_attempt in" in ci_workflow
+    assert "waiting for Deny propagation" in ci_workflow
+    assert "defaultAction hardening did not reach Deny" in ci_workflow
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in ci_workflow
     assert "for public_access_attempt in" in ci_workflow
     assert "waiting for update propagation" in ci_workflow


### PR DESCRIPTION
## Summary
- harden a drifted metrics storage account from defaultAction=Allow to Deny before enabling public network access
- only perform that remediation after proving there are zero IP allow rules and exactly one succeeded container-apps-subnet VNet rule
- poll for defaultAction=Deny before continuing with the existing public-network-access cutover

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to the main deploy failure after #1114: the target storage account now reports networkRuleSet.defaultAction=Allow, which the guard correctly blocks before public network access can be enabled.