### PR TITLE
fix: discover storage subnet across subscription

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,6 +676,81 @@ jobs:
           vuln-type: library
           scanners: vuln  # Skip secret/misconfig scanning, focus on dependency CVEs
 
+      - name: Discover Container Apps subnet for storage cutover
+        run: |
+          CONTAINER_APP_ENV_ID=$(az containerapp show \
+            --name "${{ env.CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+            --only-show-errors \
+            --query properties.managedEnvironmentId -o tsv)
+          if [ -z "$CONTAINER_APP_ENV_ID" ]; then
+            echo "::error::Unable to discover Container Apps managed environment ID for storage network rule cutover"
+            exit 1
+          fi
+
+          CONTAINER_APPS_SUBNET_ID=$(az resource show \
+            --ids "$CONTAINER_APP_ENV_ID" \
+            --api-version 2023-05-01 \
+            --only-show-errors \
+            --query properties.vnetConfiguration.infrastructureSubnetId -o tsv 2>/dev/null || true)
+
+          if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+            CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+              --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+              --only-show-errors \
+              -o json \
+              | jq -r '.[] | (.subnets // [])[] | select(.name == "container-apps-subnet") | .id')
+            CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+            if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+              echo "::error::Unable to uniquely discover container-apps-subnet ID in resource group ${{ env.AZURE_RESOURCE_GROUP }}; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+              exit 1
+            fi
+            if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+              CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+            fi
+          fi
+
+          if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+            CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+              --only-show-errors \
+              -o json \
+              | jq -r '.[] | (.subnets // [])[] | select(.name == "container-apps-subnet") | .id')
+            CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+            if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+              echo "::error::Unable to uniquely discover container-apps-subnet ID in subscription; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+              exit 1
+            fi
+            if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+              CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+            fi
+          fi
+
+          if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+            TERRAFORM_SUBNET_ERROR=$(mktemp)
+            if terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-container-apps-subnet.log 2>&1; then
+              CONTAINER_APPS_SUBNET_ID=$(terraform -chdir=infra state show -no-color azurerm_subnet.container_apps 2>"$TERRAFORM_SUBNET_ERROR" \
+                | awk -F'= ' '/^[[:space:]]*id[[:space:]]*=/{gsub(/"/, "", $2); print $2; exit}')
+            else
+              echo "::warning::Unable to initialize Terraform remote state for container-apps-subnet discovery"
+              sed 's/^/terraform init: /' /tmp/terraform-init-container-apps-subnet.log >&2
+            fi
+            if [ -n "$CONTAINER_APPS_SUBNET_ID" ]; then
+              echo "::notice::Discovered container-apps-subnet ID from Terraform state for storage network rule cutover."
+            else
+              sed 's/^/terraform state show: /' "$TERRAFORM_SUBNET_ERROR" >&2
+              echo "::warning::Unable to discover container-apps-subnet ID for storage network rule cutover"
+            fi
+            rm -f "$TERRAFORM_SUBNET_ERROR"
+          fi
+
+          if [ -n "$CONTAINER_APPS_SUBNET_ID" ]; then
+            if [[ "$CONTAINER_APPS_SUBNET_ID" != */subnets/container-apps-subnet ]]; then
+              echo "::error::Container Apps environment infrastructure subnet must be container-apps-subnet before storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID"
+              exit 1
+            fi
+            echo "CONTAINER_APPS_SUBNET_ID=$CONTAINER_APPS_SUBNET_ID" >> "$GITHUB_ENV"
+          fi
+
       - name: Validate Terraform-managed metrics storage
         run: |
           CONTAINER_APP_JSON=$(az containerapp show \
@@ -831,68 +906,8 @@ jobs:
                 exit 1
               fi
               if [ "$CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" = "0" ]; then
-                CONTAINER_APP_ENV_ID=$(az containerapp show \
-                  --name "${{ env.CONTAINER_APP_NAME }}" \
-                  --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-                  --only-show-errors \
-                  --query properties.managedEnvironmentId -o tsv)
-                if [ -z "$CONTAINER_APP_ENV_ID" ]; then
-                  echo "::error::Unable to discover Container Apps managed environment ID for storage network rule cutover"
-                  exit 1
-                fi
-                CONTAINER_APPS_SUBNET_ID=$(az resource show \
-                  --ids "$CONTAINER_APP_ENV_ID" \
-                  --api-version 2023-05-01 \
-                  --only-show-errors \
-                  --query properties.vnetConfiguration.infrastructureSubnetId -o tsv 2>/dev/null || true)
                 if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
-                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
-                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-                    --only-show-errors \
-                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
-                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
-                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
-                    echo "::error::Unable to uniquely discover container-apps-subnet ID in resource group ${{ env.AZURE_RESOURCE_GROUP }}; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
-                    exit 1
-                  fi
-                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
-                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
-                  fi
-                fi
-                if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
-                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
-                    --only-show-errors \
-                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
-                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
-                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
-                    echo "::error::Unable to uniquely discover container-apps-subnet ID in subscription; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
-                    exit 1
-                  fi
-                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
-                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
-                  fi
-                fi
-                if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
-                  TERRAFORM_SUBNET_ERROR=$(mktemp)
-                  if terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-container-apps-subnet.log 2>&1; then
-                    CONTAINER_APPS_SUBNET_ID=$(terraform -chdir=infra state show -no-color azurerm_subnet.container_apps 2>"$TERRAFORM_SUBNET_ERROR" \
-                      | awk -F'= ' '/^[[:space:]]*id[[:space:]]*=/{gsub(/"/, "", $2); print $2; exit}')
-                  else
-                    echo "::warning::Unable to initialize Terraform remote state for container-apps-subnet discovery"
-                    sed 's/^/terraform init: /' /tmp/terraform-init-container-apps-subnet.log >&2
-                  fi
-                  if [ -n "$CONTAINER_APPS_SUBNET_ID" ]; then
-                    echo "::notice::Discovered container-apps-subnet ID from Terraform state for storage network rule cutover."
-                  else
-                    sed 's/^/terraform state show: /' "$TERRAFORM_SUBNET_ERROR" >&2
-                    echo "::error::Unable to discover container-apps-subnet ID for storage network rule cutover"
-                    rm -f "$TERRAFORM_SUBNET_ERROR"
-                    exit 1
-                  fi
-                  rm -f "$TERRAFORM_SUBNET_ERROR"
-                fi
-                if [[ "$CONTAINER_APPS_SUBNET_ID" != */subnets/container-apps-subnet ]]; then
-                  echo "::error::Container Apps environment infrastructure subnet must be container-apps-subnet before storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID"
+                  echo "::error::Unable to discover container-apps-subnet ID for storage network rule cutover"
                   exit 1
                 fi
                 echo "::notice::Storage account $STORAGE_NAME is missing the container-apps-subnet rule; adding it before public network cutover."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,6 +846,33 @@ jobs:
                   --only-show-errors \
                   --query properties.vnetConfiguration.infrastructureSubnetId -o tsv 2>/dev/null || true)
                 if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+                    --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+                    --only-show-errors \
