### PR TITLE
fix: refresh backend session for signed-in users

### DIFF
--- a/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
@@ -310,10 +310,11 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     expect(screen.queryByText('Analyze This Diagram')).not.toBeInTheDocument()
   })
 
-  it('shows "Authentication required" card (not "Analysis Error") when upload returns 401 without token', async () => {
+  it('shows a backend session refresh card (not "Analysis Error") when signed-in recovery fails', async () => {
     // Set user as authenticated so the upload button is visible and upload can be triggered
     mockIsAuthenticated = true
     mockHasBackendSession = true
+    mockEnsureBackendSession.mockResolvedValue(false)
 
     const { ApiError } = await import('../../../services/apiClient')
     const authErr = new ApiError(401, { detail: 'Not authenticated' }, { hadToken: false })
@@ -338,7 +339,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     await act(async () => { fireEvent.click(analyzeBtn) })
 
     // Should show auth-specific card heading — use role query to avoid matching spine status pill
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Authentication required' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Analysis session needs refresh' })).toBeInTheDocument())
 
     // "Re-upload Diagram" should NOT be the primary CTA for auth failures
     expect(screen.queryByText('Re-upload Diagram')).not.toBeInTheDocument()
@@ -346,13 +347,15 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     // Selected file should still be visible (preserved for retry after sign-in)
     expect(screen.getByText('architecture.pdf')).toBeInTheDocument()
 
-    // Sign-in CTA should be present in the auth card
-    expect(screen.getByRole('button', { name: /Sign in to analyze/i })).toBeInTheDocument()
+    // Signed-in users should be offered a session refresh, not another sign-in prompt.
+    expect(screen.getByRole('button', { name: /Refresh session/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Sign in/i })).not.toBeInTheDocument()
   })
 
