### PR TITLE
fix: discover storage subnet from terraform state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,16 +846,31 @@ jobs:
                   --only-show-errors \
                   --query properties.vnetConfiguration.infrastructureSubnetId -o tsv 2>/dev/null || true)
                 if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
-                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
-                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-                    --only-show-errors \
-                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
-                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
-                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" != "1" ]; then
-                    echo "::error::Unable to uniquely discover container-apps-subnet ID for storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
-                    exit 1
+                  TERRAFORM_SUBNET_ERROR=$(mktemp)
+                  if terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-container-apps-subnet.log 2>&1; then
+                    CONTAINER_APPS_SUBNET_ID=$(terraform -chdir=infra state show -no-color azurerm_subnet.container_apps 2>"$TERRAFORM_SUBNET_ERROR" \
+                      | awk -F'= ' '/^[[:space:]]*id[[:space:]]*=/{gsub(/"/, "", $2); print $2; exit}')
+                  else
+                    echo "::warning::Unable to initialize Terraform remote state for container-apps-subnet discovery"
+                    sed 's/^/terraform init: /' /tmp/terraform-init-container-apps-subnet.log >&2
                   fi
-                  CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                  if [ -n "$CONTAINER_APPS_SUBNET_ID" ]; then
+                    echo "::notice::Discovered container-apps-subnet ID from Terraform state for storage network rule cutover."
+                  else
+                    sed 's/^/terraform state show: /' "$TERRAFORM_SUBNET_ERROR" >&2
+                    CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+                      --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                      --only-show-errors \
+                      --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
+                    CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+                    if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" != "1" ]; then
+                      echo "::error::Unable to uniquely discover container-apps-subnet ID for storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                      rm -f "$TERRAFORM_SUBNET_ERROR"
+                      exit 1
+                    fi
+                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                  fi
+                  rm -f "$TERRAFORM_SUBNET_ERROR"
                 fi
                 if [[ "$CONTAINER_APPS_SUBNET_ID" != */subnets/container-apps-subnet ]]; then
                   echo "::error::Container Apps environment infrastructure subnet must be container-apps-subnet before storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID"

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -195,6 +195,9 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "Unable to discover Container Apps managed environment ID" in validate_script
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in validate_script
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in validate_script
+    assert "terraform -chdir=infra init -input=false -lockfile=readonly" in validate_script
+    assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in validate_script
+    assert "Discovered container-apps-subnet ID from Terraform state" in validate_script
     assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in validate_script
     assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in validate_script
     assert "CONTAINER_APPS_SUBNET_ID_COUNT" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -306,6 +306,9 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "Unable to discover Container Apps managed environment ID" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in ci_workflow
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in ci_workflow
+    assert "terraform -chdir=infra init -input=false -lockfile=readonly" in ci_workflow
+    assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in ci_workflow
+    assert "Discovered container-apps-subnet ID from Terraform state" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in ci_workflow
     assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID_COUNT" in ci_workflow


### PR DESCRIPTION
## Summary
- prefer the Terraform state resource azurerm_subnet.container_apps when the Container Apps environment omits infrastructureSubnetId
- retain the unique live subnet fallback only after Terraform state discovery is unavailable
- keep fail-closed behavior for ambiguous subnet discovery, duplicate storage VNet rules, and non-succeeded VNet rule propagation

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to main run 26078992787: live resource-group enumeration found zero container-apps-subnet candidates, so the workflow needs to use the Terraform-managed subnet from remote state as the source of truth.