+                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
+                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+                    echo "::error::Unable to uniquely discover container-apps-subnet ID in resource group ${{ env.AZURE_RESOURCE_GROUP }}; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                    exit 1
+                  fi
+                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                  fi
+                fi
+                if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+                  CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
+                    --only-show-errors \
+                    --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
+                  CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+                    echo "::error::Unable to uniquely discover container-apps-subnet ID in subscription; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                    exit 1
+                  fi
+                  if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                  fi
+                fi
+                if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
                   TERRAFORM_SUBNET_ERROR=$(mktemp)
                   if terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-container-apps-subnet.log 2>&1; then
                     CONTAINER_APPS_SUBNET_ID=$(terraform -chdir=infra state show -no-color azurerm_subnet.container_apps 2>"$TERRAFORM_SUBNET_ERROR" \
@@ -858,17 +885,9 @@ jobs:
                     echo "::notice::Discovered container-apps-subnet ID from Terraform state for storage network rule cutover."
                   else
                     sed 's/^/terraform state show: /' "$TERRAFORM_SUBNET_ERROR" >&2
-                    CONTAINER_APPS_SUBNET_IDS=$(az network vnet list \
-                      --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-                      --only-show-errors \
-                      --query "[].subnets[?name=='container-apps-subnet'].id[]" -o tsv)
-                    CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
-                    if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" != "1" ]; then
-                      echo "::error::Unable to uniquely discover container-apps-subnet ID for storage network rule cutover; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
-                      rm -f "$TERRAFORM_SUBNET_ERROR"
-                      exit 1
-                    fi
-                    CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                    echo "::error::Unable to discover container-apps-subnet ID for storage network rule cutover"
+                    rm -f "$TERRAFORM_SUBNET_ERROR"
+                    exit 1
                   fi
                   rm -f "$TERRAFORM_SUBNET_ERROR"
                 fi

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -195,13 +195,17 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "Unable to discover Container Apps managed environment ID" in validate_script
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in validate_script
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in validate_script
+    assert "az network vnet list" in validate_script
+    assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in validate_script
+    assert "Unable to uniquely discover container-apps-subnet ID in resource group" in validate_script
+    assert "Unable to uniquely discover container-apps-subnet ID in subscription" in validate_script
     assert "terraform -chdir=infra init -input=false -lockfile=readonly" in validate_script
     assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in validate_script
     assert "Discovered container-apps-subnet ID from Terraform state" in validate_script
     assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in validate_script
     assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in validate_script
     assert "CONTAINER_APPS_SUBNET_ID_COUNT" in validate_script
-    assert "Unable to uniquely discover container-apps-subnet ID" in validate_script
+    assert "Unable to discover container-apps-subnet ID for storage network rule cutover" in validate_script
     assert "must be container-apps-subnet before storage network rule cutover" in validate_script
     assert "az storage account network-rule add" in validate_script
     assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in validate_script

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -157,7 +157,13 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
         for step in workflow["jobs"]["deploy-backend"]["steps"]
         if step.get("name") == "Validate Terraform-managed metrics storage"
     )
