### PR TITLE
fix: mint backend session before analysis

### DIFF
--- a/frontend/src/components/DiagramTranslator/UploadStep.jsx
+++ b/frontend/src/components/DiagramTranslator/UploadStep.jsx
@@ -19,7 +19,7 @@ export default function UploadStep({
   onSignIn,
 }) {
   const isPdf = !!selectedFile && (selectedFile.type === 'application/pdf' || /\.pdf$/i.test(selectedFile.name));
-  const canAnalyze = isAuthenticated && hasBackendSession;
+  const canAnalyze = isAuthenticated;
 
   return (
     <Card className="p-6 pb-24 sm:p-12 sm:pb-12">
@@ -87,16 +87,7 @@ export default function UploadStep({
                     <Button onClick={(e) => { e.stopPropagation(); onSignIn?.(); }} variant="primary" size="md" icon={LogIn}>
                       Sign in to analyze
                     </Button>
-                  ) : (
-                    <div className="flex flex-col items-center gap-2">
-                      <Button onClick={(e) => { e.stopPropagation(); }} variant="secondary" size="md" icon={LogIn} disabled>
-                        Analysis unavailable
-                      </Button>
-                      <p className="max-w-xs text-xs text-text-muted">
-                        Signed in, but the backend analysis session is not available yet.
-                      </p>
-                    </div>
-                  )}
+                  ) : null}
                   <Button onClick={(e) => { e.stopPropagation(); onRemoveFile(); }} variant="ghost" size="sm" icon={X}>
                     Remove
                   </Button>

--- a/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/UploadStep.test.jsx
@@ -155,14 +155,13 @@ describe('UploadStep', () => {
     expect(onUpload).toHaveBeenCalledWith(file)
   })
 
