### PR TITLE
fix: add production synthetic auth bridge fallback

### DIFF
--- a/backend/tests/test_production_authenticated_browser_synthetic_workflow.py
+++ b/backend/tests/test_production_authenticated_browser_synthetic_workflow.py
@@ -67,3 +67,16 @@ def test_synthetic_evidence_does_not_persist_live_endpoint_urls():
     assert "api_base: API_BASE" not in spec
     assert "frontend_url_configured: Boolean(FRONTEND_URL)" in spec
     assert "api_base_configured: Boolean(API_BASE)" in spec
+
+
+def test_synthetic_can_fall_back_to_trusted_backend_auth_bridge_without_leaking_secret_values():
+    spec = SYNTHETIC_SPEC.read_text(encoding="utf-8")
+
+    assert "authBridgeMode = 'swa-managed-function'" in spec
+    assert "authBridgeMode = 'backend-api-key-fallback'" in spec
+    assert "`${API_BASE}/auth/swa-session`" in spec
+    assert "'X-API-Key': HEALTH_API_KEY" in spec
+    assert "data: { client_principal: syntheticPrincipal }" in spec
+    assert "auth_bridge_mode: authBridgeMode" in spec
+    assert "auth_bridge_http_status: bridgeResponse.status()" in spec
+    assert "HEALTH_API_KEY:" not in spec

--- a/e2e/production-authenticated-synthetic.spec.ts
+++ b/e2e/production-authenticated-synthetic.spec.ts
@@ -45,13 +45,26 @@ test.describe('Production authenticated browser synthetic', () => {
       'utf-8',
     ).toString('base64');
 
-    const bridgeResponse = await request.post(`${FRONTEND_URL}/api/auth/swa-session`, {
+    let authBridgeMode = 'swa-managed-function';
+    let bridgeResponse = await request.post(`${FRONTEND_URL}/api/auth/swa-session`, {
       headers: {
         'x-ms-client-principal': syntheticPrincipal,
         'Content-Type': 'application/json',
       },
       data: {},
     });
+
+    if (!bridgeResponse.ok() && HEALTH_API_KEY) {
+      authBridgeMode = 'backend-api-key-fallback';
+      bridgeResponse = await request.post(`${API_BASE}/auth/swa-session`, {
+        headers: {
+          'X-API-Key': HEALTH_API_KEY,
+          'Content-Type': 'application/json',
+        },
+        data: { client_principal: syntheticPrincipal },
+      });
+    }
+
     expect(bridgeResponse.ok()).toBeTruthy();
     const bridgeBody = await bridgeResponse.json();
     const sessionToken = bridgeBody?.session_token as string;
@@ -161,7 +174,8 @@ test.describe('Production authenticated browser synthetic', () => {
         api_base_configured: Boolean(API_BASE),
       },
       checks: {
-        swa_bridge_http_status: bridgeResponse.status(),
+        auth_bridge_mode: authBridgeMode,
+        auth_bridge_http_status: bridgeResponse.status(),
         upload_http_status: uploadResponse.status(),
         analyze_async_http_status: analyzeAsyncResponse.status(),
         drawio_export_http_status: drawioResponse.status(),


### PR DESCRIPTION
## Summary
- keep the production synthetic trying the SWA managed-function bridge first
- fall back to the trusted backend auth bridge with the existing API-key secret when the public SWA edge rejects synthetic `x-ms-client-principal` headers
- record only bridge mode/status in evidence, not endpoint values or secrets

## Why
The first post-merge production synthetic gate reached `/api/auth/swa-session` but the bridge response was non-OK before a session token was minted. This keeps the release gate useful while respecting the SWA edge trust boundary.

## Validation
- `pytest -q backend/tests/test_production_authenticated_browser_synthetic_workflow.py backend/tests/test_ci_workflow_post_deploy_smoke.py`: passed
- `npx playwright test e2e/production-authenticated-synthetic.spec.ts --project=chromium`: skipped by default as expected
- exact changed-file `gitleaks dir ... --redact`: 0 findings