-  it('preserves selectedFile after 401 so user can retry after signing in', async () => {
+  it('preserves selectedFile after unrecoverable 401 so user can retry after session recovery', async () => {
     mockIsAuthenticated = true
     mockHasBackendSession = true
+    mockEnsureBackendSession.mockResolvedValue(false)
 
     const { ApiError } = await import('../../../services/apiClient')
     const authErr = new ApiError(401, { detail: 'Not authenticated' }, { hadToken: false })
@@ -397,6 +400,40 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(mockApi.post).toHaveBeenCalledTimes(4))
     expect(mockApi.post).toHaveBeenCalledWith('/projects/demo-project/diagrams', expect.any(FormData), expect.any(AbortSignal))
+  })
+
+  it('refreshes the backend session and retries when a signed-in analysis request gets 401', async () => {
+    mockIsAuthenticated = true
+    mockHasBackendSession = true
+    mockEnsureBackendSession.mockResolvedValueOnce(true)
+
+    const { ApiError } = await import('../../../services/apiClient')
+    const expiredErr = new ApiError(401, { detail: 'Token expired' }, { hadToken: true })
+
+    mockApi.post
+      .mockResolvedValueOnce({ project_id: 'project-1', diagram_id: 'diagram-1', export_capability: 'cap-1' })
+      .mockRejectedValueOnce({ status: 404, name: 'ApiError' })
+      .mockResolvedValueOnce({ diagram_id: 'diagram-1', mappings: [], zones: [], diagram_type: 'AWS Architecture', services_detected: 0 })
+      .mockRejectedValueOnce(expiredErr)
+      .mockResolvedValueOnce({ questions: [], all_questions: [], assumptions: [], inferred_answers: {} })
+    mockApi.get.mockResolvedValue({ diagrams: [] })
+
+    render(<DiagramTranslator />)
+    await screen.findByText('Upload Architecture Diagram')
+
+    const input = document.querySelector('input[type="file"]')
+    const file = new File(['diagram'], 'diagram.png', { type: 'image/png' })
+    await act(async () => { fireEvent.change(input, { target: { files: [file] } }) })
+    await waitFor(() => expect(screen.getByText('diagram.png')).toBeInTheDocument())
+
+    await act(async () => { fireEvent.click(screen.getByText('Analyze This Diagram')) })
+
+    await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalledWith({ forceRefresh: true }))
+    await waitFor(() => {
+      const questionCalls = mockApi.post.mock.calls.filter(([path]) => path === '/diagrams/diagram-1/questions')
+      expect(questionCalls).toHaveLength(2)
+    })
+    expect(screen.queryByRole('heading', { name: 'Authentication required' })).not.toBeInTheDocument()
   })
 
   it('does not fall back to sync analysis when async admission is rejected', async () => {
@@ -461,7 +498,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
   it('exchanges backend session on upload when user is SWA-only without a backend session', async () => {
     mockIsAuthenticated = true
     mockHasBackendSession = false
-    mockEnsureBackendSession.mockResolvedValueOnce(false)
+    mockEnsureBackendSession.mockResolvedValue(false)
 
     render(<DiagramTranslator />)
     await screen.findByText('Upload Architecture Diagram')
@@ -473,8 +510,8 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
 
     await act(async () => { fireEvent.click(screen.getByText('Analyze This Diagram')) })
 
-    await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalledTimes(1))
-    expect(screen.getByRole('heading', { name: 'Authentication required' })).toBeInTheDocument()
+    await waitFor(() => expect(mockEnsureBackendSession).toHaveBeenCalled())
+    expect(screen.getByRole('heading', { name: 'Analysis session needs refresh' })).toBeInTheDocument()
     expect(mockApi.post).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -625,6 +625,38 @@ export default function DiagramTranslator() {
     }
   };
 
+  const recoverBackendSession = useCallback(async () => {
+    if (!isAuthenticated || !ensureBackendSession) return false;
+    try {
+      const ready = await ensureBackendSession({ forceRefresh: true });
+      if (ready) {
+        set({ authError: null, error: null });
+        return true;
+      }
+    } catch {
+      // Keep the auth card visible so the user can retry or complete sign-in.
+    }
+    return false;
+  }, [ensureBackendSession, isAuthenticated, set]);
+
+  useEffect(() => {
+    if (!state.authError || !isAuthenticated) return undefined;
+    let cancelled = false;
+    (async () => {
+      const ready = await recoverBackendSession();
+      if (!cancelled && ready) set({ authError: null, error: null });
+    })();
+    return () => { cancelled = true; };
+  }, [isAuthenticated, recoverBackendSession, set, state.authError]);
+
+  const handleAuthCardAction = useCallback(async () => {
+    if (isAuthenticated) {
+      const ready = await recoverBackendSession();
+      if (ready) return;
+    }
+    setLoginModalOpen(true);
+  }, [isAuthenticated, recoverBackendSession]);
+
   const handleAuthenticatedUpload = async (file) => {
     if (!isAuthenticated) {
       setLoginModalOpen(true);
@@ -632,10 +664,9 @@ export default function DiagramTranslator() {
     }
     if (!hasBackendSession) {
       set({ authError: null, error: null });
-      const ready = await ensureBackendSession?.();
+      const ready = await ensureBackendSession?.({ forceRefresh: true });
       if (!ready) {
         set({ authError: 'auth_required', error: null, step: 'upload' });
-        setLoginModalOpen(true);
         return;
       }
     }
@@ -673,6 +704,17 @@ export default function DiagramTranslator() {
     }
   };
 
+  const withAuthRecovery = async (action) => {
+    try {
+      return await action();
+    } catch (err) {
+      if (err.status === 401 && await recoverBackendSession()) {
+        return action();
+      }
+      throw err;
+    }
+  };
+
   /**
    * Execute an async action with automatic session-restore-and-retry on 404.
    * Collapses the duplicated try/restore/retry pattern used across handlers (#327).
@@ -681,12 +723,12 @@ export default function DiagramTranslator() {
    */
   const withRestore = async (action, opts = {}) => {
     try {
-      return await action();
+      return await withAuthRecovery(action);
     } catch (err) {
       if (err.status === 404 && state.diagramId) {
         const restored = await tryRestoreSession(state.diagramId);
         if (restored) {
-          try { return await action(); } catch { /* fall through */ }
+          try { return await withAuthRecovery(action); } catch { /* fall through */ }
         }
         set({ error: 'Your session has expired. Please re-upload your diagram to continue.', step: 'upload' });
         clearSession();
@@ -760,7 +802,7 @@ export default function DiagramTranslator() {
 
       addProgress('Uploading diagram...');
       const projectId = state.projectId || DEFAULT_PROJECT_ID;
-      const uploadData = await api.post(`/projects/${projectId}/diagrams`, formData, signal);
+      const uploadData = await withAuthRecovery(() => api.post(`/projects/${projectId}/diagrams`, formData, signal));
       const { diagram_id } = uploadData;
       set({ projectId: uploadData.project_id || projectId, diagramId: diagram_id, exportCapability: uploadData.export_capability || null, purgeReceipt: null });
       await refreshProjectStatus(uploadData.project_id || projectId);
@@ -781,7 +823,7 @@ export default function DiagramTranslator() {
       let useAsyncEndpoint = true;
       let asyncData;
       try {
-        asyncData = await api.post(`/diagrams/${diagram_id}/analyze-async`, undefined, signal);
+        asyncData = await withAuthRecovery(() => api.post(`/diagrams/${diagram_id}/analyze-async`, undefined, signal));
         // apiClient throws on non-2xx, so if we get here it's ok
         // But we still need to check for 202-specific behavior; apiClient resolves JSON body
       } catch (err) {
@@ -891,7 +933,7 @@ export default function DiagramTranslator() {
 
         set({ analysis: result, exportCapability: result.export_capability || state.exportCapability || null, purgeReceipt: null });
         await refreshProjectStatus(uploadData.project_id || projectId);
-        const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
+        const qData = await withAuthRecovery(() => api.post(`/diagrams/${diagram_id}/questions`, undefined, signal));
         const questionState = buildQuestionState(qData);
         saveSession(diagram_id, result, questionState.questions, questionState.answers, {
           persistSensitive: persistSensitiveCache,
@@ -925,7 +967,7 @@ export default function DiagramTranslator() {
         }, 2500 + Math.random() * 1500);
         activeIntervalRef.current = progressInterval;
 
-        const result = await api.post(`/diagrams/${diagram_id}/analyze`, undefined, signal);
+        const result = await withAuthRecovery(() => api.post(`/diagrams/${diagram_id}/analyze`, undefined, signal));
         clearInterval(progressInterval);
         if (activeIntervalRef.current === progressInterval) activeIntervalRef.current = null;
 
@@ -949,7 +991,7 @@ export default function DiagramTranslator() {
 
         set({ analysis: result, exportCapability: result.export_capability || uploadData.export_capability || null, purgeReceipt: null });
         await refreshProjectStatus(uploadData.project_id || projectId);
-        const qData = await api.post(`/diagrams/${diagram_id}/questions`, undefined, signal);
+        const qData = await withAuthRecovery(() => api.post(`/diagrams/${diagram_id}/questions`, undefined, signal));
         const questionState = buildQuestionState(qData);
         saveSession(diagram_id, result, questionState.questions, questionState.answers, {
           persistSensitive: persistSensitiveCache,
@@ -1441,17 +1483,23 @@ export default function DiagramTranslator() {
               <LogIn className="w-5 h-5 text-warning" aria-hidden="true" />
             </div>
             <div>
-              <h3 className="text-sm font-semibold text-text-primary">Authentication required</h3>
+              <h3 className="text-sm font-semibold text-text-primary">
+                {isAuthenticated ? 'Analysis session needs refresh' : 'Authentication required'}
+              </h3>
               <p className="text-xs text-text-muted mt-1">
-                {state.authError === 'session_expired'
-                  ? 'Your session has expired. Sign in to continue.'
-                  : 'Sign in to analyze your diagram.'}
-                {state.selectedFile && ' Your selected file is ready to analyze once you sign in.'}
+                {isAuthenticated
+                  ? 'You are signed in, but the analysis API session needs to be refreshed.'
+                  : state.authError === 'session_expired'
+                    ? 'Your session has expired. Sign in to continue.'
+                    : 'Sign in to analyze your diagram.'}
+                {state.selectedFile && (isAuthenticated
+                  ? ' Your selected file is ready to analyze once the session refreshes.'
+                  : ' Your selected file is ready to analyze once you sign in.')}
               </p>
             </div>
             <div className="flex items-center gap-2">
-              <Button variant="primary" size="sm" icon={LogIn} onClick={() => setLoginModalOpen(true)}>
-                {state.authError === 'session_expired' ? 'Sign in again' : 'Sign in to analyze'}
+              <Button variant="primary" size="sm" icon={LogIn} onClick={handleAuthCardAction}>
+                {isAuthenticated ? 'Refresh session' : state.authError === 'session_expired' ? 'Sign in again' : 'Sign in to analyze'}
               </Button>
               <Button variant="ghost" size="sm" onClick={() => set({ authError: null })}>
                 Dismiss

--- a/frontend/src/stores/__tests__/useAuthStore.test.js
+++ b/frontend/src/stores/__tests__/useAuthStore.test.js
@@ -118,6 +118,62 @@ describe('useAuthStore', () => {
     expect(localStorage.getItem('archmorph_session_token')).toBe('on-demand-session-token');
   });
 
+  it('force-refreshes a stale claimed backend session by reminting from SWA', async () => {
+    localStorage.setItem('archmorph_session_token', 'stale-backend-token');
+    useAuthStore.setState({
+      user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+      isAuthenticated: true,
+      hasBackendSession: true,
+      isLoading: false,
+      sessionToken: 'stale-backend-token',
+    });
+    fetch
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+          session_token: 'fresh-backend-token',
+          refresh_token: 'fresh-refresh-token',
+        }),
+      });
+
+    await expect(useAuthStore.getState().ensureBackendSession({ forceRefresh: true })).resolves.toBe(true);
+
+    const state = useAuthStore.getState();
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/me', {
+      headers: {
+        'Authorization': 'Bearer stale-backend-token',
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/auth/swa-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+    expect(state.hasBackendSession).toBe(true);
+    expect(state.sessionToken).toBe('fresh-backend-token');
+    expect(localStorage.getItem('archmorph_session_token')).toBe('fresh-backend-token');
+  });
+
+  it('prefers a newer stored token over a stale in-memory backend token', async () => {
+    localStorage.setItem('archmorph_session_token', 'newer-stored-token');
+    useAuthStore.setState({
+      user: { id: 'aad_user-123', name: 'Ido Katz', provider: 'microsoft' },
+      isAuthenticated: true,
+      hasBackendSession: true,
+      isLoading: false,
+      sessionToken: 'stale-memory-token',
+    });
+
+    await expect(useAuthStore.getState().ensureBackendSession()).resolves.toBe(true);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(localStorage.getItem('archmorph_session_token')).toBe('newer-stored-token');
+    expect(useAuthStore.getState().sessionToken).toBe('newer-stored-token');
+  });
+
   it('preserves stored tokens when on-demand backend session validation is indeterminate', async () => {
     localStorage.setItem('archmorph_session_token', 'recoverable-backend-token');
     localStorage.setItem('archmorph_refresh_token', 'recoverable-refresh-token');

--- a/frontend/src/stores/useAuthStore.js
+++ b/frontend/src/stores/useAuthStore.js
@@ -51,7 +51,12 @@ async function validateStoredToken(token) {
       'Content-Type': 'application/json',
     },
   });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    if (response.status >= 500 || response.status === 0) {
+      throw new Error('Token validation indeterminate');
+    }
+    return null;
+  }
   const user = await response.json();
   return user?.id ? user : null;
 }
@@ -110,17 +115,27 @@ const useAuthStore = create((set, get) => ({
   isLoading: true,
   sessionToken: getStoredToken(),
 
-  ensureBackendSession: async () => {
+  ensureBackendSession: async ({ forceRefresh = false } = {}) => {
     const current = get();
-    if (current.hasBackendSession && current.sessionToken) return true;
-
     const storedToken = getStoredToken();
+    const activeToken = storedToken || current.sessionToken;
+    if (!forceRefresh && current.hasBackendSession && activeToken) {
+      if (!storedToken && current.sessionToken) {
+        storeTokens(current.sessionToken);
+      }
+      if (current.sessionToken !== activeToken) {
+        set({ sessionToken: activeToken });
+      }
+      return true;
+    }
+
     let tokenValidationIndeterminate = false;
-    if (storedToken) {
+    if (activeToken) {
       try {
-        const user = await validateStoredToken(storedToken);
+        const user = await validateStoredToken(activeToken);
         if (user) {
-          set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: storedToken, isLoading: false });
+          if (!storedToken) storeTokens(activeToken);
+          set({ user, isAuthenticated: true, hasBackendSession: true, sessionToken: activeToken, isLoading: false });
           return true;
         }
       } catch {


### PR DESCRIPTION
## Summary\n- force-check stale backend bearer sessions before trusting them\n- recover/retry one failed workbench API call after reminting from SWA auth\n- show signed-in users a backend session refresh CTA instead of asking them to sign in again\n\n## Validation\n- npx vitest run src/stores/__tests__/useAuthStore.test.js src/components/DiagramTranslator/__tests__/UploadStep.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx\n- npx eslint src/stores/useAuthStore.js src/stores/__tests__/useAuthStore.test.js src/components/DiagramTranslator/index.jsx src/components/DiagramTranslator/UploadStep.jsx src/components/DiagramTranslator/__tests__/UploadStep.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx --max-warnings 0\n- npm run build\n- git diff --check\n- gitleaks dir . --redact --verbose