-  it('disables analysis when the frontend has SWA auth but no backend session', async () => {
+  it('allows analysis when the frontend has SWA auth but no backend session', async () => {
     const onUpload = vi.fn()
     const onSignIn = vi.fn()
     const file = new File(['diagram.png'], 'diagram.png', { type: 'image/png' })
     render(<UploadStep {...defaultProps} selectedFile={file} isAuthenticated={true} hasBackendSession={false} onUpload={onUpload} onSignIn={onSignIn} />)
-    expect(screen.getByRole('button', { name: /Analysis unavailable/i })).toBeDisabled()
-    expect(screen.getByText(/backend analysis session is not available/i)).toBeInTheDocument()
-    expect(onUpload).not.toHaveBeenCalled()
+    await userEvent.setup().click(screen.getByRole('button', { name: /Analyze This Diagram/i }))
+    expect(onUpload).toHaveBeenCalledTimes(1)
     expect(onSignIn).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
@@ -72,10 +72,12 @@ vi.mock('../../../services/apiClient', () => ({
 // Mock useAuthStore so we can control isAuthenticated per test
 let mockIsAuthenticated = false
 let mockHasBackendSession = false
+const mockEnsureBackendSession = vi.fn()
 vi.mock('../../../stores/useAuthStore', () => ({
   default: vi.fn((selector) => selector({
     isAuthenticated: mockIsAuthenticated,
     hasBackendSession: mockHasBackendSession,
+    ensureBackendSession: mockEnsureBackendSession,
     isLoading: false,
     user: null,
     sessionToken: null,
@@ -87,6 +89,7 @@ describe('DiagramTranslator — Session UX Tests', () => {
     vi.clearAllMocks()
     mockIsAuthenticated = false // signed-out by default for these tests
     mockHasBackendSession = false
+    mockEnsureBackendSession.mockResolvedValue(true)
     mockLoadSession.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
   })
@@ -370,6 +373,32 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     await waitFor(() => expect(screen.getByText('my-diagram.pdf')).toBeInTheDocument())
   })
 
+  it('mints a backend session before upload when SWA sign-in succeeded but backend session is missing', async () => {
+    mockIsAuthenticated = true
+    mockHasBackendSession = false
+    mockEnsureBackendSession.mockResolvedValueOnce(true)
+    mockApi.post
+      .mockResolvedValueOnce({ project_id: 'project-1', diagram_id: 'diagram-1', export_capability: 'cap-1' })
+      .mockRejectedValueOnce({ status: 404, name: 'ApiError' })
+      .mockResolvedValueOnce({ diagram_id: 'diagram-1', mappings: [], zones: [], diagram_type: 'AWS Architecture', services_detected: 0 })
+      .mockResolvedValueOnce({ questions: [], all_questions: [], assumptions: [], inferred_answers: {} })
+    mockApi.get.mockResolvedValue({ diagrams: [] })
+
+    render(<DiagramTranslator />)
+    await screen.findByText('Upload Architecture Diagram')
+
+    const input = document.querySelector('input[type="file"]')
+    const file = new File(['diagram'], 'diagram.png', { type: 'image/png' })
+    await act(async () => { fireEvent.change(input, { target: { files: [file] } }) })
+    await waitFor(() => expect(screen.getByText('diagram.png')).toBeInTheDocument())
+
+    await act(async () => { fireEvent.click(screen.getByText('Analyze This Diagram')) })
+
+    await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalledTimes(4))
+    expect(mockApi.post).toHaveBeenCalledWith('/projects/demo-project/diagrams', expect.any(FormData), expect.any(AbortSignal))
+  })
+
   it('does not fall back to sync analysis when async admission is rejected', async () => {
     mockIsAuthenticated = true
     mockHasBackendSession = true
@@ -429,9 +458,10 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     expect(mockApi.post).not.toHaveBeenCalledWith('/diagrams/diag-abort/analyze', undefined, expect.any(AbortSignal))
   })
 
-  it('does not upload or analyze when user is SWA-only without a backend session', async () => {
+  it('exchanges backend session on upload when user is SWA-only without a backend session', async () => {
     mockIsAuthenticated = true
     mockHasBackendSession = false
+    mockEnsureBackendSession.mockResolvedValueOnce(false)
 
     render(<DiagramTranslator />)
     await screen.findByText('Upload Architecture Diagram')
@@ -441,9 +471,10 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     await act(async () => { fireEvent.change(input, { target: { files: [pdfFile] } }) })
     await waitFor(() => expect(screen.getByText('swa-only.pdf')).toBeInTheDocument())
 
-    expect(screen.getByRole('button', { name: /Analysis unavailable/i })).toBeDisabled()
-    expect(screen.getByText(/backend analysis session is not available/i)).toBeInTheDocument()
-    expect(screen.queryByText('Analyze This Diagram')).not.toBeInTheDocument()
+    await act(async () => { fireEvent.click(screen.getByText('Analyze This Diagram')) })
+
+    await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('heading', { name: 'Authentication required' })).toBeInTheDocument()
     expect(mockApi.post).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -343,6 +343,7 @@ export default function DiagramTranslator() {
   // Auth state — used for proactive gate and 401 error differentiation
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const hasBackendSession = useAuthStore((s) => s.hasBackendSession);
+  const ensureBackendSession = useAuthStore((s) => s.ensureBackendSession);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [authUploadRecovery, setAuthUploadRecovery] = useState(null);
 
@@ -622,6 +623,23 @@ export default function DiagramTranslator() {
       });
       return;
     }
+  };
+
+  const handleAuthenticatedUpload = async (file) => {
+    if (!isAuthenticated) {
+      setLoginModalOpen(true);
+      return;
+    }
+    if (!hasBackendSession) {
+      set({ authError: null, error: null });
+      const ready = await ensureBackendSession?.();
+      if (!ready) {
+        set({ authError: 'auth_required', error: null, step: 'upload' });
+        setLoginModalOpen(true);
+        return;
+      }
+    }
+    await handleUpload(file);
   };
 
   // ── Session auto-recovery: push cached analysis back to backend on 404 ──
@@ -1520,7 +1538,7 @@ export default function DiagramTranslator() {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
           onFileSelect={handleFileSelect}
-          onUpload={handleUpload}
+          onUpload={handleAuthenticatedUpload}
           onRemoveFile={clearSelectedUpload}
           onLoadSample={handleLoadSample}
           isAuthenticated={isAuthenticated}

--- a/frontend/src/stores/__tests__/useAuthStore.test.js
+++ b/frontend/src/stores/__tests__/useAuthStore.test.js
@@ -118,6 +118,32 @@ describe('useAuthStore', () => {
     expect(localStorage.getItem('archmorph_session_token')).toBe('on-demand-session-token');
   });
 
+  it('preserves stored tokens when on-demand backend session validation is indeterminate', async () => {
+    localStorage.setItem('archmorph_session_token', 'recoverable-backend-token');
+    localStorage.setItem('archmorph_refresh_token', 'recoverable-refresh-token');
+    useAuthStore.setState({
+      user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+      isAuthenticated: true,
+      hasBackendSession: false,
+      isLoading: false,
+      sessionToken: null,
+    });
+    fetch
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({ ok: false, status: 504 });
+
+    await expect(useAuthStore.getState().ensureBackendSession()).resolves.toBe(false);
+
+    expect(localStorage.getItem('archmorph_session_token')).toBe('recoverable-backend-token');
+    expect(localStorage.getItem('archmorph_refresh_token')).toBe('recoverable-refresh-token');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/auth/swa-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+  });
+
   it('prefers the backend user profile when SWA headers reach the API', async () => {
     fetch
       .mockResolvedValueOnce({

--- a/frontend/src/stores/__tests__/useAuthStore.test.js
+++ b/frontend/src/stores/__tests__/useAuthStore.test.js
@@ -88,6 +88,36 @@ describe('useAuthStore', () => {
     expect(localStorage.getItem('archmorph_refresh_token')).toBe('backend-refresh-token');
   });
 
+  it('can exchange an SWA-only signed-in user for a backend session on demand', async () => {
+    useAuthStore.setState({
+      user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+      isAuthenticated: true,
+      hasBackendSession: false,
+      isLoading: false,
+      sessionToken: null,
+    });
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+        session_token: 'on-demand-session-token',
+        refresh_token: 'on-demand-refresh-token',
+      }),
+    });
+
+    await expect(useAuthStore.getState().ensureBackendSession()).resolves.toBe(true);
+
+    const state = useAuthStore.getState();
+    expect(fetch).toHaveBeenCalledWith('/api/auth/swa-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+    expect(state.hasBackendSession).toBe(true);
+    expect(state.sessionToken).toBe('on-demand-session-token');
+    expect(localStorage.getItem('archmorph_session_token')).toBe('on-demand-session-token');
+  });
+
   it('prefers the backend user profile when SWA headers reach the API', async () => {
     fetch
       .mockResolvedValueOnce({

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -43,6 +43,19 @@ async function exchangeSwaSession() {
   return response.json();
 }
 
+async function validateStoredToken(token) {
+  if (!token) return null;
+  const response = await fetch(`${API_BASE}/auth/me`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) return null;
+  const user = await response.json();
+  return user?.id ? user : null;
+}
+
 const SWA_PROVIDER_MAP = {
   aad: 'microsoft',
   microsoft: 'microsoft',
@@ -97,6 +110,42 @@ const useAuthStore = create((set, get) => ({
   isLoading: true,
   sessionToken: getStoredToken(),
 
+  ensureBackendSession: async () => {
+    const current = get();
+    if (current.hasBackendSession && current.sessionToken) return true;
+
+    const storedToken = getStoredToken();
+    if (storedToken) {
+      try {
+        const user = await validateStoredToken(storedToken);
+        if (user) {
+          set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: storedToken, isLoading: false });
+          return true;
+        }
+      } catch {
+        // Try refresh/exchange below; validation can fail transiently through SWA/Front Door.
+      }
+    }
+
+    const refreshed = await current._tryRefresh();
+    if (refreshed) return true;
+
+    const exchanged = await exchangeSwaSession().catch(() => null);
+    if (exchanged?.user?.id && exchanged.session_token) {
+      storeTokens(exchanged.session_token, exchanged.refresh_token);
+      set({
+        user: exchanged.user,
+        isAuthenticated: true,
+        hasBackendSession: true,
+        sessionToken: exchanged.session_token,
+        isLoading: false,
+      });
+      return true;
+    }
+
+    return false;
+  },
+
   // ── Initialize — call on app mount ──
   initialize: async () => {
     set({ isLoading: true });
@@ -131,6 +180,11 @@ const useAuthStore = create((set, get) => ({
           if (token) {
             let shouldClearStoredToken = false;
             try {
+              const user = await validateStoredToken(token);
+              if (user) {
+                set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
+                return;
+              }
               const tokenRes = await fetch(`${API_BASE}/auth/me`, {
                 headers: {
                   'Authorization': `Bearer ${token}`,
@@ -138,11 +192,6 @@ const useAuthStore = create((set, get) => ({
                 },
               });
               if (tokenRes.ok) {
-                const user = await tokenRes.json();
-                if (user && user.id) {
-                  set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
-                  return;
-                }
                 const refreshed = await get()._tryRefresh();
                 if (refreshed) return;
                 shouldClearStoredToken = true;
@@ -183,18 +232,10 @@ const useAuthStore = create((set, get) => ({
     const token = getStoredToken();
     if (token) {
       try {
-        const res = await fetch(`${API_BASE}/auth/me`, {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-        });
-        if (res.ok) {
-          const user = await res.json();
-          if (user && user.id) {
-            set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
-            return;
-          }
+        const user = await validateStoredToken(token);
+        if (user) {
+          set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: token, isLoading: false });
+          return;
         }
         // Token expired — try refresh
         const refreshed = await get()._tryRefresh();

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -115,6 +115,7 @@ const useAuthStore = create((set, get) => ({
     if (current.hasBackendSession && current.sessionToken) return true;
 
     const storedToken = getStoredToken();
+    let tokenValidationIndeterminate = false;
     if (storedToken) {
       try {
         const user = await validateStoredToken(storedToken);
@@ -123,12 +124,14 @@ const useAuthStore = create((set, get) => ({
           return true;
         }
       } catch {
-        // Try refresh/exchange below; validation can fail transiently through SWA/Front Door.
+        tokenValidationIndeterminate = true;
       }
     }
 
-    const refreshed = await current._tryRefresh();
-    if (refreshed) return true;
+    if (!tokenValidationIndeterminate) {
+      const refreshed = await current._tryRefresh();
+      if (refreshed) return true;
+    }
 
     const exchanged = await exchangeSwaSession().catch(() => null);
     if (exchanged?.user?.id && exchanged.session_token) {


### PR DESCRIPTION
## Summary
- Allows signed-in SWA users to click Analyze even if the frontend has not yet minted a backend bearer session.
- Adds `ensureBackendSession()` to validate/refresh/exchange backend tokens on demand before upload.
- Keeps signed-out users on the existing sign-in gate, while preventing signed-in users from being sent back to sign in unnecessarily.

## Validation
- `npm run test -- --run src/stores/__tests__/useAuthStore.test.js src/components/DiagramTranslator/__tests__/UploadStep.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx`
- ESLint on touched auth/upload/session files
- `npm run build`
- `git diff --check`
- `gitleaks dir . --redact --verbose`

## Notes
- Leaves existing 401/session-expired error behavior intact.
- No backend API changes.