### PR TITLE
ci: use system chrome in production synthetic

### DIFF
--- a/.github/workflows/production-authenticated-browser-synthetic.yml
+++ b/.github/workflows/production-authenticated-browser-synthetic.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-fund --no-audit || npm ci --no-fund --no-audit
 
-      - name: Install Playwright browser
-        run: npx playwright install chromium --with-deps
+      - name: Install Playwright system dependencies
+        run: |
+          npx playwright install-deps chromium
+          if ! command -v google-chrome >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y google-chrome-stable
+          fi
+          google-chrome --version
 
       - name: Run production authenticated browser synthetic
         env:


### PR DESCRIPTION
## Summary
- Avoids the hanging Chrome-for-Testing download path in the production authenticated browser synthetic workflow.
- Reuses the same system Chrome approach that fixed Playwright and live-smoke checks in #1162.

## Validation
- `npx playwright test e2e/production-authenticated-synthetic.spec.ts --project=chromium --list`
- `git diff --check`
- `gitleaks dir . --redact --verbose`

## Notes
- No product code changes.
- Keeps production synthetic artifacts and issue-on-failure behavior unchanged.