### PR TITLE
ci: stabilize production health gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1768,6 +1768,15 @@ jobs:
             --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
             --revision-weight "${{ steps.green.outputs.green_revision }}=100"
 
+      - name: Verify production deployment
+        run: |
+          sleep 30
+          HEALTH_RETRIES=12 HEALTH_RETRY_SECONDS=15 HEALTH_API_KEY="$ARCHMORPH_API_KEY" ./scripts/health_gate.sh "${{ env.API_URL }}/health"
+          HEALTH_BODY=$(curl -s --max-time 30 -H "X-API-Key: $ARCHMORPH_API_KEY" "${{ env.API_URL }}/health")
+          HEALTH=$(printf '%s' "$HEALTH_BODY" | jq -r '.status')
+          VERSION=$(printf '%s' "$HEALTH_BODY" | jq -r '.version')
+          echo "Deployed version: $VERSION — status: $HEALTH (blue-green complete)"
+
       - name: Deactivate old revisions (keep blue for rollback)
         run: |
           OLD_REVS=$(az containerapp revision list \
@@ -1787,15 +1796,6 @@ jobs:
               --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
               --revision "$rev" || true
           done
-
-      - name: Verify production deployment
-        run: |
-          sleep 10
-          HEALTH_RETRIES=3 HEALTH_RETRY_SECONDS=10 HEALTH_API_KEY="$ARCHMORPH_API_KEY" ./scripts/health_gate.sh "${{ env.API_URL }}/health"
-          HEALTH_BODY=$(curl -s --max-time 30 -H "X-API-Key: $ARCHMORPH_API_KEY" "${{ env.API_URL }}/health")
-          HEALTH=$(printf '%s' "$HEALTH_BODY" | jq -r '.status')
-          VERSION=$(printf '%s' "$HEALTH_BODY" | jq -r '.version')
-          echo "Deployed version: $VERSION — status: $HEALTH (blue-green complete)"
 
   # ============================================
   # FRONTEND DEPLOY (Azure Static Web Apps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1772,9 +1772,9 @@ jobs:
         run: |
           sleep 30
           HEALTH_RETRIES=12 HEALTH_RETRY_SECONDS=15 HEALTH_API_KEY="$ARCHMORPH_API_KEY" ./scripts/health_gate.sh "${{ env.API_URL }}/health"
-          HEALTH_BODY=$(curl -s --max-time 30 -H "X-API-Key: $ARCHMORPH_API_KEY" "${{ env.API_URL }}/health")
-          HEALTH=$(printf '%s' "$HEALTH_BODY" | jq -r '.status')
-          VERSION=$(printf '%s' "$HEALTH_BODY" | jq -r '.version')
+          HEALTH_BODY=$(curl -sS --max-time 30 -H "X-API-Key: $ARCHMORPH_API_KEY" "${{ env.API_URL }}/health" || true)
+          HEALTH=$(printf '%s' "$HEALTH_BODY" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+          VERSION=$(printf '%s' "$HEALTH_BODY" | jq -r '.version // "unknown"' 2>/dev/null || echo "unknown")
           echo "Deployed version: $VERSION — status: $HEALTH (blue-green complete)"
 
       - name: Deactivate old revisions (keep blue for rollback)


### PR DESCRIPTION
## Summary
- verify production health before deactivating old Container Apps revisions
- extend the final custom-domain health gate retry window after traffic shift

## Context
The main CI/CD deploy reached the new revision and passed green-revision smoke tests, but final production verification twice saw a short-lived storage=unreachable response immediately after traffic shift. Live authenticated health recovered to healthy/storage=ok right after the failed gate.

## Testing
- Parsed .github/workflows/ci.yml with Ruby YAML parser
- Observed live production /api/health returning HTTP 200, status=healthy, storage=ok after the failed rerun