+    discover_step = next(
+        step
+        for step in workflow["jobs"]["deploy-backend"]["steps"]
+        if step.get("name") == "Discover Container Apps subnet for storage cutover"
+    )
     validate_script = validate_step["run"]
+    discover_script = discover_step["run"]
 
     assert 'if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then' in validate_script
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
@@ -190,23 +196,24 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert '.state == "Succeeded"' in validate_script
     assert "CONTAINER_APPS_VNET_RULE_TOTAL_COUNT" in validate_script
     assert "must not have duplicate container-apps-subnet virtual network rules" in validate_script
-    assert "CONTAINER_APP_ENV_ID=$(az containerapp show" in validate_script
-    assert "--query properties.managedEnvironmentId" in validate_script
-    assert "Unable to discover Container Apps managed environment ID" in validate_script
-    assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in validate_script
-    assert "--query properties.vnetConfiguration.infrastructureSubnetId" in validate_script
-    assert "az network vnet list" in validate_script
-    assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in validate_script
-    assert "Unable to uniquely discover container-apps-subnet ID in resource group" in validate_script
-    assert "Unable to uniquely discover container-apps-subnet ID in subscription" in validate_script
-    assert "terraform -chdir=infra init -input=false -lockfile=readonly" in validate_script
-    assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in validate_script
-    assert "Discovered container-apps-subnet ID from Terraform state" in validate_script
-    assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in validate_script
-    assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in validate_script
-    assert "CONTAINER_APPS_SUBNET_ID_COUNT" in validate_script
+    assert "CONTAINER_APP_ENV_ID=$(az containerapp show" in discover_script
+    assert "--query properties.managedEnvironmentId" in discover_script
+    assert "Unable to discover Container Apps managed environment ID" in discover_script
+    assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in discover_script
+    assert "--query properties.vnetConfiguration.infrastructureSubnetId" in discover_script
+    assert "az network vnet list" in discover_script
+    assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in discover_script
+    assert "Unable to uniquely discover container-apps-subnet ID in resource group" in discover_script
+    assert "Unable to uniquely discover container-apps-subnet ID in subscription" in discover_script
+    assert "terraform -chdir=infra init -input=false -lockfile=readonly" in discover_script
+    assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in discover_script
+    assert "Discovered container-apps-subnet ID from Terraform state" in discover_script
+    assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in discover_script
+    assert 'jq -r \'.[] | (.subnets // [])[] | select(.name == "container-apps-subnet") | .id\'' in discover_script
+    assert "CONTAINER_APPS_SUBNET_ID_COUNT" in discover_script
+    assert "CONTAINER_APPS_SUBNET_ID=$CONTAINER_APPS_SUBNET_ID" in discover_script
     assert "Unable to discover container-apps-subnet ID for storage network rule cutover" in validate_script
