### PR TITLE
test: avoid key-shaped prompt guard fixture

### DIFF
--- a/backend/tests/test_prompt_guard.py
+++ b/backend/tests/test_prompt_guard.py
@@ -219,7 +219,7 @@ class TestSanitizeMessage:
 # ─────────────────────────────────────────────────────────────
 class TestSanitizeResponse:
     def test_redacts_openai_key_pattern(self):
-        response = "Here is the key: sk-abc123def456ghi789jkl012mno345"
+        response = "Here is the key: " + "sk-" + ("x" * 48)
         result = sanitize_response(response)
         assert "sk-" not in result
         assert "[REDACTED]" in result


### PR DESCRIPTION
## Summary
- construct the fake OpenAI-style key at runtime in the prompt guard test
- avoid storing a key-shaped literal in the public repository while preserving sanitizer coverage

## Validation
- `gitleaks dir . --redact`: 0 findings after cleanup
- `pytest -q backend/tests/test_prompt_guard.py`: passed

## Local artifact cleanup
- Quarantined untracked generated/state artifacts outside the repo under a private `~/.archmorph-secret-quarantine/...` directory.
