### PR TITLE
fix: add storage vnet rule during cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,13 +820,69 @@ jobs:
                 -o json)
               NETWORK_DEFAULT_ACTION=$(echo "$STORAGE_NETWORK_RULES" | jq -r '.defaultAction // .default_action // ""')
               NETWORK_IP_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '.ipRules // .ip_rules // [] | length')
+              CONTAINER_APPS_VNET_RULE_TOTAL_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")))] | length')
               CONTAINER_APPS_VNET_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")) and (.state == "Succeeded"))] | length')
               if [ "$NETWORK_IP_RULE_COUNT" != "0" ]; then
                 echo "::error::Storage account $STORAGE_NAME must not have IP firewall allow rules before public network cutover; found $NETWORK_IP_RULE_COUNT"
                 exit 1
               fi
-              if [ "$CONTAINER_APPS_VNET_RULE_COUNT" != "1" ]; then
-                echo "::error::Storage account $STORAGE_NAME must have exactly one succeeded container-apps-subnet virtual network rule before public network cutover; found $CONTAINER_APPS_VNET_RULE_COUNT"
+              if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" -gt "1" ]; then
+                echo "::error::Storage account $STORAGE_NAME must not have duplicate container-apps-subnet virtual network rules; found $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT"
+                exit 1
+              fi
+              if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" = "0" ]; then
+                CONTAINER_APP_ENV_ID=$(az containerapp show \
+                  --name "${{ env.CONTAINER_APP_NAME }}" \
+                  --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                  --only-show-errors \
+                  --query properties.managedEnvironmentId -o tsv)
+                if [ -z "$CONTAINER_APP_ENV_ID" ]; then
+                  echo "::error::Unable to discover Container Apps managed environment ID for storage network rule cutover"
+                  exit 1
+                fi
+                CONTAINER_APPS_SUBNET_ID=$(az resource show \
+                  --ids "$CONTAINER_APP_ENV_ID" \
+                  --api-version 2023-05-01 \
+                  --only-show-errors \
+                  --query properties.vnetConfiguration.infrastructureSubnetId -o tsv)
+                if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+                  echo "::error::Unable to discover Container Apps environment infrastructure subnet ID for storage network rule cutover"
+                  exit 1
+                fi
+                if [[ "$CONTAINER_APPS_SUBNET_ID" != */subnets/container-apps-subnet ]]; then
+                  echo "::error::Container Apps environment infrastructure subnet must be container-apps-subnet before storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID"
+                  exit 1
+                fi
+                echo "::notice::Storage account $STORAGE_NAME is missing the container-apps-subnet rule; adding it before public network cutover."
+                az storage account network-rule add \
+                  --account-name "$STORAGE_NAME" \
+                  --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                  --subnet "$CONTAINER_APPS_SUBNET_ID" \
+                  --only-show-errors >/dev/null
+              fi
+              if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" != "1" ] || [ "$CONTAINER_APPS_VNET_RULE_COUNT" != "1" ]; then
+                for vnet_rule_attempt in 1 2 3 4 5; do
+                  STORAGE_NETWORK_RULES=$(az storage account show \
+                    --name "$STORAGE_NAME" \
+                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                    --only-show-errors \
+                    --query networkRuleSet \
+                    -o json)
+                  CONTAINER_APPS_VNET_RULE_TOTAL_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")))] | length')
+                  CONTAINER_APPS_VNET_RULE_COUNT=$(echo "$STORAGE_NETWORK_RULES" | jq '[.virtualNetworkRules // .virtual_network_rules // [] | .[] | select(((.id // .virtualNetworkResourceId // .virtual_network_resource_id // "") | endswith("/subnets/container-apps-subnet")) and (.state == "Succeeded"))] | length')
+                  if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" -gt "1" ]; then
+                    echo "::error::Storage account $STORAGE_NAME must not have duplicate container-apps-subnet virtual network rules; found $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT"
+                    exit 1
+                  fi
+                  if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" = "1" ] && [ "$CONTAINER_APPS_VNET_RULE_COUNT" = "1" ]; then
+                    break
+                  fi
+                  echo "Storage account $STORAGE_NAME container-apps-subnet rule count is $CONTAINER_APPS_VNET_RULE_COUNT succeeded of $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT total; waiting for VNet rule propagation (attempt $vnet_rule_attempt/5)"
+                  sleep 5
+                done
+              fi
+              if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" != "1" ] || [ "$CONTAINER_APPS_VNET_RULE_COUNT" != "1" ]; then
+                echo "::error::Storage account $STORAGE_NAME must have exactly one succeeded container-apps-subnet virtual network rule before public network cutover; found $CONTAINER_APPS_VNET_RULE_COUNT succeeded of $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT total"
                 exit 1
               fi
               if [ "$NETWORK_DEFAULT_ACTION" != "Deny" ]; then

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -188,6 +188,20 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert '.virtualNetworkRules // .virtual_network_rules // []' in validate_script
     assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in validate_script
     assert '.state == "Succeeded"' in validate_script
