### PR TITLE
fix: add Resource Graph fallback for Container Apps subnet discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,6 +726,72 @@ jobs:
           fi
 
           if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+            RESOURCE_GROUP_SUBNET_QUERY="Resources | where type =~ 'microsoft.network/virtualnetworks/subnets' | where name == 'container-apps-subnet' | where resourceGroup =~ '${{ env.AZURE_RESOURCE_GROUP }}' | project id"
+            RESOURCE_GRAPH_BODY=$(jq -n \
+              --arg subscription "${{ env.AZURE_SUBSCRIPTION_ID }}" \
+              --arg query "$RESOURCE_GROUP_SUBNET_QUERY" \
+              '{subscriptions: [$subscription], query: $query}')
+            RESOURCE_GRAPH_ERROR=$(mktemp)
+            set +e
+            CONTAINER_APPS_SUBNET_IDS=$(az rest \
+              --method post \
+              --uri "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" \
+              --body "$RESOURCE_GRAPH_BODY" \
+              --query "data[].id" -o tsv 2>"$RESOURCE_GRAPH_ERROR")
+            RESOURCE_GRAPH_STATUS=$?
+            set -e
+            if [ "$RESOURCE_GRAPH_STATUS" -ne 0 ]; then
+              echo "::warning::Unable to query Azure Resource Graph for container-apps-subnet in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
+              sed 's/^/az rest resource graph: /' "$RESOURCE_GRAPH_ERROR" >&2
+            else
+              CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+              if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+                echo "::error::Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in resource group ${{ env.AZURE_RESOURCE_GROUP }}; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                rm -f "$RESOURCE_GRAPH_ERROR"
+                exit 1
+              fi
+              if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+                CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                echo "::notice::Discovered container-apps-subnet ID through Azure Resource Graph in resource group ${{ env.AZURE_RESOURCE_GROUP }}."
+              fi
+            fi
+            rm -f "$RESOURCE_GRAPH_ERROR"
+          fi
+
+          if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
+            SUBSCRIPTION_SUBNET_QUERY="Resources | where type =~ 'microsoft.network/virtualnetworks/subnets' | where name == 'container-apps-subnet' | project id"
+            RESOURCE_GRAPH_BODY=$(jq -n \
+              --arg subscription "${{ env.AZURE_SUBSCRIPTION_ID }}" \
+              --arg query "$SUBSCRIPTION_SUBNET_QUERY" \
+              '{subscriptions: [$subscription], query: $query}')
+            RESOURCE_GRAPH_ERROR=$(mktemp)
+            set +e
+            CONTAINER_APPS_SUBNET_IDS=$(az rest \
+              --method post \
+              --uri "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" \
+              --body "$RESOURCE_GRAPH_BODY" \
+              --query "data[].id" -o tsv 2>"$RESOURCE_GRAPH_ERROR")
+            RESOURCE_GRAPH_STATUS=$?
+            set -e
+            if [ "$RESOURCE_GRAPH_STATUS" -ne 0 ]; then
+              echo "::warning::Unable to query Azure Resource Graph for container-apps-subnet in subscription"
+              sed 's/^/az rest resource graph: /' "$RESOURCE_GRAPH_ERROR" >&2
+            else
+              CONTAINER_APPS_SUBNET_ID_COUNT=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+              if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" -gt "1" ]; then
+                echo "::error::Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in subscription; found $CONTAINER_APPS_SUBNET_ID_COUNT candidates"
+                rm -f "$RESOURCE_GRAPH_ERROR"
+                exit 1
+              fi
+              if [ "$CONTAINER_APPS_SUBNET_ID_COUNT" = "1" ]; then
+                CONTAINER_APPS_SUBNET_ID=$(printf '%s\n' "$CONTAINER_APPS_SUBNET_IDS" | sed '/^$/d' | head -1)
+                echo "::notice::Discovered container-apps-subnet ID through Azure Resource Graph in subscription."
+              fi
+            fi
+            rm -f "$RESOURCE_GRAPH_ERROR"
+          fi
+
+          if [ -z "$CONTAINER_APPS_SUBNET_ID" ]; then
             TERRAFORM_SUBNET_ERROR=$(mktemp)
             if terraform -chdir=infra init -input=false -lockfile=readonly >/tmp/terraform-init-container-apps-subnet.log 2>&1; then
               CONTAINER_APPS_SUBNET_ID=$(terraform -chdir=infra state show -no-color azurerm_subnet.container_apps 2>"$TERRAFORM_SUBNET_ERROR" \

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -205,6 +205,13 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in discover_script
     assert "Unable to uniquely discover container-apps-subnet ID in resource group" in discover_script
     assert "Unable to uniquely discover container-apps-subnet ID in subscription" in discover_script
+    assert "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" in discover_script
+    assert "microsoft.network/virtualnetworks/subnets" in discover_script
+    assert "Unable to query Azure Resource Graph for container-apps-subnet in resource group" in discover_script
+    assert "Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in resource group" in discover_script
+    assert "Unable to query Azure Resource Graph for container-apps-subnet in subscription" in discover_script
+    assert "Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in subscription" in discover_script
+    assert "Discovered container-apps-subnet ID through Azure Resource Graph" in discover_script
     assert "terraform -chdir=infra init -input=false -lockfile=readonly" in discover_script
     assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in discover_script
     assert "Discovered container-apps-subnet ID from Terraform state" in discover_script

--- a/tests/test_infra_policy_ci.py
+++ b/tests/test_infra_policy_ci.py
@@ -310,6 +310,13 @@ def test_ci_validates_prod_storage_network_and_user_assigned_identity_role():
     assert "--resource-group \"${{ env.AZURE_RESOURCE_GROUP }}\"" in ci_workflow
     assert "Unable to uniquely discover container-apps-subnet ID in resource group" in ci_workflow
     assert "Unable to uniquely discover container-apps-subnet ID in subscription" in ci_workflow
+    assert "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01" in ci_workflow
+    assert "microsoft.network/virtualnetworks/subnets" in ci_workflow
+    assert "Unable to query Azure Resource Graph for container-apps-subnet in resource group" in ci_workflow
+    assert "Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in resource group" in ci_workflow
+    assert "Unable to query Azure Resource Graph for container-apps-subnet in subscription" in ci_workflow
+    assert "Unable to uniquely discover container-apps-subnet ID through Azure Resource Graph in subscription" in ci_workflow
+    assert "Discovered container-apps-subnet ID through Azure Resource Graph" in ci_workflow
     assert "terraform -chdir=infra init -input=false -lockfile=readonly" in ci_workflow
     assert "terraform -chdir=infra state show -no-color azurerm_subnet.container_apps" in ci_workflow
     assert "Discovered container-apps-subnet ID from Terraform state" in ci_workflow


### PR DESCRIPTION
## Summary
- add an Azure Resource Graph fallback to discover `container-apps-subnet` when Container Apps environment metadata and `az network vnet list` do not expose it
- keep duplicate-candidate detection fail-closed for both resource-group and subscription-wide ARG queries
- preserve Terraform state fallback after live Azure discovery paths
- update workflow contract tests for the new discovery path

## Validation
- `/Users/idokatz/VSCode/.venv/bin/python -m pytest backend/tests/test_ci_workflow_post_deploy_smoke.py tests/test_infra_policy_ci.py` -> 37 passed
- parsed `.github/workflows/ci.yml` with PyYAML
- extracted discovery script and ran `bash -n`
- `actionlint .github/workflows/ci.yml` only reports existing unrelated shellcheck warnings