### PR TITLE
fix: allow bearer diagram exports

### DIFF
--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -10,7 +10,14 @@ from typing import Dict, Any
 import asyncio
 import logging
 
-from routers.shared import SESSION_STORE, authorize_diagram_access, limiter, verify_api_key, require_diagram_access
+from routers.shared import (
+    SESSION_STORE,
+    authorize_diagram_access,
+    limiter,
+    require_diagram_access,
+    verify_api_key,
+    verify_api_key_or_user_session,
+)
 from usage_metrics import record_event, record_funnel_step
 from guided_questions import generate_questions, apply_answers, get_question_constraints, build_adaptive_question_set
 from mcp_diagram_generator import mcp_client
@@ -164,7 +171,7 @@ async def export_architecture_diagram(
     format: str = "excalidraw",
     multi_page: bool = False,
     dr_variant: str = "primary",
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
     capability=Depends(verify_export_capability),
 ):
     """Generate an architecture diagram in Excalidraw, Draw.io, Visio, or

--- a/backend/routers/shared.py
+++ b/backend/routers/shared.py
@@ -93,7 +93,7 @@ async def verify_api_key_or_user_session(
 
         if get_user_from_request_headers(dict(request.headers)):
             return
-        raise
+        raise ArchmorphException(status_code=401, detail="Invalid or missing API key or user session") from exc
 
 
 def get_api_key_service_principal(headers: dict) -> Optional[str]:

--- a/backend/tests/test_diagram_access_hardening.py
+++ b/backend/tests/test_diagram_access_hardening.py
@@ -12,7 +12,12 @@ from export_capabilities import verify_export_capability  # noqa: E402
 from main import SESSION_STORE, app  # noqa: E402
 from routers.replay_routes import _replay_store, require_replay_access, require_replay_body_access  # noqa: E402
 from routers.share_routes import require_share_access  # noqa: E402
-from routers.shared import get_api_key_service_principal, require_diagram_access, verify_api_key  # noqa: E402
+from routers.shared import (  # noqa: E402
+    get_api_key_service_principal,
+    require_diagram_access,
+    verify_api_key,
+    verify_api_key_or_user_session,
+)
 from shareable_reports import _shares  # noqa: E402
 from tests.conftest import SAMPLE_ANALYSIS, assert_cross_tenant_denied  # noqa: E402
 
@@ -133,7 +138,7 @@ def test_replay_get_denies_cross_tenant_access(test_client, tenant_a_auth_header
     assert_cross_tenant_denied(intruder)
 
 
-def test_diagram_artifact_routes_require_api_key_access_dependency_and_export_capability():
+def test_diagram_artifact_routes_require_api_key_or_user_session_dependency_and_export_capability():
     exempt_paths = {
         "/api/diagrams/{diagram_id}/restore-session",
         "/api/diagrams/{diagram_id}/analyze",
@@ -156,8 +161,8 @@ def test_diagram_artifact_routes_require_api_key_access_dependency_and_export_ca
             continue
         dependency_callables = {dep.call for dep in route.dependant.dependencies}
         methods = sorted(set(route.methods or ()) - {"HEAD", "OPTIONS"})
-        if verify_api_key not in dependency_callables:
-            missing.append(f"{methods} {route.path} missing verify_api_key")
+        if verify_api_key not in dependency_callables and verify_api_key_or_user_session not in dependency_callables:
+            missing.append(f"{methods} {route.path} missing API-key-or-user-session auth dependency")
         if require_diagram_access not in dependency_callables:
             missing.append(f"{methods} {route.path} missing require_diagram_access")
         if route.path in capability_paths and verify_export_capability not in dependency_callables:

--- a/backend/tests/test_export_capabilities.py
+++ b/backend/tests/test_export_capabilities.py
@@ -136,6 +136,26 @@ def test_rotated_capability_allows_next_valid_export(test_client, diagram_id, au
     assert second.json()["export_capability"] != next_token
 
 
+def test_diagram_export_accepts_bearer_session_with_capability_when_api_key_configured(
+    test_client,
+    diagram_id,
+    auth_headers,
+    monkeypatch,
+):
+    monkeypatch.setattr(shared_router, "API_KEY", "configured-api-key")
+    token = issue_export_capability(diagram_id)
+    headers = {**auth_headers, "X-Export-Capability": token}
+
+    response = test_client.post(
+        f"/api/diagrams/{diagram_id}/export-diagram?format=drawio",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["format"] == "drawio"
+    assert response.json()["content"]
+
+
 def test_valid_capability_survives_route_failure_before_export_success(test_client, diagram_id, auth_headers):
     token = issue_export_capability(diagram_id)
     SESSION_STORE.delete(diagram_id)


### PR DESCRIPTION
## Summary
- Allow `/api/diagrams/{diagram_id}/export-diagram` to authenticate with either the existing API key or a signed-in user bearer session.
- Preserve `require_diagram_access` and `verify_export_capability` on the export route.
- Add regression coverage for the browser-authenticated flow: API key configured, bearer user session present, valid export capability present, and no `X-API-Key` header.

## Validation
- `cd backend && /Users/idokatz/VSCode/.venv/bin/python -m pytest -q tests/test_export_capabilities.py tests/test_diagram_access_hardening.py tests/test_runtime_openapi_conformance.py tests/test_api_v1_manifest.py`

## Production evidence before fix
- Browser-authenticated upload/analyze succeeded from Chrome using SWA bridge session.
- Draw.io export failed with `401 Invalid or missing API key`, proving export route still required API-key auth.