+    assert "CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" in validate_script
+    assert "must not have duplicate container-apps-subnet virtual network rules" in validate_script
+    assert "CONTAINER_APP_ENV_ID=$(az containerapp show" in validate_script
+    assert "--query properties.managedEnvironmentId" in validate_script
+    assert "Unable to discover Container Apps managed environment ID" in validate_script
+    assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in validate_script
+    assert "--query properties.vnetConfiguration.infrastructureSubnetId" in validate_script
+    assert "Unable to discover Container Apps environment infrastructure subnet ID" in validate_script
+    assert "must be container-apps-subnet before storage network rule cutover" in validate_script
+    assert "az storage account network-rule add" in validate_script
+    assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in validate_script
+    assert "for vnet_rule_attempt in" in validate_script
+    assert "succeeded of $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT total" in validate_script
+    assert "waiting for VNet rule propagation" in validate_script
     assert "has defaultAction=Allow; hardening to Deny before enabling public network access" in validate_script
     assert "--default-action Deny" in validate_script
     assert "for default_action_attempt in" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -299,6 +299,20 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert '.virtualNetworkRules // .virtual_network_rules // []' in ci_workflow
     assert '.virtualNetworkResourceId // .virtual_network_resource_id // ""' in ci_workflow
     assert '.state == "Succeeded"' in ci_workflow
+    assert "CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" in ci_workflow
+    assert "must not have duplicate container-apps-subnet virtual network rules" in ci_workflow
+    assert "CONTAINER_APP_ENV_ID=$(az containerapp show" in ci_workflow
+    assert "--query properties.managedEnvironmentId" in ci_workflow
+    assert "Unable to discover Container Apps managed environment ID" in ci_workflow
+    assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in ci_workflow
+    assert "--query properties.vnetConfiguration.infrastructureSubnetId" in ci_workflow
+    assert "Unable to discover Container Apps environment infrastructure subnet ID" in ci_workflow
+    assert "must be container-apps-subnet before storage network rule cutover" in ci_workflow
+    assert "az storage account network-rule add" in ci_workflow
+    assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in ci_workflow
+    assert "for vnet_rule_attempt in" in ci_workflow
+    assert "succeeded of $CONTAINER_APPS_VNET_RULE_TOTAL_COUNT total" in ci_workflow
+    assert "waiting for VNet rule propagation" in ci_workflow
     assert "has defaultAction=Allow; hardening to Deny before enabling public network access" in ci_workflow
     assert "--default-action Deny" in ci_workflow
     assert "for default_action_attempt in" in ci_workflow


### PR DESCRIPTION
## Summary
- discover the Terraform-created container-apps-subnet during the reviewed storage cutover
- add the missing storage account VNet rule when it is absent, then poll until it is succeeded
- keep fail-closed behavior for IP allow rules, unexpected VNet rule counts, defaultAction hardening, and public-network-access propagation

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to the main deploy failure after #1115: the target storage account had zero succeeded container-apps-subnet virtual network rules, which the guard correctly blocked.