### PR TITLE
chore: ignore historical gitleaks false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+d76db65850b07cd5a336cd1504a238c436c2a639:backend/tests/test_prompt_guard.py:generic-api-key:222
+56f953b371cc3376cc5f4090e42e99d73a9ac69a:backend/tests/test_prompt_guard.py:generic-api-key:222
+5cfe228f5bb022df15ce68980698871ae98a7529:infra/main.tf:hashicorp-tf-password:254


### PR DESCRIPTION
## Summary
- add a root `.gitleaksignore` for exact historical fingerprints reported by the scheduled main security scan
- keep the ignores narrow: exact commit/file/rule/line fingerprints only, no broad path or rule exclusions

## Validation
- `gitleaks detect --redact -v --exit-code=2`: 0 findings
- `gitleaks dir . --redact`: 0 findings
- `pytest -q backend/tests/test_prompt_guard.py`: passed