-    assert "must be container-apps-subnet before storage network rule cutover" in validate_script
+    assert "must be container-apps-subnet before storage network rule cutover" in discover_script
     assert "az storage account network-rule add" in validate_script
     assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in validate_script
     assert "for vnet_rule_attempt in" in validate_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -314,7 +314,7 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in ci_workflow
     assert "Discovered container-apps-subnet ID from Terraform state" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in ci_workflow
-    assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in ci_workflow
+    assert 'jq -r \'.[] | (.subnets // [])[] | select(.name == "container-apps-subnet") | .id\'' in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID_COUNT" in ci_workflow
     assert "Unable to discover container-apps-subnet ID for storage network rule cutover" in ci_workflow
     assert "must be container-apps-subnet before storage network rule cutover" in ci_workflow

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -306,13 +306,17 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "Unable to discover Container Apps managed environment ID" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID=$(az resource show" in ci_workflow
     assert "--query properties.vnetConfiguration.infrastructureSubnetId" in ci_workflow
+    assert "az network vnet list" in ci_workflow
+    assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in ci_workflow
+    assert "Unable to uniquely discover container-apps-subnet ID in resource group" in ci_workflow
+    assert "Unable to uniquely discover container-apps-subnet ID in subscription" in ci_workflow
     assert "terraform -chdir=infra init -input=false -lockfile=readonly" in ci_workflow
     assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in ci_workflow
     assert "Discovered container-apps-subnet ID from Terraform state" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_IDS=$(az network vnet list" in ci_workflow
     assert "--query \"[].subnets[?name=='container-apps-subnet'].id[]\"" in ci_workflow
     assert "CONTAINER_APPS_SUBNET_ID_COUNT" in ci_workflow
-    assert "Unable to uniquely discover container-apps-subnet ID" in ci_workflow
+    assert "Unable to discover container-apps-subnet ID for storage network rule cutover" in ci_workflow
     assert "must be container-apps-subnet before storage network rule cutover" in ci_workflow
     assert "az storage account network-rule add" in ci_workflow
     assert "--subnet \"$CONTAINER_APPS_SUBNET_ID\"" in ci_workflow


### PR DESCRIPTION
## Summary
- search the deployment resource group for a unique container-apps-subnet first
- fall back to a subscription-wide unique subnet lookup before trying Terraform state, since the Terraform backend is currently storage-firewalled during this cutover
- preserve fail-closed behavior for ambiguous subnet discovery, duplicate VNet rules, and non-succeeded storage network rule propagation

## Validation
- /Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py

Follow-up to main run 26079530751: Terraform backend init is blocked by the storage firewall with 403, and the deployment resource group has zero container-apps-subnet candidates.