### PR TITLE
fix: fall back to unique container apps subnet discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,10 +844,18 @@ jobs:
                   --ids "$CONTAINER_APP_ENV_ID" \
                   --api-version 2023-05-01 \
                   --only-show-errors \
-                  --query properties.vnetConfiguration.infrastructureSubnetId -o tsv)
+                  --query properties.vnetConfiguration.infrastructureSubnetId -o tsv 2>/dev/null || true)
                 if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
-                  echo "::error::Unable to discover Container Apps environment infrastructure subnet ID for storage network rule cutover"
-                  exit 1
+                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                    --only-show-errors \
+                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
+                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" != "1" ]; then
+                    echo "::error::Unable to uniquely discover container-apps-subnet ID for storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                    exit 1
+                  fi
+                  CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
                 fi
                 if [[ "$CONTAINER_APPS_SUBNET_ID" != */subnets/container-apps-subnet ]]; then
                   echo "::error::Container Apps environment infrastructure subnet must be container-apps-subnet before storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID"

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -195,7 +195,10 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "Unable to discover Container Apps managed environment ID" in validate_script
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in validate_script
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in validate_script
-    assert "Unable to discover Container Apps environment infrastructure subnet ID" in validate_script
+    assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in validate_script
+    assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in validate_script
+    assert "CONTAINER_APPS_SUBNET_ID_COUNT" in validate_script
+    assert "Unable to uniquely discover container-apps-subnet ID" in validate_script
     assert "must be container-apps-subnet before storage network rule cutover" in validate_script
     assert "az storage account network-rule add" in validate_script
     assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -306,7 +306,10 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "Unable to discover Container Apps managed environment ID" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in ci_workflow
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in ci_workflow
-    assert "Unable to discover Container Apps environment infrastructure subnet ID" in ci_workflow
+    assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in ci_workflow
+    assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in ci_workflow
+    assert "CONTAINER_APPS_SUBNET_ID_COUNT" in ci_workflow
+    assert "Unable to uniquely discover container-apps-subnet ID" in ci_workflow
     assert "must be container-apps-subnet before storage network rule cutover" in ci_workflow
     assert "az storage account network-rule add" in ci_workflow
     assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in ci_workflow


### PR DESCRIPTION
## Summary
- keep the Container Apps managed-environment subnet lookup when it is available
- fall back to enumerating container-apps-subnet in the resource group only when exactly one candidate exists
- preserve fail-closed behavior for ambiguous subnet discovery, duplicate storage VNet rules, and non-succeeded VNet rule propagation

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to main run 26078432122: the live Container Apps environment did not expose properties.vnetConfiguration.infrastructureSubnetId, so the storage cutover could not discover the subnet ID.