### PR TITLE
feat: add trust and evidence layer for AI service mappings (#1130)

### DIFF
--- a/backend/ai_suggestion.py
+++ b/backend/ai_suggestion.py
@@ -28,6 +28,17 @@ from openai_client import (
 
 logger = logging.getLogger(__name__)
 
+
+def _attach_evidence(mapping: Dict[str, Any]) -> None:
+    """Attach evidence block and needs_review flag to a mapping in-place (#1130)."""
+    try:
+        from mapping_evidence import build_mapping_evidence  # type: ignore[import]
+        evidence = build_mapping_evidence(mapping)
+        mapping["evidence"] = evidence
+        mapping.setdefault("needs_review", evidence["needs_review"])
+    except Exception:  # noqa: BLE001 — non-fatal, evidence is additive
+        pass
+
 # ─────────────────────────────────────────────────────────
 # In-memory admin review queue (replaced by DB in prod)
 # ─────────────────────────────────────────────────────────
@@ -684,6 +695,8 @@ def suggest_mapping(
         # Add deep-dive data for catalogue matches too (#404)
         result["confidence_factors"] = _build_confidence_factors(result, source_service)
         result.update(build_mapping_deep_dive(result, source_service))
+        # ── Trust/evidence layer (#1130) ──
+        _attach_evidence(result)
         return result
 
     # Slow path — GPT-4o
@@ -721,6 +734,9 @@ def suggest_mapping(
         # ── Deep-dive strengths/limitations/migration notes (#404) ──
         **build_mapping_deep_dive(suggestion, source_service),
     }
+
+    # ── Trust/evidence layer (#1130) ──
+    _attach_evidence(result)
 
     # Queue for review unless auto-approved (confidence >= 0.9)
     if auto_queue_review and result["confidence"] < _AUTO_APPROVE_THRESHOLD:

--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -139,6 +139,7 @@ def _render_html_package(
     )
     cost_filename = _cost_assumptions_filename(manifest)
     cost_panel = _render_cost_assumptions_panel(manifest.get("cost_assumptions", {}), cost_filename)
+    methodology_panel = _render_methodology_panel(analysis, manifest)
 
     manifest_json = _manifest_json(manifest)
     cost_assumptions_json = _manifest_json(manifest.get("cost_assumptions", {}))
@@ -162,7 +163,7 @@ def _render_html_package(
     .brand-pill {{ display: inline-flex; align-items: center; min-height: 28px; border-radius: 8px; padding: 5px 9px; background: var(--soft); color: #155f9f; font-size: 12px; font-weight: 700; }}
     .story {{ display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 14px 0; padding: 12px 14px; background: #fff; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); font-size: 13px; }}
     .story strong {{ color: var(--ink); }}
-    nav {{ display: grid; grid-template-columns: repeat(5, minmax(160px, 1fr)); gap: 10px; margin-bottom: 14px; position: sticky; top: 0; z-index: 2; background: rgba(246, 248, 251, 0.94); padding: 8px 0; backdrop-filter: blur(8px); }}
+    nav {{ display: grid; grid-template-columns: repeat(6, minmax(140px, 1fr)); gap: 10px; margin-bottom: 14px; position: sticky; top: 0; z-index: 2; background: rgba(246, 248, 251, 0.94); padding: 8px 0; backdrop-filter: blur(8px); }}
     button.tab {{ border: 1px solid var(--line); background: #fff; color: var(--ink); border-radius: 8px; padding: 11px 12px; font: inherit; font-size: 13px; font-weight: 750; cursor: pointer; text-align: left; box-shadow: 0 4px 14px rgba(17, 24, 39, 0.04); }}
     button.tab span {{ display: block; margin-top: 4px; color: var(--muted); font-size: 11px; font-weight: 650; }}
     button.tab[aria-selected="true"] {{ border-color: #b8d8f5; background: #edf4ff; color: #074f87; }}
@@ -207,6 +208,16 @@ def _render_html_package(
         .insight-b {{ font-size: 13px; line-height: 1.5; color: #314158; }}
         .cost-actions {{ display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 12px; }}
         .download-link {{ display: inline-flex; align-items: center; min-height: 34px; border: 1px solid #b8d8f5; border-radius: 8px; padding: 7px 10px; background: #edf4ff; color: #074f87; font-size: 12px; font-weight: 800; text-decoration: none; }}
+        .review-flag {{ display: inline-flex; align-items: center; gap: 5px; border-radius: 6px; padding: 4px 9px; background: #fff3cd; border: 1px solid #fbbf24; color: #92400e; font-size: 11px; font-weight: 800; }}
+        .mapping-ev {{ border: 1px solid #e7edf5; border-radius: 8px; padding: 10px; margin: 4px 0; background: #fbfdff; }}
+        .mapping-ev-h {{ font-size: 12px; font-weight: 800; color: var(--ink); margin-bottom: 4px; }}
+        .mapping-ev-svc {{ display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 700; }}
+        .mapping-ev-conf {{ font-size: 11px; padding: 2px 7px; border-radius: 6px; font-weight: 800; }}
+        .conf-high {{ background: #dcfce7; color: #15803d; }}
+        .conf-med {{ background: #fef3c7; color: #92400e; }}
+        .conf-low {{ background: #fee2e2; color: #b91c1c; }}
+        .mapping-ev-rationale {{ font-size: 12px; color: #314158; line-height: 1.5; margin: 6px 0; }}
+        .mapping-ev-gaps {{ font-size: 11px; color: #92400e; margin-top: 4px; padding-left: 14px; }}
         footer {{ margin-top: 16px; color: var(--muted); font-size: 12px; }}
         @media (max-width: 900px) {{ .shell {{ padding: 12px; }} header {{ flex-direction: column; }} .meta-pills {{ justify-content: flex-start; }} .grid {{ grid-template-columns: 1fr; }} .dr-layout {{ grid-template-columns: 1fr; }} nav {{ grid-template-columns: 1fr; position: static; }} }}
   </style>
@@ -217,13 +228,14 @@ def _render_html_package(
         <div class="brand"><div class="mark">A↻</div><div><h1>{title}</h1><p>Cross-cloud architecture translation and Azure hardening package</p></div></div>
         <div class="meta-pills"><span class="brand-pill">Customer / workload: {display_name}</span><span class="brand-pill">Source: {source}</span><span class="brand-pill">Target: Azure</span><span class="brand-pill">Region: {target_region}</span></div>
     </header>
-    <div class="story"><strong>{source_file}</strong><span>→</span><span>Archmorph produced five review outputs:</span><span class="brand-pill">A · Target</span><span class="brand-pill">B · DR</span><span class="brand-pill">C · Talking Points</span><span class="brand-pill">D · Limitations</span><span class="brand-pill">E · Cost Assumptions JSON</span></div>
+    <div class="story"><strong>{source_file}</strong><span>→</span><span>Archmorph produced six review outputs:</span><span class="brand-pill">A · Target</span><span class="brand-pill">B · DR</span><span class="brand-pill">C · Talking Points</span><span class="brand-pill">D · Limitations</span><span class="brand-pill">E · Cost Assumptions JSON</span><span class="brand-pill">F · Evidence &amp; Methodology</span></div>
     <nav aria-label="Architecture package sections">
         <button class="tab" type="button" data-tab="as-is" aria-selected="true">A — Target Azure Topology<span>customer-ready package</span></button>
         <button class="tab" type="button" data-tab="dr" aria-selected="false">B — DR Topology<span>resilience review</span></button>
         <button class="tab" type="button" data-tab="talking" aria-selected="false">C — Talking Points<span>customer-facing narrative</span></button>
         <button class="tab" type="button" data-tab="limits" aria-selected="false">D — Services Limitations<span>technical gotchas</span></button>
         <button class="tab" type="button" data-tab="cost" aria-selected="false">E — Cost Assumptions<span>reviewable JSON artifact</span></button>
+        <button class="tab" type="button" data-tab="methodology" aria-selected="false">F — Evidence &amp; Methodology<span>trust provenance</span></button>
     </nav>
     <main>
     <section id="as-is" class="panel active"><div class="diagram">{primary_svg}</div></section>
@@ -231,6 +243,7 @@ def _render_html_package(
         <section id="talking" class="panel"><div class="grid"><div class="block"><h2>Customer Intent</h2><div class="intent">{intent_rows}</div></div><div class="block"><h2>Recommended Narrative</h2><div class="insight-list">{talking_points}</div></div></div></section>
         <section id="limits" class="panel"><div class="grid"><div class="block"><h2>Service Tiers</h2><ul class="tiers">{tier_summary}</ul></div><div class="block"><h2>Assumptions And Constraints</h2><div class="insight-list">{limitations}</div></div></div></section>
           <section id="cost" class="panel">{cost_panel}</section>
+          <section id="methodology" class="panel">{methodology_panel}</section>
   </main>
     <footer>Archmorph · {display_name} · {source} → Azure · generated from the customer-uploaded architecture diagram.</footer>
     </div>
@@ -292,6 +305,110 @@ def _cost_assumptions_filename(manifest: dict[str, Any]) -> str:
     return "archmorph-cost-assumptions.json"
 
 
+def _render_methodology_panel(analysis: dict[str, Any], manifest: dict[str, Any]) -> str:
+    """Render the customer-safe Evidence & Methodology HTML panel (#1130)."""
+    run_meta = manifest.get("run_metadata") or {}
+    mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
+
+    # Run details row
+    run_id = html.escape(str(run_meta.get("run_id") or manifest.get("analysis_id") or "N/A"))
+    generated_at = html.escape(str(run_meta.get("analysis_timestamp") or manifest.get("generated_at") or "N/A"))
+    source_provider = html.escape(str(run_meta.get("source_provider") or manifest.get("source_provider") or "N/A"))
+    target_provider = html.escape(str(run_meta.get("target_provider") or "Azure"))
+    total_mappings = html.escape(str(run_meta.get("total_mappings") or len(mappings)))
+    low_conf_count = html.escape(str(run_meta.get("low_confidence_count") or sum(
+        1 for m in mappings if float(m.get("confidence") or 0) < 0.70
+    )))
+    needs_review_count = html.escape(str(run_meta.get("needs_review_count") or sum(
+        1 for m in mappings if m.get("needs_review")
+    )))
+
+    freshness = run_meta.get("catalog_freshness") or {}
+    catalog_last_success = html.escape(str(freshness.get("last_success") or "N/A"))
+    catalog_stale = freshness.get("stale", False)
+    catalog_stale_note = " ⚠ Catalog refresh overdue" if catalog_stale else ""
+
+    methodology = html.escape(str(run_meta.get("methodology") or ""))
+    limitation_items = run_meta.get("limitations") or []
+    limitation_html = "\n".join(
+        f"<li>{html.escape(str(item))}</li>" for item in limitation_items
+    )
+
+    # Per-mapping evidence rows (up to 50)
+    mapping_rows = []
+    for m in mappings[:50]:
+        src = html.escape(str(m.get("source_service") or ""))
+        tgt = html.escape(str(m.get("azure_service") or ""))
+        conf_raw = float(m.get("confidence") or 0)
+        conf_pct = f"{conf_raw * 100:.0f}%"
+        conf_cls = "conf-high" if conf_raw >= 0.9 else ("conf-med" if conf_raw >= 0.7 else "conf-low")
+        evidence = m.get("evidence") or {}
+        rationale = html.escape(str(evidence.get("rationale") or m.get("notes") or ""))
+        detection_source = html.escape(str(evidence.get("detection_source") or m.get("source") or "unknown"))
+        gaps = evidence.get("known_gaps") or []
+        gaps_html = ""
+        if gaps:
+            items = "".join(f"<li>{html.escape(str(g))}</li>" for g in gaps[:3])
+            gaps_html = f'<ul class="mapping-ev-gaps">{items}</ul>'
+        needs_review = m.get("needs_review") or evidence.get("needs_review")
+        review_flag = '<span class="review-flag">⚠ Needs review</span>' if needs_review else ""
+        alts = evidence.get("alternatives_considered") or []
+        alts_text = ""
+        if alts:
+            alt_names = html.escape(", ".join(
+                str(a.get("azure_service") or a) for a in alts[:3] if a
+            ))
+            alts_text = f'<div class="mapping-ev-rationale" style="font-style:italic;color:#526178">Alternatives: {alt_names}</div>'
+        freshness_date = html.escape(str(evidence.get("catalog_freshness") or ""))
+        freshness_note = f'<div style="font-size:11px;color:#526178">Catalog: {freshness_date}</div>' if freshness_date else ""
+        mapping_rows.append(
+            f'<div class="mapping-ev">'
+            f'<div class="mapping-ev-h"><span class="mapping-ev-svc">'
+            f'<strong>{src}</strong>'
+            f'<span style="color:#526178">→</span>'
+            f'<span style="color:#0078d4">{tgt}</span>'
+            f'<span class="mapping-ev-conf {conf_cls}">{conf_pct}</span>'
+            f'<span style="font-size:11px;color:#526178">via {detection_source}</span>'
+            f'</span>{review_flag}</div>'
+            f'<div class="mapping-ev-rationale">{rationale}</div>'
+            f'{alts_text}'
+            f'{freshness_note}'
+            f'{gaps_html}'
+            f'</div>'
+        )
+
+    mapping_section = "\n".join(mapping_rows) if mapping_rows else (
+        '<div class="insight-row"><div class="insight-b">No mapping evidence available for this package.</div></div>'
+    )
+
+    return (
+        f'<div class="grid">'
+        f'<div class="block">'
+        f'<h2>Run Details</h2>'
+        f'<div class="intent">'
+        f'<div><span>Run / Correlation ID</span><strong style="font-family:monospace;font-size:11px">{run_id}</strong></div>'
+        f'<div><span>Analysis Timestamp</span><strong>{generated_at}</strong></div>'
+        f'<div><span>Source Provider</span><strong>{source_provider}</strong></div>'
+        f'<div><span>Target Provider</span><strong>{target_provider}</strong></div>'
+        f'<div><span>Total Mappings</span><strong>{total_mappings}</strong></div>'
+        f'<div><span>Low Confidence (&lt;70%)</span><strong>{low_conf_count}</strong></div>'
+        f'<div><span>Needs Review</span><strong>{needs_review_count}</strong></div>'
+        f'<div><span>Catalog Last Refreshed</span><strong>{catalog_last_success}{html.escape(catalog_stale_note)}</strong></div>'
+        f'</div>'
+        f'<h2 style="margin-top:16px">Methodology &amp; Limitations</h2>'
+        f'<div class="insight-b" style="margin-bottom:10px">{methodology}</div>'
+        f'<ul>{limitation_html}</ul>'
+        f'</div>'
+        f'<div class="block">'
+        f'<h2>Mapping Evidence</h2>'
+        f'<p class="insight-b" style="margin-bottom:10px">Per-service evidence and rationale for each Azure target mapping. '
+        f'Mappings flagged <em>Needs review</em> have confidence below 70&#37; and must be confirmed by the architecture owner.</p>'
+        f'{mapping_section}'
+        f'</div>'
+        f'</div>'
+    )
+
+
 def _build_manifest(
     analysis: dict[str, Any],
     *,
@@ -309,6 +426,9 @@ def _build_manifest(
     unsupported = analysis.get("unsupported_assumptions") or analysis.get("unsupported") or []
     if not isinstance(unsupported, list):
         unsupported = [unsupported]
+
+    # ── Run metadata / trust provenance (#1130) ──
+    run_metadata = _build_run_metadata(analysis, analysis_id=analysis_id)
 
     manifest = {
         "schema_version": "architecture-package-manifest/v1",
@@ -337,6 +457,7 @@ def _build_manifest(
             for title, detail in limitations
         ],
         "unsupported_assumptions": [str(item) for item in unsupported if item][:10],
+        "run_metadata": run_metadata,
     }
     return _sanitize_manifest(manifest)
 
@@ -379,8 +500,47 @@ def _mapping_references(analysis: dict[str, Any]) -> list[dict[str, Any]]:
             ref["category"] = str(mapping["category"])
         if mapping.get("confidence") is not None:
             ref["confidence"] = mapping["confidence"]
+        # ── Trust/evidence layer (#1130) ──
+        if mapping.get("needs_review") is not None:
+            ref["needs_review"] = bool(mapping["needs_review"])
+        evidence = mapping.get("evidence")
+        if isinstance(evidence, dict):
+            ref["evidence"] = {
+                "detection_source": str(evidence.get("detection_source") or "unknown"),
+                "rationale": str(evidence.get("rationale") or ""),
+                "alternatives_considered": evidence.get("alternatives_considered") or [],
+                "known_gaps": evidence.get("known_gaps") or [],
+                "catalog_freshness": evidence.get("catalog_freshness"),
+                "user_override": bool(evidence.get("user_override")),
+                "user_confirmed": bool(evidence.get("user_confirmed")),
+                "needs_review": bool(evidence.get("needs_review")),
+            }
         references.append(ref)
     return references[:200]
+
+
+def _build_run_metadata(
+    analysis: dict[str, Any],
+    *,
+    analysis_id: str | None,
+) -> dict[str, Any]:
+    """Build customer-safe run metadata for the manifest (#1130)."""
+    try:
+        from mapping_evidence import build_run_metadata  # type: ignore[import]
+        meta = build_run_metadata(
+            {**analysis, "analysis_id": analysis_id or analysis.get("analysis_id")},
+            run_id=str(analysis_id or ""),
+        )
+        return meta
+    except Exception:  # noqa: BLE001
+        pass
+    return {
+        "schema_version": "run-metadata/v1",
+        "run_id": str(analysis_id or ""),
+        "analysis_timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source_provider": str(analysis.get("source_provider") or "aws").lower(),
+        "target_provider": "azure",
+    }
 
 
 def _manifest_json(manifest: dict[str, Any]) -> str:

--- a/backend/architecture_package.py
+++ b/backend/architecture_package.py
@@ -278,7 +278,7 @@ def _render_cost_assumptions_panel(cost_assumptions: Any, cost_filename: str) ->
         f"<div class=\"insight-h\">{html.escape(str(service.get('service') or 'Unknown service'))}</div>"
         f"<div class=\"insight-b\">{html.escape(str(service.get('quantity_assumption') or 'Quantity not specified.'))} "
         f"{html.escape(str(service.get('reservation_assumption') or 'Reservation not specified.'))} "
-        f"Monthly range: ${float(service.get('monthly_low') or 0):,.2f} to ${float(service.get('monthly_high') or 0):,.2f}. "
+        f"Monthly range: ${_safe_float(service.get('monthly_low')):,.2f} to ${_safe_float(service.get('monthly_high')):,.2f}. "
         f"Source: {html.escape(', '.join(str(item) for item in service.get('source_services', []) if item) or str(service.get('source_service') or 'Not mapped'))}.</div>"
         "</div>"
         for service in services[:12]
@@ -292,7 +292,7 @@ def _render_cost_assumptions_panel(cost_assumptions: Any, cost_filename: str) ->
         f"<p class=\"insight-b\">{html.escape(str(cost_assumptions.get('directional_notice') or DIRECTIONAL_COST_NOTICE))}</p>"
         f"<div class=\"intent\"><div><span>Region</span><strong>{html.escape(str(cost_assumptions.get('region') or 'Not generated'))}</strong></div>"
         f"<div><span>SKU Strategy</span><strong>{html.escape(str(cost_assumptions.get('sku_strategy') or 'Not generated'))}</strong></div>"
-        f"<div><span>Monthly Range</span><strong>${float(total.get('low') or 0):,.2f} to ${float(total.get('high') or 0):,.2f}</strong></div></div>"
+        f"<div><span>Monthly Range</span><strong>${_safe_float(total.get('low')):,.2f} to ${_safe_float(total.get('high')):,.2f}</strong></div></div>"
         f"<div class=\"insight-list\" style=\"margin-top:12px\">{rows}</div>"
         "</div>"
     )
@@ -317,7 +317,7 @@ def _render_methodology_panel(analysis: dict[str, Any], manifest: dict[str, Any]
     target_provider = html.escape(str(run_meta.get("target_provider") or "Azure"))
     total_mappings = html.escape(str(run_meta.get("total_mappings") or len(mappings)))
     low_conf_count = html.escape(str(run_meta.get("low_confidence_count") or sum(
-        1 for m in mappings if float(m.get("confidence") or 0) < 0.70
+        1 for m in mappings if _safe_float(m.get("confidence")) < 0.70
     )))
     needs_review_count = html.escape(str(run_meta.get("needs_review_count") or sum(
         1 for m in mappings if m.get("needs_review")
@@ -339,7 +339,7 @@ def _render_methodology_panel(analysis: dict[str, Any], manifest: dict[str, Any]
     for m in mappings[:50]:
         src = html.escape(str(m.get("source_service") or ""))
         tgt = html.escape(str(m.get("azure_service") or ""))
-        conf_raw = float(m.get("confidence") or 0)
+        conf_raw = _safe_float(m.get("confidence"))
         conf_pct = f"{conf_raw * 100:.0f}%"
         conf_cls = "conf-high" if conf_raw >= 0.9 else ("conf-med" if conf_raw >= 0.7 else "conf-low")
         evidence = m.get("evidence") or {}
@@ -552,6 +552,13 @@ def _manifest_json(manifest: dict[str, Any]) -> str:
     )
 
 
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _embed_svg_manifest(svg: str, manifest: dict[str, Any]) -> str:
     manifest_json = _manifest_json(manifest)
     metadata = (
@@ -644,7 +651,7 @@ def _talking_points(analysis: dict[str, Any], profile: dict[str, str]) -> list[t
     regions = infer_regions(analysis, dr_variant="primary")
     dr_mode = infer_dr_mode({**analysis, "regions": regions})
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
-    high_conf = sum(1 for m in mappings if float(m.get("confidence") or 0) >= 0.9)
+    high_conf = sum(1 for m in mappings if _safe_float(m.get("confidence")) >= 0.9)
     source = _source_label(analysis)
     target_region = profile.get("region") or regions[0].get("name", "the selected Azure region")
 
@@ -909,7 +916,7 @@ def _source_label(analysis: dict[str, Any]) -> str:
 def _limitations(analysis: dict[str, Any], profile: dict[str, str]) -> list[tuple[str, str]]:
     warnings = [str(_sanitize_manifest(str(w))) for w in analysis.get("warnings", []) if w]
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
-    low_conf = [m for m in mappings if float(m.get("confidence") or 0) < 0.8]
+    low_conf = [m for m in mappings if _safe_float(m.get("confidence")) < 0.8]
     limits = [("Review warning", warning) for warning in warnings[:5]]
     if low_conf:
         names = ", ".join(str(m.get("azure_service") or m.get("target") or "Unknown") for m in low_conf[:4])

--- a/backend/mapping_evidence.py
+++ b/backend/mapping_evidence.py
@@ -1,0 +1,360 @@
+"""Mapping Evidence & Rationale Contract (issue #1130).
+
+Provides a reusable evidence envelope for every AI service mapping.
+Evidence is customer-safe: no secrets, no environment-specific details.
+
+Evidence fields per mapping
+───────────────────────────
+- detection_source     : "catalogue" | "ai" | "user" | "sample" | "infra_import"
+- detection_confidence : raw float confidence (0–1)
+- rationale            : human-readable reason why this Azure service was chosen
+- alternatives_considered : list of alternative Azure services weighed
+- known_gaps           : no-direct-equivalent notes and feature gaps
+- catalog_freshness    : last_reviewed date from the catalog entry (if any)
+- user_override        : True if the user changed or confirmed the mapping
+- user_confirmed       : True if the user explicitly confirmed the mapping
+- needs_review         : True when confidence < NEEDS_REVIEW_THRESHOLD
+
+Run metadata (build_run_metadata)
+──────────────────────────────────
+- run_id               : stable correlation / support ID for the analysis run
+- analysis_timestamp   : ISO-8601 UTC timestamp of the analysis
+- source_provider      : "aws" | "gcp"
+- target_provider      : "azure"
+- catalog_freshness    : freshness info from freshness_registry (age, stale flag)
+- model_version        : AI model identifier used for suggestions
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from services.mappings import CROSS_CLOUD_MAPPINGS
+
+# Confidence below this threshold flags the mapping for human review.
+NEEDS_REVIEW_THRESHOLD = 0.70
+
+# Build a lookup from (source_aws_lower or source_gcp_lower) → catalog row
+_CATALOG_BY_AWS: Dict[str, Dict[str, Any]] = {}
+_CATALOG_BY_GCP: Dict[str, Dict[str, Any]] = {}
+
+for _row in CROSS_CLOUD_MAPPINGS:
+    if _row.get("aws"):
+        _CATALOG_BY_AWS[_row["aws"].lower()] = _row
+    if _row.get("gcp"):
+        _CATALOG_BY_GCP[_row["gcp"].lower()] = _row
+
+
+# ─────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────
+
+def build_mapping_evidence(
+    mapping: Dict[str, Any],
+    *,
+    run_id: Optional[str] = None,
+    analysis_timestamp: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a standardised evidence block for a single service mapping.
+
+    Parameters
+    ----------
+    mapping : dict
+        The mapping dict (must contain ``source_service``, ``azure_service``,
+        ``confidence``, and optionally ``source``, ``alternatives``,
+        ``feature_gaps``, ``notes``, ``source_provider``).
+    run_id : str | None
+        Correlation ID for the analysis run. If omitted a UUID is generated.
+    analysis_timestamp : str | None
+        ISO-8601 UTC timestamp. If omitted the current time is used.
+
+    Returns
+    -------
+    dict
+        Evidence block suitable for embedding directly in the mapping dict.
+    """
+    source_service = str(mapping.get("source_service") or "")
+    azure_service = str(mapping.get("azure_service") or mapping.get("target_service") or "")
+    confidence = float(mapping.get("confidence") or 0)
+    source = str(mapping.get("source") or "unknown")
+    source_provider = str(mapping.get("source_provider") or "aws").lower()
+
+    # --- rationale ---
+    rationale = _build_rationale(mapping, source_service, azure_service, source)
+
+    # --- alternatives considered ---
+    alternatives = _build_alternatives(mapping)
+
+    # --- known gaps ---
+    known_gaps = _build_known_gaps(mapping)
+
+    # --- catalog freshness ---
+    catalog_freshness = _lookup_catalog_freshness(source_service, source_provider)
+
+    # --- user override status ---
+    user_override = bool(mapping.get("user_override") or mapping.get("user_added"))
+    user_confirmed = bool(
+        mapping.get("user_confirmed")
+        or mapping.get("review_status") in ("approved", "user_confirmed")
+        or source == "user"
+    )
+
+    # --- needs review ---
+    needs_review = confidence < NEEDS_REVIEW_THRESHOLD and not user_confirmed
+
+    return {
+        "detection_source": source,
+        "detection_confidence": round(confidence, 4),
+        "rationale": rationale,
+        "alternatives_considered": alternatives,
+        "known_gaps": known_gaps,
+        "catalog_freshness": catalog_freshness,
+        "user_override": user_override,
+        "user_confirmed": user_confirmed,
+        "needs_review": needs_review,
+        "run_id": run_id or "",
+        "generated_at": analysis_timestamp or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def build_run_metadata(
+    analysis: Dict[str, Any],
+    *,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build run-level metadata for an analysis result.
+
+    This is embedded in manifests and exports so downstream consumers (including
+    customers) can trace a package back to its originating run, catalog version,
+    and model.
+
+    Parameters
+    ----------
+    analysis : dict
+        The full analysis result.
+    run_id : str | None
+        Stable correlation / support ID for the run.  If omitted a UUID is
+        generated (and will differ between calls — pass the same ID for a
+        given analysis session).
+
+    Returns
+    -------
+    dict
+        Run metadata block.
+    """
+    stable_run_id = run_id or str(analysis.get("run_id") or analysis.get("correlation_id") or uuid.uuid4())
+    source_provider = str(
+        analysis.get("source_provider") or analysis.get("provider") or "aws"
+    ).lower()
+    target_provider = str(analysis.get("target_provider") or "azure").lower()
+    analysis_timestamp = str(
+        analysis.get("analysis_timestamp")
+        or analysis.get("generated_at")
+        or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+
+    # Catalog freshness from freshness_registry (best effort)
+    catalog_freshness = _get_catalog_freshness_from_registry()
+
+    # Confidence summary from mappings
+    mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
+    low_conf = sum(1 for m in mappings if float(m.get("confidence") or 0) < NEEDS_REVIEW_THRESHOLD)
+    needs_review_count = sum(1 for m in mappings if m.get("evidence", {}).get("needs_review") or
+                             (float(m.get("confidence") or 0) < NEEDS_REVIEW_THRESHOLD and
+                              not m.get("evidence", {}).get("user_confirmed")))
+
+    return {
+        "schema_version": "run-metadata/v1",
+        "run_id": stable_run_id,
+        "analysis_timestamp": analysis_timestamp,
+        "source_provider": source_provider,
+        "target_provider": target_provider,
+        "catalog_freshness": catalog_freshness,
+        "model_version": "gpt-4o",
+        "total_mappings": len(mappings),
+        "low_confidence_count": low_conf,
+        "needs_review_count": needs_review_count,
+        "methodology": _METHODOLOGY_SUMMARY,
+        "limitations": _CUSTOMER_SAFE_LIMITATIONS,
+    }
+
+
+def attach_evidence_to_mappings(
+    mappings: List[Dict[str, Any]],
+    *,
+    run_id: Optional[str] = None,
+    analysis_timestamp: Optional[str] = None,
+) -> None:
+    """Attach an ``evidence`` block and ``needs_review`` flag to each mapping in-place.
+
+    Idempotent: mappings that already carry an ``evidence`` block are skipped
+    unless the existing block is missing ``needs_review``.
+    """
+    ts = analysis_timestamp or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    for m in mappings:
+        if not isinstance(m, dict):
+            continue
+        existing_evidence = m.get("evidence")
+        if isinstance(existing_evidence, dict) and "needs_review" in existing_evidence:
+            continue
+        evidence = build_mapping_evidence(m, run_id=run_id, analysis_timestamp=ts)
+        m["evidence"] = evidence
+        # Promote needs_review to the top level for quick filtering
+        m.setdefault("needs_review", evidence["needs_review"])
+
+
+# ─────────────────────────────────────────────────────────
+# Internal helpers
+# ─────────────────────────────────────────────────────────
+
+def _build_rationale(
+    mapping: Dict[str, Any],
+    source_service: str,
+    azure_service: str,
+    source: str,
+) -> str:
+    """Build a human-readable rationale string."""
+    # Use existing notes/confidence_explanation if meaningful
+    notes = str(mapping.get("notes") or "").strip()
+    # Remove zone annotations (e.g. "Zone 1 – Web: some note")
+    import re
+    notes = re.sub(r"^Zone\s+\d+\s*[–\-]\s*[^:]+:\s*", "", notes).strip()
+
+    if source == "catalogue":
+        base = f"{azure_service} is the recommended Azure equivalent for {source_service} per the Archmorph curated service catalog."
+        if notes:
+            base += f" {notes}."
+        return base
+    if source == "user":
+        return f"{azure_service} was manually specified by the user for {source_service}."
+    if source in ("ai", "gpt"):
+        base = f"{azure_service} was selected by AI analysis as the best Azure match for {source_service}."
+        if notes:
+            base += f" {notes}."
+        return base
+    if source == "sample":
+        base = f"{azure_service} is mapped from a pre-verified sample architecture for {source_service}."
+        if notes:
+            base += f" {notes}."
+        return base
+    if source == "infra_import":
+        return f"{azure_service} was inferred from IaC/infrastructure import for {source_service}."
+    # Generic fallback
+    base = f"{azure_service} is the suggested Azure equivalent for {source_service}."
+    if notes:
+        base += f" {notes}."
+    return base
+
+
+def _build_alternatives(mapping: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract alternative Azure services from the mapping."""
+    raw = mapping.get("alternatives") or []
+    if not isinstance(raw, list):
+        return []
+    result = []
+    for alt in raw:
+        if isinstance(alt, dict):
+            result.append({
+                "azure_service": str(alt.get("name") or alt.get("azure_service") or ""),
+                "confidence": float(alt.get("confidence") or 0),
+                "rationale": str(alt.get("rationale") or alt.get("notes") or ""),
+            })
+        elif isinstance(alt, str) and alt.strip():
+            result.append({"azure_service": alt.strip(), "confidence": 0.0, "rationale": ""})
+    return result[:5]  # cap at 5 alternatives
+
+
+def _build_known_gaps(mapping: Dict[str, Any]) -> List[str]:
+    """Collect known gaps, feature gaps, and no-direct-equivalent notes."""
+    gaps: List[str] = []
+    # Feature gaps from AI suggestion
+    for gap in (mapping.get("feature_gaps") or []):
+        if isinstance(gap, str) and gap.strip():
+            gaps.append(gap.strip())
+    # Limitations (structured)
+    for lim in (mapping.get("limitations") or []):
+        if isinstance(lim, dict):
+            detail = str(lim.get("detail") or lim.get("factor") or "").strip()
+            if detail and not any(g.lower() == detail.lower() for g in gaps):
+                gaps.append(detail)
+        elif isinstance(lim, str) and lim.strip():
+            text = lim.strip()
+            if not any(g.lower() == text.lower() for g in gaps):
+                gaps.append(text)
+    # Notes that mention no-direct-equivalent
+    notes = str(mapping.get("notes") or "").lower()
+    if "no direct equivalent" in notes or "no-direct-equivalent" in notes:
+        note_text = str(mapping.get("notes") or "").strip()
+        if not any(g.lower() == note_text.lower() for g in gaps):
+            gaps.append(note_text)
+    return gaps[:10]  # cap at 10 gaps
+
+
+def _lookup_catalog_freshness(source_service: str, source_provider: str) -> Optional[str]:
+    """Return the last_reviewed date for a catalog entry, or None."""
+    key = source_service.strip().lower()
+    if source_provider == "gcp":
+        row = _CATALOG_BY_GCP.get(key)
+    else:
+        row = _CATALOG_BY_AWS.get(key)
+    if row:
+        return str(row.get("last_reviewed") or "") or None
+    return None
+
+
+def _get_catalog_freshness_from_registry() -> Dict[str, Any]:
+    """Get catalog freshness info from the freshness_registry (best effort)."""
+    try:
+        from freshness_registry import get_all  # type: ignore[import]
+        jobs = get_all()
+        for job in jobs:
+            if job.get("name") == "service_catalog_refresh":
+                return {
+                    "last_success": job.get("last_success"),
+                    "age_hours": job.get("age_hours"),
+                    "stale": job.get("stale", False),
+                    "budget_hours": job.get("budget_hours"),
+                }
+    except Exception:
+        pass
+    # Fallback: derive from catalog last_reviewed dates
+    dates = sorted(
+        {row.get("last_reviewed") for row in CROSS_CLOUD_MAPPINGS if row.get("last_reviewed")},
+        reverse=True,
+    )
+    return {
+        "last_success": dates[0] if dates else None,
+        "age_hours": None,
+        "stale": False,
+        "budget_hours": None,
+    }
+
+
+# ─────────────────────────────────────────────────────────
+# Customer-safe methodology and limitations text
+# ─────────────────────────────────────────────────────────
+
+_METHODOLOGY_SUMMARY = (
+    "Archmorph detects cloud services from the uploaded architecture diagram using "
+    "GPT-4o multimodal analysis and a curated cross-cloud mapping catalog. "
+    "Each mapping is scored using a blended confidence model: 70% catalog parity "
+    "weight plus 30% AI detection confidence. Mappings with confidence below 70% "
+    "are flagged for human review. The mapping catalog is reviewed periodically; "
+    "the catalog freshness date is included in each package manifest."
+)
+
+_CUSTOMER_SAFE_LIMITATIONS = [
+    "Archmorph produces directional mapping recommendations, not certified migration plans.",
+    "Confidence scores reflect feature-level parity; they do not account for pricing, "
+    "support agreements, or regulatory constraints specific to your organisation.",
+    "AI-suggested mappings (source='ai') should be reviewed by a qualified cloud architect "
+    "before committing to implementation.",
+    "Service catalog is updated periodically; newly released cloud services may not yet "
+    "be reflected in mapping recommendations.",
+    "Alternatives listed are indicative; the optimal choice depends on workload "
+    "characteristics not always visible in a static architecture diagram.",
+    "Mappings marked needs_review=true have confidence below 70% and must be "
+    "confirmed or overridden by the architecture owner before export.",
+]

--- a/backend/mapping_evidence.py
+++ b/backend/mapping_evidence.py
@@ -75,11 +75,11 @@ def build_mapping_evidence(
     dict
         Evidence block suitable for embedding directly in the mapping dict.
     """
-    source_service = str(mapping.get("source_service") or "")
-    azure_service = str(mapping.get("azure_service") or mapping.get("target_service") or "")
-    confidence = float(mapping.get("confidence") or 0)
-    source = str(mapping.get("source") or "unknown")
-    source_provider = str(mapping.get("source_provider") or "aws").lower()
+    source_service = _coerce_text(mapping.get("source_service"))
+    azure_service = _coerce_text(mapping.get("azure_service") or mapping.get("target_service"))
+    confidence = _safe_float(mapping.get("confidence"), default=0.0)
+    source = _coerce_text(mapping.get("source") or "unknown").lower()
+    source_provider = _coerce_text(mapping.get("source_provider") or "aws").lower()
 
     # --- rationale ---
     rationale = _build_rationale(mapping, source_service, azure_service, source)
@@ -160,9 +160,9 @@ def build_run_metadata(
 
     # Confidence summary from mappings
     mappings = [m for m in analysis.get("mappings", []) if isinstance(m, dict)]
-    low_conf = sum(1 for m in mappings if float(m.get("confidence") or 0) < NEEDS_REVIEW_THRESHOLD)
+    low_conf = sum(1 for m in mappings if _safe_float(m.get("confidence"), default=0.0) < NEEDS_REVIEW_THRESHOLD)
     needs_review_count = sum(1 for m in mappings if m.get("evidence", {}).get("needs_review") or
-                             (float(m.get("confidence") or 0) < NEEDS_REVIEW_THRESHOLD and
+                             (_safe_float(m.get("confidence"), default=0.0) < NEEDS_REVIEW_THRESHOLD and
                               not m.get("evidence", {}).get("user_confirmed")))
 
     return {
@@ -208,6 +208,31 @@ def attach_evidence_to_mappings(
 # ─────────────────────────────────────────────────────────
 # Internal helpers
 # ─────────────────────────────────────────────────────────
+
+def _coerce_text(value: Any) -> str:
+    """Return a compact customer-safe text representation for arbitrary mapping fields."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, dict):
+        for key in ("name", "source", "source_service", "azure_service", "target_service", "label", "message", "description"):
+            text = _coerce_text(value.get(key))
+            if text:
+                return text
+        return ""
+    if isinstance(value, list):
+        return ", ".join(text for text in (_coerce_text(item) for item in value) if text)
+    return str(value).strip()
+
+
+def _safe_float(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 def _build_rationale(
     mapping: Dict[str, Any],
@@ -257,9 +282,9 @@ def _build_alternatives(mapping: Dict[str, Any]) -> List[Dict[str, Any]]:
     for alt in raw:
         if isinstance(alt, dict):
             result.append({
-                "azure_service": str(alt.get("name") or alt.get("azure_service") or ""),
-                "confidence": float(alt.get("confidence") or 0),
-                "rationale": str(alt.get("rationale") or alt.get("notes") or ""),
+                "azure_service": _coerce_text(alt.get("name") or alt.get("azure_service")),
+                "confidence": _safe_float(alt.get("confidence"), default=0.0),
+                "rationale": _coerce_text(alt.get("rationale") or alt.get("notes")),
             })
         elif isinstance(alt, str) and alt.strip():
             result.append({"azure_service": alt.strip(), "confidence": 0.0, "rationale": ""})

--- a/backend/routers/samples.py
+++ b/backend/routers/samples.py
@@ -366,6 +366,7 @@ def build_sample_analysis(sample_id: str, diagram_id: str) -> dict:
                 "azure_service": azure_svc,
                 "confidence": confidence,
                 "confidence_explanation": conf_explanation,
+                "source": "sample",
                 "notes": f"Zone {zone_idx} \u2013 {zone_def['name']}: {role}. {notes_text}".strip()
             }
             deep_dive = build_mapping_deep_dive(mapping_entry, svc_name)
@@ -377,7 +378,20 @@ def build_sample_analysis(sample_id: str, diagram_id: str) -> dict:
                 mapping_entry["limitations"] = [f"Feature parity mismatch: Azure {azure_svc} may lack some specific integrations available natively in {sample['provider'].upper()}. Refer to https://learn.microsoft.com/en-us/azure/architecture/aws-professional/services for a detailed feature comparison."]
             if not mapping_entry.get("migration_notes"):
                 mapping_entry["migration_notes"] = [f"AWS usually migrates to Azure {azure_svc} with minimal refactoring." if sample['provider'] == 'aws' else f"GCP has differing networking topologies, test {azure_svc} routes."]
-            
+
+            # ── Trust/evidence layer (#1130) ──
+            try:
+                from mapping_evidence import build_mapping_evidence  # type: ignore[import]
+                # Use a deterministic timestamp derived from the catalog's last_reviewed
+                # date so repeated calls to build_sample_analysis produce identical output.
+                catalog_freshness = mapping.get("last_reviewed") if mapping else None
+                _sample_ts = f"{catalog_freshness}T00:00:00Z" if catalog_freshness else "2026-05-03T00:00:00Z"
+                evidence = build_mapping_evidence(mapping_entry, run_id=diagram_id, analysis_timestamp=_sample_ts)
+                mapping_entry["evidence"] = evidence
+                mapping_entry.setdefault("needs_review", evidence["needs_review"])
+            except Exception:  # noqa: BLE001
+                pass
+
             mappings.append(mapping_entry)
 
             zone_services.append({

--- a/backend/tests/fixtures/architecture_package_visual_snapshots.json
+++ b/backend/tests/fixtures/architecture_package_visual_snapshots.json
@@ -6,14 +6,16 @@
       "B — DR Topology",
       "C — Talking Points",
       "D — Services Limitations",
-      "E — Cost Assumptions"
+      "E — Cost Assumptions",
+      "F — Evidence &amp; Methodology"
     ],
     "panel_ids": [
       "as-is",
       "dr",
       "talking",
       "limits",
-      "cost"
+      "cost",
+      "methodology"
     ],
     "css_vars": "color-scheme: light; --ink:#111827; --muted:#526178; --line:#d9e0ea; --azure:#0078d4; --brand:#0078d4; --brand-2:#5c2d91; --bg:#f6f8fb; --card:#ffffff; --soft:#edf4ff;",
     "required_text": [

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -173,7 +173,10 @@ def test_architecture_package_html_manifest_contains_traceability_fields():
     assert manifest["renderer"] == {"name": "architecture_package", "version": "1"}
     assert len(manifest["customer_intent_profile_hash"]) == 64
     assert result["filename"] in manifest["artifact_filenames"]
-    assert {"source_service": "ALB", "azure_service": "Application Gateway", "category": "Networking", "confidence": 0.96} in manifest["mapping_references"]
+    assert any(
+        ref["source_service"] == "ALB" and ref["azure_service"] == "Application Gateway"
+        for ref in manifest["mapping_references"]
+    )
     assert manifest["dr_readiness"]["schema_version"] == "dr-readiness-rubric/v1"
     assert len(manifest["dr_readiness"]["dimensions"]) == 7
     assert manifest["cost_assumptions"]["schema_version"] == "cost-assumptions/v1"
@@ -183,7 +186,7 @@ def test_architecture_package_html_manifest_contains_traceability_fields():
     assert "cost-assumptions/v1" in result["artifact_contents"]["archmorph-web-tier-cost-assumptions.json"]
     assert "archmorph-artifact-manifest" in result["content"]
     assert "archmorph-cost-assumptions" in result["content"]
-    assert "five review outputs" in result["content"]
+    assert "six review outputs" in result["content"]
     assert "E · Cost Assumptions JSON" in result["content"]
     assert "E — Cost Assumptions" in result["content"]
     assert "id=\"download-cost-assumptions\"" in result["content"]
@@ -441,3 +444,191 @@ def test_export_architecture_package_rejects_oversized_analysis_with_413(test_cl
         "count": MAX_ANALYSIS_LIST_ITEMS + 1,
         "limit": MAX_ANALYSIS_LIST_ITEMS,
     }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Trust/evidence layer tests (#1130)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_html_package_includes_methodology_tab():
+    """The HTML package must include the F — Evidence & Methodology tab."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    content = result["content"]
+    assert "F — Evidence" in content or "F &mdash; Evidence" in content or "methodology" in content.lower()
+    assert "Evidence" in content and "Methodology" in content
+
+
+def test_html_package_methodology_tab_data_tab_attribute():
+    """The methodology tab button must carry data-tab='methodology'."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    assert 'data-tab="methodology"' in result["content"]
+
+
+def test_html_package_methodology_section_present():
+    """The methodology panel must be present in the HTML body."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    assert 'id="methodology"' in result["content"]
+
+
+def test_html_package_run_details_present():
+    """Run details (Run ID, Analysis Timestamp, Source/Target Provider) must appear in the methodology panel."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html", analysis_id="pkg-run-test")
+    content = result["content"]
+    assert "Run / Correlation ID" in content
+    assert "Analysis Timestamp" in content
+    assert "Source Provider" in content
+    assert "Target Provider" in content
+
+
+def test_html_package_mapping_evidence_rendered():
+    """Per-mapping evidence rows must appear in the methodology panel."""
+    analysis_with_evidence = {
+        **SAMPLE_ANALYSIS,
+        "mappings": [
+            {
+                "source_service": "EC2",
+                "azure_service": "Virtual Machines",
+                "confidence": 0.95,
+                "source": "catalogue",
+                "evidence": {
+                    "detection_source": "catalogue",
+                    "detection_confidence": 0.95,
+                    "rationale": "Virtual Machines is the recommended Azure equivalent for EC2.",
+                    "alternatives_considered": [],
+                    "known_gaps": [],
+                    "catalog_freshness": "2026-05-03",
+                    "user_override": False,
+                    "user_confirmed": True,
+                    "needs_review": False,
+                    "run_id": "test-run",
+                    "generated_at": "2026-05-25T12:00:00Z",
+                },
+                "needs_review": False,
+            },
+            {
+                "source_service": "UnknownSvc",
+                "azure_service": "Some Azure Service",
+                "confidence": 0.55,
+                "source": "ai",
+                "evidence": {
+                    "detection_source": "ai",
+                    "detection_confidence": 0.55,
+                    "rationale": "Some Azure Service was selected by AI analysis.",
+                    "alternatives_considered": [],
+                    "known_gaps": ["Feature gap: limited native support"],
+                    "catalog_freshness": None,
+                    "user_override": False,
+                    "user_confirmed": False,
+                    "needs_review": True,
+                    "run_id": "test-run",
+                    "generated_at": "2026-05-25T12:00:00Z",
+                },
+                "needs_review": True,
+            },
+        ],
+    }
+    result = generate_architecture_package(analysis_with_evidence, format="html")
+    content = result["content"]
+    assert "EC2" in content
+    assert "Virtual Machines" in content
+    assert "Needs review" in content  # for low-confidence mapping
+    assert "Feature gap" in content or "feature gap" in content.lower() or "known_gaps" in content.lower() or "limited native support" in content
+
+
+def test_manifest_includes_run_metadata():
+    """The manifest must include a run_metadata block with required fields."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html", analysis_id="meta-test")
+    manifest = result["manifest"]
+    assert "run_metadata" in manifest
+    run_meta = manifest["run_metadata"]
+    assert run_meta["schema_version"] == "run-metadata/v1"
+    assert "analysis_timestamp" in run_meta
+    assert "source_provider" in run_meta
+    assert "target_provider" in run_meta
+    assert "catalog_freshness" in run_meta
+    assert "methodology" in run_meta
+    assert "limitations" in run_meta
+
+
+def test_manifest_run_metadata_analysis_id_in_run_id():
+    """run_metadata.run_id must equal the analysis_id passed."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html", analysis_id="specific-run-id")
+    run_meta = result["manifest"]["run_metadata"]
+    assert run_meta["run_id"] == "specific-run-id"
+
+
+def test_manifest_mapping_references_include_evidence_when_present():
+    """mapping_references must include evidence fields when evidence is on the mapping."""
+    analysis_with_evidence = {
+        **SAMPLE_ANALYSIS,
+        "mappings": [
+            {
+                "source_service": "ALB",
+                "azure_service": "Application Gateway",
+                "category": "Networking",
+                "confidence": 0.96,
+                "evidence": {
+                    "detection_source": "catalogue",
+                    "detection_confidence": 0.96,
+                    "rationale": "Application Gateway is the recommended Azure equivalent.",
+                    "alternatives_considered": [{"azure_service": "Front Door", "confidence": 0.8, "rationale": "Global option"}],
+                    "known_gaps": [],
+                    "catalog_freshness": "2026-05-03",
+                    "user_override": False,
+                    "user_confirmed": True,
+                    "needs_review": False,
+                    "run_id": "",
+                    "generated_at": "2026-05-25T12:00:00Z",
+                },
+                "needs_review": False,
+            },
+        ],
+    }
+    result = generate_architecture_package(analysis_with_evidence, format="html")
+    refs = result["manifest"]["mapping_references"]
+    assert len(refs) >= 1
+    ref = refs[0]
+    assert ref["source_service"] == "ALB"
+    assert "evidence" in ref
+    assert ref["evidence"]["detection_source"] == "catalogue"
+    assert ref["evidence"]["rationale"]
+    assert ref["needs_review"] is False
+
+
+def test_manifest_mapping_references_low_confidence_needs_review_flag():
+    """mapping_references must propagate needs_review=True for low-confidence mappings."""
+    analysis = {
+        **SAMPLE_ANALYSIS,
+        "mappings": [
+            {
+                "source_service": "ObscureSvc",
+                "azure_service": "SomeAzureSvc",
+                "confidence": 0.55,
+                "needs_review": True,
+            },
+        ],
+    }
+    result = generate_architecture_package(analysis, format="html")
+    refs = result["manifest"]["mapping_references"]
+    assert refs[0]["needs_review"] is True
+
+
+def test_html_package_six_tabs_in_nav():
+    """The HTML package nav must contain exactly 6 tab buttons."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    content = result["content"]
+    tab_count = content.count('class="tab"')
+    assert tab_count == 6
+
+
+def test_html_package_story_mentions_six_outputs():
+    """The story bar must mention six review outputs (including F)."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")
+    content = result["content"]
+    assert "six review outputs" in content
+
+
+def test_svg_package_run_metadata_in_manifest():
+    """SVG format package must also include run_metadata in the manifest."""
+    result = generate_architecture_package(SAMPLE_ANALYSIS, format="svg", diagram="primary")
+    assert "run_metadata" in result["manifest"]
+    assert result["manifest"]["run_metadata"]["schema_version"] == "run-metadata/v1"

--- a/backend/tests/test_architecture_package.py
+++ b/backend/tests/test_architecture_package.py
@@ -612,6 +612,27 @@ def test_manifest_mapping_references_low_confidence_needs_review_flag():
     assert refs[0]["needs_review"] is True
 
 
+def test_html_package_tolerates_non_numeric_mapping_confidence():
+    analysis = {
+        **SAMPLE_ANALYSIS,
+        "mappings": [
+            {
+                "source_service": "UnknownService",
+                "azure_service": "Review Required",
+                "category": "Other",
+                "confidence": "n/a",
+                "needs_review": True,
+                "evidence": {"rationale": "Manual review required", "needs_review": True},
+            }
+        ],
+    }
+
+    result = generate_architecture_package(analysis, format="html")
+
+    assert "Manual review required" in result["content"]
+    assert "Needs review" in result["content"]
+
+
 def test_html_package_six_tabs_in_nav():
     """The HTML package nav must contain exactly 6 tab buttons."""
     result = generate_architecture_package(SAMPLE_ANALYSIS, format="html")

--- a/backend/tests/test_mapping_evidence.py
+++ b/backend/tests/test_mapping_evidence.py
@@ -1,0 +1,356 @@
+"""Tests for backend/mapping_evidence.py (issue #1130).
+
+Validates evidence payload shape, needs_review flagging,
+run metadata structure, and the attach_evidence_to_mappings helper.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import mapping_evidence as me
+
+
+# ─────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────
+
+CATALOGUE_MAPPING = {
+    "source_service": "EC2",
+    "source_provider": "aws",
+    "azure_service": "Virtual Machines",
+    "confidence": 0.95,
+    "source": "catalogue",
+    "notes": "Direct equivalent — IaaS virtual machines",
+    "review_status": "approved",
+}
+
+LOW_CONFIDENCE_MAPPING = {
+    "source_service": "CustomProprietary",
+    "source_provider": "aws",
+    "azure_service": "Unknown",
+    "confidence": 0.55,
+    "source": "ai",
+    "notes": "No clear Azure equivalent found",
+    "review_status": "pending",
+}
+
+AI_MAPPING_WITH_ALTERNATIVES = {
+    "source_service": "Fargate",
+    "source_provider": "aws",
+    "azure_service": "Container Apps",
+    "confidence": 0.88,
+    "source": "ai",
+    "notes": "Serverless container execution",
+    "alternatives": [
+        {"name": "AKS", "confidence": 0.80, "rationale": "Full orchestration option"},
+        {"name": "Container Instances", "confidence": 0.75, "rationale": "Simpler per-container option"},
+    ],
+    "feature_gaps": ["Fargate Spot pricing model differs from Container Apps consumption pricing"],
+}
+
+USER_MAPPING = {
+    "source_service": "MyService",
+    "source_provider": "aws",
+    "azure_service": "Azure App Service",
+    "confidence": 1.0,
+    "source": "user",
+    "user_added": True,
+}
+
+GCP_MAPPING = {
+    "source_service": "GKE",
+    "source_provider": "gcp",
+    "azure_service": "AKS",
+    "confidence": 0.92,
+    "source": "catalogue",
+}
+
+
+# ─────────────────────────────────────────────────────────
+# build_mapping_evidence
+# ─────────────────────────────────────────────────────────
+
+class TestBuildMappingEvidence:
+    def test_required_fields_present(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        assert "detection_source" in ev
+        assert "detection_confidence" in ev
+        assert "rationale" in ev
+        assert "alternatives_considered" in ev
+        assert "known_gaps" in ev
+        assert "catalog_freshness" in ev
+        assert "user_override" in ev
+        assert "user_confirmed" in ev
+        assert "needs_review" in ev
+        assert "run_id" in ev
+        assert "generated_at" in ev
+
+    def test_catalogue_mapping_not_flagged_for_review(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        assert ev["needs_review"] is False
+        assert ev["detection_source"] == "catalogue"
+        assert ev["user_confirmed"] is True  # review_status == "approved"
+
+    def test_low_confidence_flagged_for_review(self):
+        ev = me.build_mapping_evidence(LOW_CONFIDENCE_MAPPING)
+        assert ev["needs_review"] is True
+        assert ev["detection_confidence"] == pytest.approx(0.55)
+
+    def test_needs_review_threshold_boundary(self):
+        """Exactly at the threshold should NOT be flagged."""
+        m = {**LOW_CONFIDENCE_MAPPING, "confidence": me.NEEDS_REVIEW_THRESHOLD}
+        ev = me.build_mapping_evidence(m)
+        assert ev["needs_review"] is False
+
+    def test_needs_review_below_threshold(self):
+        m = {**LOW_CONFIDENCE_MAPPING, "confidence": me.NEEDS_REVIEW_THRESHOLD - 0.01}
+        ev = me.build_mapping_evidence(m)
+        assert ev["needs_review"] is True
+
+    def test_user_mapping_confirmed_and_not_needs_review(self):
+        ev = me.build_mapping_evidence(USER_MAPPING)
+        assert ev["user_override"] is True
+        assert ev["user_confirmed"] is True
+        assert ev["needs_review"] is False  # user confirmed overrides needs_review
+
+    def test_rationale_contains_azure_service_name(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        assert "Virtual Machines" in ev["rationale"]
+
+    def test_rationale_catalogue_source(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        assert "catalog" in ev["rationale"].lower() or "catalogue" in ev["rationale"].lower()
+
+    def test_rationale_ai_source(self):
+        ev = me.build_mapping_evidence(AI_MAPPING_WITH_ALTERNATIVES)
+        assert "ai" in ev["rationale"].lower() or "analysis" in ev["rationale"].lower()
+
+    def test_rationale_user_source(self):
+        ev = me.build_mapping_evidence(USER_MAPPING)
+        assert "user" in ev["rationale"].lower()
+
+    def test_alternatives_extracted(self):
+        ev = me.build_mapping_evidence(AI_MAPPING_WITH_ALTERNATIVES)
+        alts = ev["alternatives_considered"]
+        assert len(alts) == 2
+        assert alts[0]["azure_service"] == "AKS"
+        assert alts[1]["azure_service"] == "Container Instances"
+
+    def test_alternatives_empty_for_catalogue(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        assert ev["alternatives_considered"] == []
+
+    def test_known_gaps_from_feature_gaps(self):
+        ev = me.build_mapping_evidence(AI_MAPPING_WITH_ALTERNATIVES)
+        assert len(ev["known_gaps"]) >= 1
+        assert any("Fargate Spot" in g for g in ev["known_gaps"])
+
+    def test_catalog_freshness_for_known_aws_service(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        # EC2 is in the catalog with last_reviewed date
+        assert ev["catalog_freshness"] is not None
+        assert ev["catalog_freshness"].startswith("20")
+
+    def test_catalog_freshness_none_for_unknown_service(self):
+        m = {**LOW_CONFIDENCE_MAPPING, "source_service": "TotallyUnknownService42"}
+        ev = me.build_mapping_evidence(m)
+        assert ev["catalog_freshness"] is None
+
+    def test_gcp_catalog_freshness(self):
+        ev = me.build_mapping_evidence(GCP_MAPPING)
+        # GKE should be in the GCP catalog
+        assert ev["catalog_freshness"] is not None
+
+    def test_detection_confidence_rounded(self):
+        m = {**CATALOGUE_MAPPING, "confidence": 0.123456789}
+        ev = me.build_mapping_evidence(m)
+        assert ev["detection_confidence"] == pytest.approx(0.1235, abs=1e-4)
+
+    def test_generated_at_is_iso_format(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING)
+        # Should be parseable as ISO datetime
+        ts = ev["generated_at"].replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts)
+        assert dt.tzinfo is not None
+
+    def test_custom_run_id_passed_through(self):
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING, run_id="test-run-123")
+        assert ev["run_id"] == "test-run-123"
+
+    def test_custom_analysis_timestamp_passed_through(self):
+        ts = "2026-05-01T12:00:00Z"
+        ev = me.build_mapping_evidence(CATALOGUE_MAPPING, analysis_timestamp=ts)
+        assert ev["generated_at"] == ts
+
+
+# ─────────────────────────────────────────────────────────
+# build_run_metadata
+# ─────────────────────────────────────────────────────────
+
+class TestBuildRunMetadata:
+    ANALYSIS = {
+        "source_provider": "aws",
+        "target_provider": "azure",
+        "mappings": [
+            {"source_service": "EC2", "azure_service": "Virtual Machines", "confidence": 0.95},
+            {"source_service": "Lambda", "azure_service": "Azure Functions", "confidence": 0.88},
+            {"source_service": "Unknown", "azure_service": "Unknown", "confidence": 0.55,
+             "evidence": {"needs_review": True, "user_confirmed": False}},
+        ],
+    }
+
+    def test_required_fields_present(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        for field in ("schema_version", "run_id", "analysis_timestamp",
+                      "source_provider", "target_provider", "catalog_freshness",
+                      "model_version", "total_mappings", "low_confidence_count",
+                      "needs_review_count", "methodology", "limitations"):
+            assert field in meta, f"Missing field: {field}"
+
+    def test_schema_version(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["schema_version"] == "run-metadata/v1"
+
+    def test_source_and_target_provider(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["source_provider"] == "aws"
+        assert meta["target_provider"] == "azure"
+
+    def test_total_mappings_count(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["total_mappings"] == 3
+
+    def test_low_confidence_count(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["low_confidence_count"] == 1  # only the 0.55 one
+
+    def test_needs_review_count_uses_evidence_flag(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["needs_review_count"] >= 1
+
+    def test_custom_run_id(self):
+        meta = me.build_run_metadata(self.ANALYSIS, run_id="abc-123")
+        assert meta["run_id"] == "abc-123"
+
+    def test_run_id_generated_when_absent(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["run_id"]  # non-empty
+
+    def test_methodology_is_nonempty_string(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert isinstance(meta["methodology"], str)
+        assert len(meta["methodology"]) > 20
+
+    def test_limitations_is_nonempty_list(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert isinstance(meta["limitations"], list)
+        assert len(meta["limitations"]) > 0
+
+    def test_catalog_freshness_structure(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        cf = meta["catalog_freshness"]
+        assert isinstance(cf, dict)
+        assert "last_success" in cf
+        assert "stale" in cf
+
+    def test_model_version_not_empty(self):
+        meta = me.build_run_metadata(self.ANALYSIS)
+        assert meta["model_version"]
+
+
+# ─────────────────────────────────────────────────────────
+# attach_evidence_to_mappings
+# ─────────────────────────────────────────────────────────
+
+class TestAttachEvidenceToMappings:
+    def test_evidence_attached_to_all_mappings(self):
+        mappings = [
+            {"source_service": "EC2", "azure_service": "Virtual Machines", "confidence": 0.95, "source": "catalogue"},
+            {"source_service": "S3", "azure_service": "Blob Storage", "confidence": 0.90, "source": "catalogue"},
+        ]
+        me.attach_evidence_to_mappings(mappings, run_id="test-run")
+        for m in mappings:
+            assert "evidence" in m
+            assert isinstance(m["evidence"], dict)
+            assert "needs_review" in m["evidence"]
+
+    def test_needs_review_promoted_to_top_level(self):
+        mappings = [
+            {"source_service": "Obscure", "azure_service": "Something", "confidence": 0.5, "source": "ai"},
+        ]
+        me.attach_evidence_to_mappings(mappings)
+        assert "needs_review" in mappings[0]
+        assert mappings[0]["needs_review"] is True
+
+    def test_high_confidence_not_needs_review(self):
+        mappings = [
+            {"source_service": "EC2", "azure_service": "Virtual Machines", "confidence": 0.95, "source": "catalogue"},
+        ]
+        me.attach_evidence_to_mappings(mappings)
+        assert mappings[0]["needs_review"] is False
+
+    def test_idempotent_skips_existing_evidence(self):
+        existing_evidence = {
+            "detection_source": "catalogue",
+            "detection_confidence": 0.95,
+            "rationale": "Pre-existing rationale",
+            "alternatives_considered": [],
+            "known_gaps": [],
+            "catalog_freshness": None,
+            "user_override": False,
+            "user_confirmed": True,
+            "needs_review": False,
+            "run_id": "old-run",
+            "generated_at": "2026-01-01T00:00:00Z",
+        }
+        mappings = [
+            {
+                "source_service": "EC2",
+                "azure_service": "Virtual Machines",
+                "confidence": 0.95,
+                "evidence": existing_evidence,
+            }
+        ]
+        me.attach_evidence_to_mappings(mappings, run_id="new-run")
+        # Evidence should NOT have been replaced (idempotent)
+        assert mappings[0]["evidence"]["run_id"] == "old-run"
+        assert mappings[0]["evidence"]["rationale"] == "Pre-existing rationale"
+
+    def test_non_dict_items_skipped(self):
+        mappings = ["string_item", None, {"source_service": "EC2", "azure_service": "VMs", "confidence": 0.9}]
+        # Should not raise
+        me.attach_evidence_to_mappings(mappings)
+        assert "evidence" in mappings[2]
+
+    def test_run_id_shared_across_all_mappings(self):
+        mappings = [
+            {"source_service": "EC2", "azure_service": "VMs", "confidence": 0.95},
+            {"source_service": "S3", "azure_service": "Blob", "confidence": 0.95},
+        ]
+        me.attach_evidence_to_mappings(mappings, run_id="shared-run-xyz")
+        for m in mappings:
+            assert m["evidence"]["run_id"] == "shared-run-xyz"
+
+
+# ─────────────────────────────────────────────────────────
+# Constants / public API contract
+# ─────────────────────────────────────────────────────────
+
+class TestConstants:
+    def test_needs_review_threshold_is_0_70(self):
+        assert me.NEEDS_REVIEW_THRESHOLD == 0.70
+
+    def test_methodology_summary_not_empty(self):
+        assert len(me._METHODOLOGY_SUMMARY) > 50
+
+    def test_customer_safe_limitations_not_empty(self):
+        assert len(me._CUSTOMER_SAFE_LIMITATIONS) >= 3
+        for item in me._CUSTOMER_SAFE_LIMITATIONS:
+            assert isinstance(item, str)

--- a/backend/tests/test_mapping_evidence.py
+++ b/backend/tests/test_mapping_evidence.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pytest
 
@@ -189,6 +189,29 @@ class TestBuildMappingEvidence:
         ev = me.build_mapping_evidence(CATALOGUE_MAPPING, analysis_timestamp=ts)
         assert ev["generated_at"] == ts
 
+    def test_non_numeric_confidence_falls_back_to_zero(self):
+        ev = me.build_mapping_evidence({**LOW_CONFIDENCE_MAPPING, "confidence": "not-a-number"})
+        assert ev["detection_confidence"] == 0
+        assert ev["needs_review"] is True
+
+    def test_object_shaped_services_are_coerced_to_names(self):
+        ev = me.build_mapping_evidence({
+            "source_service": {"name": "EC2"},
+            "azure_service": {"name": "Virtual Machines"},
+            "confidence": 0.95,
+            "source": "catalogue",
+        })
+        assert "EC2" in ev["rationale"]
+        assert "Virtual Machines" in ev["rationale"]
+
+    def test_alternative_confidence_accepts_non_numeric_values(self):
+        ev = me.build_mapping_evidence({
+            **AI_MAPPING_WITH_ALTERNATIVES,
+            "alternatives": [{"name": "AKS", "confidence": "n/a", "rationale": {"message": "Full control"}}],
+        })
+        assert ev["alternatives_considered"][0]["confidence"] == 0
+        assert ev["alternatives_considered"][0]["rationale"] == "Full control"
+
 
 # ─────────────────────────────────────────────────────────
 # build_run_metadata
@@ -259,6 +282,13 @@ class TestBuildRunMetadata:
         assert isinstance(cf, dict)
         assert "last_success" in cf
         assert "stale" in cf
+
+    def test_non_numeric_confidence_does_not_break_run_metadata(self):
+        meta = me.build_run_metadata({
+            **self.ANALYSIS,
+            "mappings": [{"source_service": "X", "azure_service": "Y", "confidence": "n/a"}],
+        })
+        assert meta["low_confidence_count"] == 1
 
     def test_model_version_not_empty(self):
         meta = me.build_run_metadata(self.ANALYSIS)

--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -158,12 +158,89 @@ function DeepDivePanel({ m }) {
   );
 }
 
+
+/* ── Evidence Panel for a mapping (#1130) ───────────────── */
+function EvidencePanel({ m }) {
+  const evidence = m.evidence;
+  if (!evidence) return null;
+
+  const rationale = evidence.rationale;
+  const alternatives = (evidence.alternatives_considered || []).filter(a => a?.azure_service);
+  const gaps = (evidence.known_gaps || []).filter(Boolean);
+  const catalogFreshness = evidence.catalog_freshness;
+  const detectionSource = evidence.detection_source;
+  const userConfirmed = evidence.user_confirmed;
+  const userOverride = evidence.user_override;
+
+  const hasContent = rationale || alternatives.length > 0 || gaps.length > 0 || detectionSource;
+  if (!hasContent) return null;
+
+  return (
+    <div className="mt-2 ml-1 pl-3 border-l-2 border-warning/30 space-y-2 animate-in fade-in slide-in-from-top-1">
+      <p className="text-xs font-semibold text-text-secondary flex items-center gap-1.5">
+        <ShieldCheck className="w-3.5 h-3.5 text-warning" />
+        Mapping Evidence &amp; Rationale
+      </p>
+
+      {/* Detection source + status */}
+      {detectionSource && (
+        <div className="flex items-center gap-2 text-xs text-text-muted">
+          <span className="font-medium text-text-primary">Source:</span>
+          <span className="px-1.5 py-0.5 rounded bg-surface text-text-secondary font-mono text-[10px]">{detectionSource}</span>
+          {userConfirmed && <span className="px-1.5 py-0.5 rounded bg-success/10 text-success text-[10px] font-medium">User confirmed</span>}
+          {userOverride && <span className="px-1.5 py-0.5 rounded bg-info/10 text-info text-[10px] font-medium">User override</span>}
+          {catalogFreshness && <span className="text-text-muted text-[10px]">Catalog: {catalogFreshness}</span>}
+        </div>
+      )}
+
+      {/* Rationale */}
+      {rationale && (
+        <div className="flex items-start gap-2 text-xs text-text-secondary">
+          <span className="text-warning/60 mt-0.5 shrink-0">•</span>
+          <span>{rationale}</span>
+        </div>
+      )}
+
+      {/* Alternatives */}
+      {alternatives.length > 0 && (
+        <div className="space-y-0.5">
+          <p className="text-[10px] font-semibold text-text-muted uppercase tracking-wide">Alternatives considered</p>
+          {alternatives.map((alt, i) => (
+            <div key={i} className="flex items-start gap-2 text-xs text-text-muted">
+              <span className="text-text-muted/60 mt-0.5 shrink-0">◦</span>
+              <span>
+                <span className="font-medium text-text-secondary">{alt.azure_service}</span>
+                {alt.rationale && <span className="text-text-muted"> — {alt.rationale}</span>}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Known gaps */}
+      {gaps.length > 0 && (
+        <div className="space-y-0.5">
+          <p className="text-[10px] font-semibold text-text-muted uppercase tracking-wide">Known gaps</p>
+          {gaps.slice(0, 3).map((gap, i) => (
+            <div key={i} className="flex items-start gap-2 text-xs text-text-muted">
+              <AlertTriangle className="w-3 h-3 text-warning/70 shrink-0 mt-0.5" />
+              <span>{gap}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ── Confidence Explanation Row ──────────────────────────── */
 function MappingRow({ m, sourceProvider }) {
   const [open, setOpen] = useState(false);
   const hasExplanation = m.confidence_explanation?.length > 0;
   const hasDeepDive = (m.strengths?.length > 0 || m.limitations?.length > 0 || m.migration_notes?.length > 0);
-  const expandable = hasExplanation || hasDeepDive;
+  const hasEvidence = !!(m.evidence && (m.evidence.rationale || m.evidence.alternatives_considered?.length || m.evidence.known_gaps?.length));
+  const expandable = hasExplanation || hasDeepDive || hasEvidence;
+  const needsReview = m.needs_review || m.evidence?.needs_review;
 
   return (
     <div className="px-4 py-3">
@@ -173,6 +250,12 @@ function MappingRow({ m, sourceProvider }) {
             <span className={`text-sm font-medium ${sourceProvider === 'gcp' ? 'text-[#EA4335]' : 'text-[#FF9900]'}`}>{typeof m.source_service === 'object' ? m.source_service.name : m.source_service}</span>
             <ArrowRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
             <span className="text-sm text-info font-medium">{m.azure_service}</span>
+            {needsReview && (
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-warning/15 text-warning border border-warning/30" title="Low confidence — requires architecture owner review before export">
+                <AlertTriangle className="w-2.5 h-2.5" />
+                Needs review
+              </span>
+            )}
           </div>
         </div>
         <button
@@ -192,7 +275,7 @@ function MappingRow({ m, sourceProvider }) {
         </button>
       </div>
 
-      {/* Expanded: Confidence Explanation + Deep Dive */}
+      {/* Expanded: Confidence Explanation + Deep Dive + Evidence */}
       {open && (
         <>
           {hasExplanation && (
@@ -210,6 +293,7 @@ function MappingRow({ m, sourceProvider }) {
             </div>
           )}
           <DeepDivePanel m={m} />
+          <EvidencePanel m={m} />
         </>
       )}
     </div>
@@ -280,6 +364,28 @@ export default function AnalysisResults({
                 </div>
               </div>
             )}
+
+            {/* Low-confidence / needs-review alert (#1130) */}
+            {(() => {
+              const needsReviewCount = (analysis.mappings || []).filter(m => m.needs_review || m.evidence?.needs_review).length;
+              if (!needsReviewCount) return null;
+              return (
+                <div className="mt-3 px-3.5 py-2.5 rounded-lg bg-warning/8 border border-warning/30">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="w-4 h-4 text-warning shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-xs font-semibold text-warning mb-1">
+                        {needsReviewCount} mapping{needsReviewCount === 1 ? '' : 's'} flagged for review
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        These mappings have confidence below 70% and must be confirmed or overridden by the architecture owner before export.
+                        Expand each flagged mapping to see the rationale and alternatives.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })()}
           </>
         )}
       </Card>

--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -164,11 +164,16 @@ function EvidencePanel({ m }) {
   const evidence = m.evidence;
   if (!evidence) return null;
 
-  const rationale = evidence.rationale;
-  const alternatives = (evidence.alternatives_considered || []).filter(a => a?.azure_service);
-  const gaps = (evidence.known_gaps || []).filter(Boolean);
-  const catalogFreshness = evidence.catalog_freshness;
-  const detectionSource = evidence.detection_source;
+  const rationale = toRenderableString(evidence.rationale);
+  const alternatives = (evidence.alternatives_considered || [])
+    .map(a => ({
+      azure_service: toRenderableString(a?.azure_service ?? a?.name ?? a),
+      rationale: toRenderableString(a?.rationale || a?.notes),
+    }))
+    .filter(a => a.azure_service);
+  const gaps = (evidence.known_gaps || []).map(toRenderableString).filter(Boolean);
+  const catalogFreshness = toRenderableString(evidence.catalog_freshness);
+  const detectionSource = toRenderableString(evidence.detection_source);
   const userConfirmed = evidence.user_confirmed;
   const userOverride = evidence.user_override;
 

--- a/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
@@ -11,6 +11,15 @@ vi.mock('../../DiagramTranslator/HLDPanel', () => ({
   default: (props) => <div data-testid="hld-panel">HLDPanel</div>,
 }))
 
+// Prevent lazy-loaded xyflow components from causing ResizeObserver errors in JSDOM
+vi.mock('../../DiagramTranslator/ArchitectureFlow', () => ({
+  default: (props) => <div data-testid="architecture-flow">ArchitectureFlow</div>,
+}))
+
+vi.mock('../../DiagramTranslator/DependencyGraph', () => ({
+  default: (props) => <div data-testid="dependency-graph">DependencyGraph</div>,
+}))
+
 describe('AnalysisResults', () => {
   const mockAnalysis = {
     diagram_type: 'AWS Architecture',
@@ -190,5 +199,227 @@ describe('AnalysisResults', () => {
     expect(screen.getByText(/Event triggers/)).toBeInTheDocument()
     expect(screen.getByText(/Runtime limit differs/)).toBeInTheDocument()
     expect(screen.getByText('Rewrite deployment package')).toBeInTheDocument()
+  })
+})
+
+describe('AnalysisResults — trust/evidence layer (#1130)', () => {
+  const baseProps = {
+    analysis: {
+      diagram_type: 'AWS Architecture',
+      services_detected: 3,
+      source_provider: 'aws',
+      zones: [{ id: 1, name: 'Web', services: ['EC2'] }],
+      mappings: [],
+      confidence_summary: { high: 2, medium: 1, low: 0, average: 0.88 },
+      warnings: [],
+    },
+    loading: false,
+    iacFormat: 'terraform',
+    exportLoading: {},
+    copyFeedback: {},
+    onSetStep: vi.fn(),
+    onGenerateIac: vi.fn(),
+    onExportDiagram: vi.fn(),
+    onCopyWithFeedback: vi.fn(),
+    onReviewAssumptions: vi.fn(),
+  }
+
+  it('shows needs-review banner when mappings have needs_review=true', () => {
+    const analysis = {
+      ...baseProps.analysis,
+      mappings: [
+        { source_service: 'ObscureSvc', azure_service: 'SomeSvc', confidence: 0.55, needs_review: true },
+        { source_service: 'EC2', azure_service: 'Virtual Machines', confidence: 0.95, needs_review: false },
+      ],
+      confidence_summary: { high: 1, medium: 0, low: 1, average: 0.75 },
+    }
+    const { getByText } = render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    expect(getByText(/flagged for review/i)).toBeInTheDocument()
+  })
+
+  it('does not show needs-review banner when all mappings are high confidence', () => {
+    const analysis = {
+      ...baseProps.analysis,
+      mappings: [
+        { source_service: 'EC2', azure_service: 'Virtual Machines', confidence: 0.95, needs_review: false },
+        { source_service: 'S3', azure_service: 'Blob Storage', confidence: 0.92, needs_review: false },
+      ],
+      confidence_summary: { high: 2, medium: 0, low: 0, average: 0.93 },
+    }
+    const { queryByText } = render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    expect(queryByText(/flagged for review/i)).not.toBeInTheDocument()
+  })
+
+  it('shows "Needs review" badge in mapping row when needs_review is true', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['ObscureSvc'] }],
+      mappings: [
+        {
+          source_service: 'ObscureSvc',
+          azure_service: 'SomeSvc',
+          confidence: 0.55,
+          needs_review: true,
+          notes: 'Zone 1',
+        },
+      ],
+      confidence_summary: { high: 0, medium: 0, low: 1, average: 0.55 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    expect(screen.getByText('Needs review')).toBeInTheDocument()
+  })
+
+  it('shows evidence panel when mapping has evidence with rationale', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['Lambda'] }],
+      mappings: [
+        {
+          source_service: 'Lambda',
+          azure_service: 'Azure Functions',
+          confidence: 0.95,
+          needs_review: false,
+          notes: 'Zone 1',
+          evidence: {
+            detection_source: 'catalogue',
+            detection_confidence: 0.95,
+            rationale: 'Azure Functions is the recommended Azure equivalent for Lambda.',
+            alternatives_considered: [
+              { azure_service: 'Container Apps', confidence: 0.80, rationale: 'Alternative option' },
+            ],
+            known_gaps: ['Provisioned Concurrency requires Premium plan'],
+            catalog_freshness: '2026-05-03',
+            user_override: false,
+            user_confirmed: true,
+            needs_review: false,
+            run_id: 'test-run',
+            generated_at: '2026-05-25T12:00:00Z',
+          },
+        },
+      ],
+      confidence_summary: { high: 1, medium: 0, low: 0, average: 0.93 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    // Click the confidence badge (getAllByText handles the confidence summary + badge)
+    const badges = screen.getAllByText('95%')
+    await user.click(badges[badges.length - 1])
+    expect(screen.getByText('Mapping Evidence & Rationale')).toBeInTheDocument()
+    expect(screen.getByText(/Azure Functions is the recommended/)).toBeInTheDocument()
+  })
+
+  it('shows alternatives considered in evidence panel', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['Lambda'] }],
+      mappings: [
+        {
+          source_service: 'Lambda',
+          azure_service: 'Azure Functions',
+          confidence: 0.95,
+          needs_review: false,
+          notes: 'Zone 1',
+          evidence: {
+            detection_source: 'catalogue',
+            detection_confidence: 0.95,
+            rationale: 'Azure Functions is the recommended Azure equivalent for Lambda.',
+            alternatives_considered: [
+              { azure_service: 'Container Apps', confidence: 0.80, rationale: 'Containerized option' },
+            ],
+            known_gaps: [],
+            catalog_freshness: '2026-05-03',
+            user_override: false,
+            user_confirmed: true,
+            needs_review: false,
+            run_id: '',
+            generated_at: '2026-05-25T12:00:00Z',
+          },
+        },
+      ],
+      confidence_summary: { high: 1, medium: 0, low: 0, average: 0.93 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    const badges = screen.getAllByText('95%')
+    await user.click(badges[badges.length - 1])
+    expect(screen.getByText('Alternatives considered')).toBeInTheDocument()
+    expect(screen.getByText('Container Apps')).toBeInTheDocument()
+  })
+
+  it('shows known gaps in evidence panel', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['Lambda'] }],
+      mappings: [
+        {
+          source_service: 'Lambda',
+          azure_service: 'Azure Functions',
+          confidence: 0.88,
+          needs_review: false,
+          notes: 'Zone 1',
+          evidence: {
+            detection_source: 'ai',
+            detection_confidence: 0.88,
+            rationale: 'Azure Functions mapped via AI analysis.',
+            alternatives_considered: [],
+            known_gaps: ['Provisioned Concurrency requires Premium plan'],
+            catalog_freshness: null,
+            user_override: false,
+            user_confirmed: false,
+            needs_review: false,
+            run_id: '',
+            generated_at: '2026-05-25T12:00:00Z',
+          },
+        },
+      ],
+      confidence_summary: { high: 0, medium: 1, low: 0, average: 0.85 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    const badges = screen.getAllByText('88%')
+    await user.click(badges[badges.length - 1])
+    expect(screen.getByText('Known gaps')).toBeInTheDocument()
+    expect(screen.getByText('Provisioned Concurrency requires Premium plan')).toBeInTheDocument()
+  })
+
+  it('shows user-confirmed status in evidence panel', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['EC2'] }],
+      mappings: [
+        {
+          source_service: 'EC2',
+          azure_service: 'Virtual Machines',
+          confidence: 0.95,
+          needs_review: false,
+          notes: 'Zone 1',
+          evidence: {
+            detection_source: 'user',
+            detection_confidence: 1.0,
+            rationale: 'Virtual Machines was manually specified by the user.',
+            alternatives_considered: [],
+            known_gaps: [],
+            catalog_freshness: '2026-05-03',
+            user_override: true,
+            user_confirmed: true,
+            needs_review: false,
+            run_id: '',
+            generated_at: '2026-05-25T12:00:00Z',
+          },
+        },
+      ],
+      confidence_summary: { high: 1, medium: 0, low: 0, average: 0.93 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    const badges = screen.getAllByText('95%')
+    await user.click(badges[badges.length - 1])
+    expect(screen.getByText('User confirmed')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
@@ -422,4 +422,39 @@ describe('AnalysisResults — trust/evidence layer (#1130)', () => {
     await user.click(badges[badges.length - 1])
     expect(screen.getByText('User confirmed')).toBeInTheDocument()
   })
+
+  it('renders object-shaped evidence fields without crashing', async () => {
+    const user = userEvent.setup()
+    const analysis = {
+      ...baseProps.analysis,
+      zones: [{ id: 1, name: 'Web', services: ['Lambda'] }],
+      mappings: [
+        {
+          source_service: 'Lambda',
+          azure_service: 'Azure Functions',
+          confidence: 0.95,
+          notes: 'Zone 1',
+          evidence: {
+            detection_source: { label: 'catalogue' },
+            rationale: { message: 'Object rationale rendered safely' },
+            alternatives_considered: [
+              { azure_service: { name: 'Container Apps' }, notes: { message: 'Object note rendered safely' } },
+            ],
+            known_gaps: [{ message: 'Object gap rendered safely' }],
+            catalog_freshness: { value: '2026-05-03' },
+            user_confirmed: true,
+            needs_review: false,
+          },
+        },
+      ],
+      confidence_summary: { high: 1, medium: 0, low: 0, average: 0.95 },
+    }
+    render(<AnalysisResults {...baseProps} analysis={analysis} />)
+    await user.click(screen.getByText('Map'))
+    const badges = screen.getAllByText('95%')
+    await user.click(badges[badges.length - 1])
+    expect(screen.getByText('Object rationale rendered safely')).toBeInTheDocument()
+    expect(screen.getByText(/Object note rendered safely/)).toBeInTheDocument()
+    expect(screen.getByText('Object gap rendered safely')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Replacement for #1160 because the original Copilot-authored PR is stuck with stale `action_required` workflow runs that do not attach to the current head SHA.

Adds a customer-safe trust/evidence contract for service mappings across the backend mapping pipeline, architecture package export, and mapping review UI.

## What changed
- Adds `backend/mapping_evidence.py` for per-mapping evidence envelopes and run-level methodology metadata.
- Attaches evidence to catalogue, AI, and sample mapping paths.
- Extends architecture package manifests and HTML export with an Evidence & Methodology panel.
- Shows mapping rationale, alternatives, known gaps, catalog freshness, and needs-review signals in `AnalysisResults`.
- Hardens evidence rendering/coercion so malformed AI/user-shaped values cannot crash exports or React rendering.

## Validation
- `python -m py_compile mapping_evidence.py architecture_package.py ai_suggestion.py routers/samples.py`
- `python -m ruff check ...` on changed backend files/tests
- `pytest -q tests/test_mapping_evidence.py tests/test_architecture_package.py tests/test_ai_suggestion.py`
- `npm run test -- --run src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx`
- `npm run build`
- `npx eslint src/components/DiagramTranslator/AnalysisResults.jsx src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx --max-warnings 0`
- `git diff --check`
- `gitleaks dir . --redact --verbose` returned no leaks.

## Notes
- No schema migration.
- No new public secret, environment URL, private endpoint, or live resource identifiers are included.
- Low-confidence mappings remain visible but are flagged for architecture-owner review before customer commitment.