### PR TITLE
feat: add data lifecycle trust receipts

### DIFF
--- a/backend/data_lifecycle.py
+++ b/backend/data_lifecycle.py
@@ -1,0 +1,124 @@
+"""Customer-safe data lifecycle and trust receipt helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+TRUST_RECEIPT_SCHEMA_VERSION = "2026-05-25"
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+CONTENT_RETENTION_CLASS = os.getenv("ARCHMORPH_CONTENT_RETENTION_CLASS", "ephemeral-analysis")
+CONTENT_RETENTION_SECONDS = _int_env("ARCHMORPH_CONTENT_RETENTION_SECONDS", 2 * 60 * 60)
+AUDIT_SECURITY_LOG_RETENTION_DAYS = _int_env("ARCHMORPH_AUDIT_SECURITY_LOG_RETENTION_DAYS", 30)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _receipt_id(diagram_id: str, generated_at: str) -> str:
+    digest = hashlib.sha256(f"{diagram_id}:{generated_at}".encode("utf-8")).hexdigest()
+    return f"tr-{digest[:16]}"
+
+
+def _default_artifacts(image_present: bool, session_present: bool, project_present: bool) -> Dict[str, Any]:
+    return {
+        "uploaded_content": "present" if image_present else "not_present",
+        "analysis_session": "present" if session_present else "not_present",
+        "project_index": "tracked" if project_present else "not_present",
+        "share_links": "not_checked",
+        "export_capabilities": "not_checked",
+        "async_jobs": "not_checked",
+        "iac_chat": "not_checked",
+    }
+
+
+def build_trust_receipt(
+    diagram_id: str,
+    *,
+    project_id: Optional[str] = None,
+    uploaded_at: Optional[str] = None,
+    generated_at: Optional[datetime] = None,
+    image_present: bool = False,
+    session_present: bool = False,
+    export_capability_expires_in: Optional[int] = None,
+    artifact_status: Optional[Dict[str, Any]] = None,
+    purge: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a customer-safe receipt for one diagram analysis lifecycle."""
+    now = generated_at or _now()
+    generated_iso = _iso(now)
+    uploaded_dt = _parse_iso(uploaded_at)
+    expires_at = _iso(uploaded_dt + timedelta(seconds=CONTENT_RETENTION_SECONDS)) if uploaded_dt else None
+    purge_status = purge.get("status") if isinstance(purge, dict) else "not_requested"
+
+    return {
+        "schema_version": TRUST_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": _receipt_id(diagram_id, generated_iso),
+        "generated_at": generated_iso,
+        "correlation_id": diagram_id,
+        "diagram_id": diagram_id,
+        "project_id": project_id,
+        "status": "purged" if purge_status == "purged" else "active",
+        "retention": {
+            "class": CONTENT_RETENTION_CLASS,
+            "customer_content_ttl_seconds": CONTENT_RETENTION_SECONDS,
+            "uploaded_at": _iso(uploaded_dt) if uploaded_dt else None,
+            "expires_at": expires_at,
+        },
+        "export_capability": {
+            "status": "issued" if export_capability_expires_in else "not_issued",
+            "expires_in_seconds": export_capability_expires_in,
+        },
+        "ai_processing": {
+            "processor": "Azure OpenAI",
+            "purpose": "architecture analysis and Azure migration mapping",
+            "training_use": "not_used_by_archmorph_for_model_training",
+        },
+        "artifacts": artifact_status or _default_artifacts(image_present, session_present, bool(project_id)),
+        "purge": purge or {
+            "status": "not_requested",
+            "server_content_deleted": False,
+            "client_cache_action": "clear_session_storage_after_successful_purge",
+        },
+        "audit_security_logs": {
+            "retained": True,
+            "retention_class": "security-audit",
+            "retention_days": AUDIT_SECURITY_LOG_RETENTION_DAYS,
+            "contains_customer_content": False,
+            "scope": "operational metadata such as correlation id, project id, event type, and deletion outcome",
+        },
+    }
+
+
+def attach_trust_receipt(payload: Dict[str, Any], diagram_id: str, **kwargs: Any) -> Dict[str, Any]:
+    """Return payload with a trust_receipt field added."""
+    payload["trust_receipt"] = build_trust_receipt(diagram_id, **kwargs)
+    return payload

--- a/backend/routers/diagrams.py
+++ b/backend/routers/diagrams.py
@@ -19,7 +19,7 @@ import base64
 import logging
 
 from routers.shared import (
-    SESSION_STORE, IMAGE_STORE, SHARE_STORE, EXPORT_CAPABILITY_STORE,
+    SESSION_STORE, IMAGE_STORE, PROJECT_STORE, SHARE_STORE, EXPORT_CAPABILITY_STORE,
     limiter, verify_api_key, verify_api_key_or_user_session, MAX_UPLOAD_SIZE, generate_session_id,
     require_authenticated_user, get_api_key_service_principal,
     require_diagram_access,
@@ -28,6 +28,7 @@ import ci_smoke
 from job_queue import job_manager
 from usage_metrics import record_event, record_funnel_step
 from export_capabilities import attach_export_capability
+from data_lifecycle import attach_trust_receipt, build_trust_receipt
 from image_classifier import classify_image
 from vision_analyzer import analyze_image
 from openai_client import OpenAIServiceError, handle_openai_error
@@ -185,6 +186,36 @@ def _purge_store_records_for_diagram(store, diagram_id: str) -> int:
     return purged
 
 
+def _diagram_project_metadata(diagram_id: str) -> tuple[Optional[str], Dict[str, Any]]:
+    project_id = get_project_id_for_diagram(diagram_id)
+    if not project_id:
+        return None, {}
+    project = PROJECT_STORE.get(project_id) or {}
+    for diagram in project.get("diagrams", []):
+        if diagram.get("diagram_id") == diagram_id:
+            return project_id, diagram
+    return project_id, {}
+
+
+def _attach_lifecycle_receipt(
+    payload: Dict[str, Any],
+    diagram_id: str,
+    *,
+    image_present: Optional[bool] = None,
+    session_present: Optional[bool] = None,
+) -> Dict[str, Any]:
+    project_id, diagram_meta = _diagram_project_metadata(diagram_id)
+    return attach_trust_receipt(
+        payload,
+        diagram_id,
+        project_id=project_id,
+        uploaded_at=diagram_meta.get("created_at"),
+        image_present=(diagram_id in IMAGE_STORE) if image_present is None else image_present,
+        session_present=(diagram_id in SESSION_STORE) if session_present is None else session_present,
+        export_capability_expires_in=payload.get("export_capability_expires_in"),
+    )
+
+
 # ─────────────────────────────────────────────────────────────
 # Diagrams — Upload
 # ─────────────────────────────────────────────────────────────
@@ -248,13 +279,13 @@ async def upload_diagram(request: Request, project_id: str, file: UploadFile = F
 
     record_event("diagrams_uploaded", {"filename": file.filename})
     record_funnel_step(diagram_id, "upload")
-    return attach_export_capability({
+    return _attach_lifecycle_receipt(attach_export_capability({
         "diagram_id": diagram_id,
         "project_id": project_id,
         "filename": file.filename,
         "size": len(image_bytes),
         "status": "uploaded"
-    }, diagram_id)
+    }, diagram_id), diagram_id, image_present=True, session_present=False)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -339,10 +370,10 @@ async def restore_session(
         restored_parts.append("image")
     logger.info("Session restored for %s via client cache (%s)", str(diagram_id).replace('\n', '').replace('\r', ''), str(", ".join(restored_parts)).replace('\n', '').replace('\r', ''))  # codeql[py/log-injection] Handled by custom
     record_event("sessions_restored", {"diagram_id": diagram_id, "parts": restored_parts})
-    return attach_export_capability(
+    return _attach_lifecycle_receipt(attach_export_capability(
         {"status": "restored", "diagram_id": diagram_id, "restored": restored_parts},
         diagram_id,
-    )
+    ), diagram_id, image_present=diagram_id in IMAGE_STORE, session_present=True)
 
 
 @router.delete("/api/diagrams/{diagram_id}/purge", dependencies=[Depends(require_diagram_access)])
@@ -368,12 +399,14 @@ async def purge_diagram_session(
     session_record = SESSION_STORE.get(diagram_id)
     image_deleted = image_record is not None
     session_deleted = session_record is not None
+    project_id = get_project_id_for_diagram(diagram_id)
+    _, diagram_meta = _diagram_project_metadata(diagram_id)
     if image_record is not None:
         IMAGE_STORE.delete(diagram_id)
     if session_record is not None:
         SESSION_STORE.delete(diagram_id)
 
-    project_id = get_project_id_for_diagram(diagram_id)
+    project_index_deleted = project_id is not None
     remove_diagram(diagram_id)
 
     export_capabilities_deleted = _purge_store_records_for_diagram(EXPORT_CAPABILITY_STORE, diagram_id)
@@ -393,10 +426,45 @@ async def purge_diagram_session(
         "jobs_deleted": jobs_deleted,
         "iac_chat_deleted": iac_chat_deleted,
     })
+    purge_confirmation = {
+        "status": "purged",
+        "server_content_deleted": bool(
+            image_deleted
+            or session_deleted
+            or project_index_deleted
+            or export_capabilities_deleted
+            or share_store_deleted
+            or share_links_deleted
+            or jobs_deleted
+            or iac_chat_deleted
+        ),
+        "client_cache_action": "clear_session_storage_after_successful_purge",
+        "audit_security_logs_retained": True,
+    }
+    artifact_status = {
+        "uploaded_content": "purged" if image_deleted else "not_present",
+        "analysis_session": "purged" if session_deleted else "not_present",
+        "project_index": "purged" if project_index_deleted else "not_present",
+        "share_links": share_links_deleted,
+        "share_store": share_store_deleted,
+        "export_capabilities": export_capabilities_deleted,
+        "async_jobs": jobs_deleted,
+        "iac_chat": bool(iac_chat_deleted),
+    }
+    trust_receipt = build_trust_receipt(
+        diagram_id,
+        project_id=project_id,
+        uploaded_at=diagram_meta.get("created_at"),
+        image_present=False,
+        session_present=False,
+        artifact_status=artifact_status,
+        purge=purge_confirmation,
+    )
     return {
         "status": "purged",
         "diagram_id": diagram_id,
         "project_id": project_id,
+        "trust_receipt": trust_receipt,
         "purged": {
             "image": image_deleted,
             "session": session_deleted,
@@ -476,7 +544,7 @@ async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verif
         record_funnel_step(diagram_id, "analyze")
         if user:
             maybe_save_from_session(user.id, result, diagram_id)
-        return attach_export_capability(result, diagram_id)
+        return _attach_lifecycle_receipt(attach_export_capability(result, diagram_id), diagram_id, image_present=True, session_present=True)
 
     # No need to pre-compress, vision analyzer and classifier handle it internally
     compressed_bytes, compressed_type = image_bytes, content_type
@@ -538,7 +606,7 @@ async def analyze_diagram(request: Request, diagram_id: str, _auth=Depends(verif
     if user:
         maybe_save_from_session(user.id, result, diagram_id)
 
-    return attach_export_capability(result, diagram_id)
+    return _attach_lifecycle_receipt(attach_export_capability(result, diagram_id), diagram_id, image_present=True, session_present=True)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -667,7 +735,12 @@ async def _run_analysis_job(job_id: str, diagram_id: str) -> None:
             )
 
         job_manager.update_progress(job_id, 95, "Finalizing...", phase="saving")
-        job_manager.complete(job_id, result=attach_export_capability(result, diagram_id))
+        job_manager.complete(job_id, result=_attach_lifecycle_receipt(
+            attach_export_capability(result, diagram_id),
+            diagram_id,
+            image_present=diagram_id in IMAGE_STORE,
+            session_present=True,
+        ))
 
     except Exception as exc:
         logger.error("Async analysis failed for %s: %s", str(diagram_id).replace('\n', '').replace('\r', ''), str(exc).replace('\n', '').replace('\r', ''), exc_info=True)  # codeql[py/log-injection] Handled by custom

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -272,6 +272,18 @@ class TestPurge:
         with patch("routers.diagrams.analyze_image", return_value=copy.deepcopy(MOCK_ANALYSIS)):
             analyzed = client.post(f"/api/diagrams/{did}/analyze", headers=tenant_a_auth_headers)
         assert analyzed.status_code == 200
+        analysis_payload = analyzed.json()
+        receipt = analysis_payload["trust_receipt"]
+        assert receipt["schema_version"] == "2026-05-25"
+        assert receipt["correlation_id"] == did
+        assert receipt["retention"]["class"] == "ephemeral-analysis"
+        assert receipt["retention"]["customer_content_ttl_seconds"] == 7200
+        assert receipt["retention"]["uploaded_at"] is not None
+        assert receipt["retention"]["expires_at"] is not None
+        assert receipt["export_capability"]["status"] == "issued"
+        assert receipt["ai_processing"]["training_use"] == "not_used_by_archmorph_for_model_training"
+        assert receipt["audit_security_logs"]["retained"] is True
+        assert receipt["audit_security_logs"]["contains_customer_content"] is False
         assert did in SESSION_STORE
         assert did in IMAGE_STORE
 
@@ -292,6 +304,17 @@ class TestPurge:
         assert payload["purged"]["session"] is True
         assert payload["purged"]["jobs"] >= 1
         assert payload["purged"]["iac_chat"] is True
+        purge_receipt = payload["trust_receipt"]
+        assert purge_receipt["status"] == "purged"
+        assert purge_receipt["purge"]["status"] == "purged"
+        assert purge_receipt["purge"]["client_cache_action"] == "clear_session_storage_after_successful_purge"
+        assert purge_receipt["purge"]["audit_security_logs_retained"] is True
+        assert purge_receipt["audit_security_logs"]["retained"] is True
+        assert purge_receipt["audit_security_logs"]["contains_customer_content"] is False
+        assert purge_receipt["purge"]["server_content_deleted"] is True
+        assert purge_receipt["artifacts"]["uploaded_content"] == "purged"
+        assert purge_receipt["artifacts"]["analysis_session"] == "purged"
+        assert purge_receipt["artifacts"]["project_index"] == "purged"
 
         assert did not in IMAGE_STORE
         assert did not in SESSION_STORE

--- a/docs/security/data-lifecycle-trust-receipts.md
+++ b/docs/security/data-lifecycle-trust-receipts.md
@@ -1,0 +1,36 @@
+# Data Lifecycle Trust Receipts
+
+Archmorph treats uploaded architecture diagrams and derived analysis payloads as ephemeral customer content. The trust receipt is the customer-safe record of what the current analysis stored, when it expires, how export capability is scoped, and what remains after purge.
+
+## Retention Classes
+
+| Class | Scope | Default retention window | Purge behavior |
+| --- | --- | ---: | --- |
+| `ephemeral-analysis` | Uploaded bytes, analysis session payload, project diagram index, generated artifact capability state, queued analysis job state, and IaC chat state for a diagram | 2 hours | Deleted immediately by `DELETE /api/diagrams/{diagram_id}/purge` |
+| `security-audit` | Operational metadata such as correlation ID, project ID, event type, and deletion outcome | 30 days | Retained after customer content purge |
+
+The `security-audit` class must not contain uploaded diagram bytes, prompts, generated customer artifacts, API keys, bearer tokens, or export capability tokens.
+
+## Receipt Schema
+
+Every receipt uses `schema_version: 2026-05-25` and includes:
+
+- `receipt_id`: generated opaque receipt identifier.
+- `correlation_id`: customer-safe run identifier, currently the diagram ID.
+- `diagram_id` and `project_id`: identifiers needed for support and audit correlation.
+- `retention`: retention class, content TTL, uploaded timestamp, and expiry timestamp.
+- `export_capability`: whether a one-time export capability was issued and its remaining TTL.
+- `ai_processing`: processing purpose and model-training disclosure.
+- `artifacts`: backend artifact presence or deletion status.
+- `purge`: deletion status, server deletion confirmation, and the required client cache action.
+- `audit_security_logs`: audit retention boundary and customer-content exclusion.
+
+## Purge Semantics
+
+The purge endpoint deletes server-side customer content for the current diagram: uploaded bytes, analysis session payload, project index membership, share records, export capabilities, async jobs/events, and IaC chat state. The response includes a purge receipt that confirms which artifact groups were deleted.
+
+The browser must clear the current diagram session cache after a successful purge. The frontend does this before resetting the workbench and keeps the purge receipt visible so the user can download it as JSON.
+
+## Non-Goals For This Slice
+
+This slice does not introduce durable workspace records, historical analysis versions, or long-lived artifact ledgers. Those belong to the durable workspace work tracked separately in #1133.

--- a/frontend/src/components/DiagramTranslator/DataLifecyclePanel.jsx
+++ b/frontend/src/components/DiagramTranslator/DataLifecyclePanel.jsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { Clock, Download, ShieldCheck, Trash2 } from 'lucide-react';
+import { Button, Card } from '../ui';
+
+function formatTimestamp(value) {
+  if (!value) return 'Pending';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+function formatDuration(seconds) {
+  if (!seconds) return 'Not issued';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h`;
+}
+
+function normalizeReceipt({ diagramId, analysis, exportCapability, purgeReceipt }) {
+  if (purgeReceipt && (!diagramId || purgeReceipt.diagram_id === diagramId)) return purgeReceipt;
+  if (analysis?.trust_receipt) return analysis.trust_receipt;
+  if (!diagramId) return null;
+  return {
+    schema_version: 'client-fallback',
+    receipt_id: `client-${diagramId}`,
+    correlation_id: diagramId,
+    diagram_id: diagramId,
+    status: 'active',
+    retention: {
+      class: null,
+      customer_content_ttl_seconds: null,
+      uploaded_at: null,
+      expires_at: null,
+    },
+    export_capability: {
+      status: exportCapability ? 'issued' : 'not_issued',
+      expires_in_seconds: null,
+    },
+    ai_processing: {
+      processor: null,
+      training_use: null,
+    },
+    artifacts: {
+      uploaded_content: 'present',
+      analysis_session: analysis ? 'present' : 'not_present',
+    },
+    purge: {
+      status: 'not_requested',
+      server_content_deleted: false,
+      client_cache_action: 'clear_session_storage_after_successful_purge',
+    },
+    audit_security_logs: {
+      retained: null,
+      contains_customer_content: null,
+      retention_days: null,
+    },
+  };
+}
+
+function downloadJson(filename, payload) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+function artifactSummary(artifacts = {}) {
+  const uploaded = artifacts.uploaded_content || 'not_present';
+  const session = artifacts.analysis_session || 'not_present';
+  return `Upload: ${uploaded} / Analysis: ${session}`;
+}
+
+function auditLogSummary(auditSecurityLogs = {}) {
+  if (auditSecurityLogs.retained === true) {
+    return `Audit/security logs retained${auditSecurityLogs.contains_customer_content === false ? ' / no customer content' : ''}`;
+  }
+  if (auditSecurityLogs.retained === false) return 'Not retained';
+  return 'Not available';
+}
+
+export default function DataLifecyclePanel({
+  diagramId,
+  analysis,
+  exportCapability,
+  purgeReceipt,
+  purgeLoading = false,
+  onPurge,
+}) {
+  const receipt = normalizeReceipt({ diagramId, analysis, exportCapability, purgeReceipt });
+  if (!receipt) return null;
+
+  const isPurged = receipt.status === 'purged' || receipt.purge?.status === 'purged';
+  const receiptDiagramId = receipt.diagram_id || diagramId;
+  const filename = `archmorph-trust-receipt-${receiptDiagramId || 'analysis'}.json`;
+
+  return (
+    <Card className={`p-4 ${isPurged ? 'border-cta/30 bg-cta/5' : 'border-info/25 bg-info/5'}`}>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-cta" aria-hidden="true" />
+            <h2 className="text-base font-semibold text-text-primary">Data lifecycle receipt</h2>
+          </div>
+          <dl className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Correlation ID</dt>
+              <dd className="mt-1 truncate font-mono text-xs text-text-primary">{receipt.correlation_id || receiptDiagramId}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Uploaded</dt>
+              <dd className="mt-1 text-sm text-text-primary">{formatTimestamp(receipt.retention?.uploaded_at)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Content expiry</dt>
+              <dd className="mt-1 flex items-center gap-1.5 text-sm text-text-primary">
+                <Clock className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+                {formatTimestamp(receipt.retention?.expires_at)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Retention class</dt>
+              <dd className="mt-1 text-sm text-text-primary">{receipt.retention?.class || 'Not available'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Export capability</dt>
+              <dd className="mt-1 text-sm text-text-primary">{formatDuration(receipt.export_capability?.expires_in_seconds)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">AI processing</dt>
+              <dd className="mt-1 text-sm text-text-primary">{receipt.ai_processing?.processor || 'Not available'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Backend artifacts</dt>
+              <dd className="mt-1 text-sm text-text-primary">{artifactSummary(receipt.artifacts)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-text-muted">Purge status</dt>
+              <dd className="mt-1 text-sm text-text-primary">{isPurged ? 'Purged' : 'Available'}</dd>
+            </div>
+            <div className="sm:col-span-2 lg:col-span-4">
+              <dt className="text-xs font-medium text-text-muted">Audit/security logs</dt>
+              <dd className="mt-1 text-sm text-text-primary">
+                {auditLogSummary(receipt.audit_security_logs)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={Download}
+            onClick={() => downloadJson(filename, receipt)}
+          >
+            Download Receipt
+          </Button>
+          {diagramId && onPurge && !isPurged && (
+            <Button
+              variant="danger"
+              size="sm"
+              icon={Trash2}
+              loading={purgeLoading}
+              onClick={onPurge}
+            >
+              Purge Current Analysis
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/DiagramTranslator/__tests__/DataLifecyclePanel.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/DataLifecyclePanel.test.jsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import DataLifecyclePanel from '../../DiagramTranslator/DataLifecyclePanel'
+
+const receipt = {
+  schema_version: '2026-05-25',
+  receipt_id: 'tr-abc123',
+  correlation_id: 'diag-1',
+  diagram_id: 'diag-1',
+  status: 'active',
+  retention: {
+    class: 'ephemeral-analysis',
+    customer_content_ttl_seconds: 7200,
+    uploaded_at: '2026-05-25T10:00:00+00:00',
+    expires_at: '2026-05-25T12:00:00+00:00',
+  },
+  export_capability: {
+    status: 'issued',
+    expires_in_seconds: 900,
+  },
+  ai_processing: {
+    processor: 'Azure OpenAI',
+    training_use: 'not_used_by_archmorph_for_model_training',
+  },
+  artifacts: {
+    uploaded_content: 'present',
+    analysis_session: 'present',
+  },
+  purge: {
+    status: 'not_requested',
+    server_content_deleted: false,
+    client_cache_action: 'clear_session_storage_after_successful_purge',
+  },
+  audit_security_logs: {
+    retained: true,
+    retention_days: 30,
+    contains_customer_content: false,
+  },
+}
+
+describe('DataLifecyclePanel', () => {
+  beforeEach(() => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:trust-receipt')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const createElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      const element = createElement(tagName, options)
+      if (tagName === 'a') element.click = vi.fn()
+      return element
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows lifecycle receipt fields from backend analysis', () => {
+    render(<DataLifecyclePanel diagramId="diag-1" analysis={{ trust_receipt: receipt }} exportCapability="cap-token" />)
+
+    expect(screen.getByText('Data lifecycle receipt')).toBeInTheDocument()
+    expect(screen.getByText('diag-1')).toBeInTheDocument()
+    expect(screen.getByText('ephemeral-analysis')).toBeInTheDocument()
+    expect(screen.getByText('15m')).toBeInTheDocument()
+    expect(screen.getByText('Azure OpenAI')).toBeInTheDocument()
+    expect(screen.getByText('Upload: present / Analysis: present')).toBeInTheDocument()
+    expect(screen.getByText('Audit/security logs retained / no customer content')).toBeInTheDocument()
+  })
+
+  it('calls purge handler from the active receipt', async () => {
+    const user = userEvent.setup()
+    const onPurge = vi.fn()
+    render(<DataLifecyclePanel diagramId="diag-1" analysis={{ trust_receipt: receipt }} onPurge={onPurge} />)
+
+    await user.click(screen.getByRole('button', { name: /Purge Current Analysis/i }))
+    expect(onPurge).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows purge confirmation and hides purge action after deletion', () => {
+    const purgeReceipt = {
+      ...receipt,
+      status: 'purged',
+      purge: { ...receipt.purge, status: 'purged', server_content_deleted: true },
+      artifacts: { uploaded_content: 'purged', analysis_session: 'purged' },
+    }
+    render(<DataLifecyclePanel purgeReceipt={purgeReceipt} onPurge={vi.fn()} />)
+
+    expect(screen.getByText('Purged')).toBeInTheDocument()
+    expect(screen.getByText('Upload: purged / Analysis: purged')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Purge Current Analysis/i })).not.toBeInTheDocument()
+  })
+
+  it('ignores stale purge receipt when a different diagram is active', () => {
+    const purgeReceipt = {
+      ...receipt,
+      status: 'purged',
+      purge: { ...receipt.purge, status: 'purged', server_content_deleted: true },
+    }
+    render(<DataLifecyclePanel diagramId="diag-2" analysis={null} purgeReceipt={purgeReceipt} />)
+
+    expect(screen.getByText('diag-2')).toBeInTheDocument()
+    expect(screen.getByText('Available')).toBeInTheDocument()
+    expect(screen.getAllByText('Not available')).toHaveLength(3)
+  })
+
+  it('downloads the receipt as JSON', async () => {
+    const user = userEvent.setup()
+    render(<DataLifecyclePanel diagramId="diag-1" analysis={{ trust_receipt: receipt }} />)
+
+    await user.click(screen.getByRole('button', { name: /Download Receipt/i }))
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:trust-receipt')
+  })
+})

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback, useEffect, Suspense, lazy, useState } from 'react';
 import {
-  Upload, ChevronRight, CheckCircle, XCircle, X, Trash2,
+  Upload, ChevronRight, CheckCircle, XCircle, X,
   Loader2, Eye, Clock, FileCode, FileText, DollarSign, Rocket, Layers3, GitMerge, LogIn,
 } from 'lucide-react';
 import { Button, Card, ErrorCard, Tabs } from '../ui';
@@ -32,6 +32,7 @@ const HLDTab = lazy(() => import('./HLDTab'));
 const PricingTab = lazy(() => import('./PricingTab'));
 const MigrationChat = lazy(() => import('./MigrationChat'));
 const DeployPanel = lazy(() => import('./DeployPanel'));
+const DataLifecyclePanel = lazy(() => import('./DataLifecyclePanel'));
 
 const normalizeIacFormat = (format) => (format === 'bicep' ? 'bicep' : 'terraform');
 const DEFAULT_PROJECT_ID = 'demo-project';
@@ -385,6 +386,7 @@ export default function DiagramTranslator() {
           set({
             diagramId: data.diagram_id,
             analysis: data.analysis || null,
+            purgeReceipt: null,
             questions: data.questions || [],
             allQuestions: data.all_questions || data.questions || [],
             questionAssumptions: data.question_assumptions || [],
@@ -411,6 +413,7 @@ export default function DiagramTranslator() {
       step: 'analyzing',
       diagramId: analysis.diagram_id,
       analysis,
+      purgeReceipt: null,
       exportCapability: analysis.export_capability || null,
       analyzeProgress: [`Loading ${analysis.template_title || analysis.diagram_type} template...`],
     });
@@ -486,11 +489,13 @@ export default function DiagramTranslator() {
 
   const handleAddProjectDiagram = () => {
     clearSelectedUpload();
-    set({ step: 'upload', iacCode: null, error: null, analysis: null });
+    set({ step: 'upload', iacCode: null, error: null, analysis: null, purgeReceipt: null });
   };
 
   const handlePurgeCurrentAnalysis = async () => {
     if (!state.diagramId) return;
+    const diagramId = state.diagramId;
+    const projectId = state.projectId;
     const confirmed = window.confirm(
       'Purge this analysis now? This deletes uploaded bytes and generated server-side artifacts for the current diagram.',
     );
@@ -498,10 +503,12 @@ export default function DiagramTranslator() {
 
     set({ loading: true, error: null });
     try {
-      await api.delete(`/diagrams/${state.diagramId}/purge`);
-      clearSession(state.diagramId);
+      const purgeResult = await api.delete(`/diagrams/${diagramId}/purge`);
+      clearSession(diagramId);
+      clearPendingUploadForAuth();
       reset();
-      if (state.projectId) await refreshProjectStatus(state.projectId);
+      set({ loading: false, purgeReceipt: purgeResult?.trust_receipt || null });
+      if (projectId) await refreshProjectStatus(projectId);
     } catch (err) {
       set({
         loading: false,
@@ -509,7 +516,6 @@ export default function DiagramTranslator() {
       });
       return;
     }
-    set({ loading: false });
   };
 
   // ── Session auto-recovery: push cached analysis back to backend on 404 ──
@@ -583,6 +589,7 @@ export default function DiagramTranslator() {
       set({
         selectedFile: file,
         filePreviewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+        purgeReceipt: null,
       });
     }
   }, [set, state.filePreviewUrl]);
@@ -601,12 +608,13 @@ export default function DiagramTranslator() {
       filePreviewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
       error: null,
       authError: null,
+      purgeReceipt: null,
     });
   }, [set, state.filePreviewUrl]);
 
   // ── Upload & Analyze ──
   const handleUpload = async (file) => {
-    set({ error: null, authError: null, step: 'analyzing', analyzeProgress: [] });
+    set({ error: null, authError: null, step: 'analyzing', analyzeProgress: [], purgeReceipt: null });
     // Create a new AbortController for this upload flow
     if (abortRef.current) abortRef.current.abort();
     const controller = new AbortController();
@@ -623,7 +631,7 @@ export default function DiagramTranslator() {
       const projectId = state.projectId || DEFAULT_PROJECT_ID;
       const uploadData = await api.post(`/projects/${projectId}/diagrams`, formData, signal);
       const { diagram_id } = uploadData;
-      set({ projectId: uploadData.project_id || projectId, diagramId: diagram_id, exportCapability: uploadData.export_capability || null });
+      set({ projectId: uploadData.project_id || projectId, diagramId: diagram_id, exportCapability: uploadData.export_capability || null, purgeReceipt: null });
       await refreshProjectStatus(uploadData.project_id || projectId);
 
       // Cache uploaded image for session restore (#333)
@@ -724,7 +732,7 @@ export default function DiagramTranslator() {
         addProgress('Analysis complete. ✓');
         await new Promise(r => setTimeout(r, 400));
 
-        set({ analysis: result, exportCapability: result.export_capability || state.exportCapability || null });
+        set({ analysis: result, exportCapability: result.export_capability || state.exportCapability || null, purgeReceipt: null });
         await refreshProjectStatus(uploadData.project_id || projectId);
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questionState = buildQuestionState(qData);
@@ -782,7 +790,7 @@ export default function DiagramTranslator() {
         addProgress('Analysis complete. ✓');
         await new Promise(r => setTimeout(r, 800));
 
-        set({ analysis: result, exportCapability: result.export_capability || uploadData.export_capability || null });
+        set({ analysis: result, exportCapability: result.export_capability || uploadData.export_capability || null, purgeReceipt: null });
         await refreshProjectStatus(uploadData.project_id || projectId);
         const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
         const questionState = buildQuestionState(qData);
@@ -829,7 +837,7 @@ export default function DiagramTranslator() {
     set({ step: 'analyzing', analyzeProgress: ['Loading sample diagram...'] });
     try {
       const result = await api.post(`/samples/${sample.id}/analyze`);
-      set({ diagramId: result.diagram_id, analysis: result, exportCapability: result.export_capability || null });
+      set({ diagramId: result.diagram_id, analysis: result, exportCapability: result.export_capability || null, purgeReceipt: null });
       for (const zone of (result.zones || [])) {
         const svcNames = (zone.services || []).map(s => s.source || s.name || '').filter(Boolean).slice(0, 3);
         addProgress(`Zone ${zone.id}: ${zone.name} (${svcNames.join(', ')})...`);
@@ -1322,22 +1330,17 @@ export default function DiagramTranslator() {
         </Card>
       )}
 
-      {state.diagramId && (
-        <Card className="p-3 border-danger/25 bg-danger/5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-text-secondary">
-              Need to remove sensitive data now? Purge the current analysis to clear uploaded bytes, session analysis, project indexes, export capabilities, and queued jobs.
-            </p>
-            <Button
-              variant="ghost"
-              size="sm"
-              icon={Trash2}
-              onClick={handlePurgeCurrentAnalysis}
-            >
-              Purge Current Analysis
-            </Button>
-          </div>
-        </Card>
+      {(state.diagramId || state.purgeReceipt) && (
+        <Suspense fallback={null}>
+          <DataLifecyclePanel
+            diagramId={state.diagramId}
+            analysis={state.analysis}
+            exportCapability={state.exportCapability}
+            purgeReceipt={state.purgeReceipt}
+            purgeLoading={state.loading && !!state.diagramId}
+            onPurge={handlePurgeCurrentAnalysis}
+          />
+        </Suspense>
       )}
 
       <ProjectPanel

--- a/frontend/src/components/DiagramTranslator/useWorkflow.js
+++ b/frontend/src/components/DiagramTranslator/useWorkflow.js
@@ -13,6 +13,7 @@ const initialState = {
   projectStatus: null,
   diagramId: null,
   exportCapability: null,
+  purgeReceipt: null,
   jobId: null,
   analysis: null,
   questions: [],


### PR DESCRIPTION
## Summary
- Add a backend trust receipt builder and attach customer-safe lifecycle receipts to upload, restore, sync analysis, async analysis completion, and purge responses.
- Replace the purge-only workbench banner with a data lifecycle receipt panel that shows retention, export capability, AI processing, backend artifact status, purge status, and audit/security log boundary.
- Keep purge confirmation visible after the workbench resets and support downloading the receipt as JSON.
- Document retention classes, receipt schema, purge semantics, and the audit-log boundary.

## Validation
- `pytest -q tests/test_api.py::TestPurge`
- `pytest -q tests/test_api.py::TestAnalyze tests/test_api.py::TestPurge tests/test_job_queue.py`
- `python3 -m py_compile data_lifecycle.py routers/diagrams.py`
- `npm test -- --run src/components/DiagramTranslator/__tests__/DataLifecyclePanel.test.jsx`
- `npm test -- --run src/components/DiagramTranslator/__tests__/index.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx src/services/__tests__/sessionCache.test.js`
- `npm run lint`
- `npm run build`
- `python3 export_openapi.py > /tmp/archmorph-openapi-1135.json && python3 check_openapi_contract.py /tmp/archmorph-openapi-1135.json`
- `git diff --check`
- `gitleaks dir <changed files> --redact`

Refs #1135