### PR TITLE
fix: allow bearer auth on workbench routes

### DIFF
--- a/backend/routers/analysis.py
+++ b/backend/routers/analysis.py
@@ -15,7 +15,6 @@ from routers.shared import (
     authorize_diagram_access,
     limiter,
     require_diagram_access,
-    verify_api_key,
     verify_api_key_or_user_session,
 )
 from usage_metrics import record_event, record_funnel_step
@@ -42,7 +41,7 @@ class AddServicesRequest(StrictBaseModel):
 # ─────────────────────────────────────────────────────────────
 @router.post("/api/diagrams/{diagram_id}/questions", dependencies=[Depends(require_diagram_access)])
 @limiter.limit("15/minute")
-async def get_guided_questions(request: Request, diagram_id: str, smart_dedup: bool = True, _auth=Depends(verify_api_key)):
+async def get_guided_questions(request: Request, diagram_id: str, smart_dedup: bool = True, _auth=Depends(verify_api_key_or_user_session)):
     """Generate guided questions based on detected AWS services.
 
     If smart_dedup=True, questions that have been implicitly answered
@@ -94,7 +93,7 @@ async def add_services_natural_language(
     request: Request,
     diagram_id: str,
     body: AddServicesRequest,
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
 ):
     """Add Azure services to an architecture using natural language.
 
@@ -148,7 +147,7 @@ async def apply_guided_answers(
     request: Request,
     diagram_id: str,
     answers: Dict[str, Any],
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
 ):
     """Apply user answers to refine the Azure architecture analysis."""
     analysis = authorize_diagram_access(request, diagram_id, purpose="apply answers")
@@ -269,7 +268,7 @@ async def export_architecture_package(
     diagram_id: str,
     format: str = "html",
     diagram: str = "primary",
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
     capability=Depends(verify_export_capability),
 ):
     """Generate the customer-facing Architecture Package.

--- a/backend/routers/projects.py
+++ b/backend/routers/projects.py
@@ -10,7 +10,7 @@ from iac_generator import generate_iac_code
 from project_merge import merge_project_analyses
 from project_store import get_project, list_analyzed_diagrams, set_combined_analysis
 from routers.iac_routes import _check_architecture_blockers
-from routers.shared import SESSION_STORE, limiter, verify_api_key
+from routers.shared import SESSION_STORE, limiter, verify_api_key_or_user_session
 from usage_metrics import record_event, record_funnel_step
 
 router = APIRouter()
@@ -37,7 +37,7 @@ def _combined_analysis_for_project(project_id: str) -> dict:
 
 @router.get("/api/projects/{project_id}")
 @limiter.limit("30/minute")
-async def get_project_status(request: Request, project_id: str, _auth=Depends(verify_api_key)):
+async def get_project_status(request: Request, project_id: str, _auth=Depends(verify_api_key_or_user_session)):
     """Return project metadata and per-diagram analysis status."""
     project = get_project(project_id)
     if not project:
@@ -47,7 +47,7 @@ async def get_project_status(request: Request, project_id: str, _auth=Depends(ve
 
 @router.get("/api/projects/{project_id}/analysis")
 @limiter.limit("15/minute")
-async def get_project_analysis(request: Request, project_id: str, _auth=Depends(verify_api_key)):
+async def get_project_analysis(request: Request, project_id: str, _auth=Depends(verify_api_key_or_user_session)):
     """Return a deterministic combined analysis for all analyzed project diagrams."""
     combined = _combined_analysis_for_project(project_id)
     record_event("project_analysis_merged", {
@@ -65,7 +65,7 @@ async def generate_project_iac(
     project_id: str,
     format: Literal["terraform", "bicep"] = "terraform",
     force: bool = False,
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
 ):
     """Generate unified Infrastructure as Code from combined project analysis."""
     combined = _combined_analysis_for_project(project_id)

--- a/backend/tests/test_swa_session_bridge.py
+++ b/backend/tests/test_swa_session_bridge.py
@@ -16,6 +16,39 @@ from routers import diagrams  # noqa: E402
 from routers import shared  # noqa: E402
 
 
+OWNER_USER_ID = "aad_bridge-user"
+OWNER_TENANT_ID = "default_tenant"
+
+
+def _owner_headers() -> dict[str, str]:
+    user = User(
+        id=OWNER_USER_ID,
+        email="bridge@example.com",
+        provider=AuthProvider.MICROSOFT,
+        tenant_id=OWNER_TENANT_ID,
+    )
+    return {"Authorization": f"Bearer {generate_session_token(user)}"}
+
+
+def _owned_analysis(diagram_id: str) -> dict:
+    return {
+        "diagram_id": diagram_id,
+        "diagram_type": "AWS Architecture",
+        "source_provider": "aws",
+        "target_provider": "azure",
+        "services_detected": 2,
+        "zones": [
+            {"id": 1, "number": 1, "name": "Compute", "services": [{"aws": "EC2", "azure": "Azure VM"}]},
+        ],
+        "mappings": [
+            {"source_service": "Amazon EC2", "azure_service": "Azure Virtual Machines", "confidence": 0.95},
+            {"source_service": "Amazon S3", "azure_service": "Azure Blob Storage", "confidence": 0.92},
+        ],
+        "_owner_user_id": OWNER_USER_ID,
+        "_tenant_id": OWNER_TENANT_ID,
+    }
+
+
 def _png_bytes() -> bytes:
     return b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
 
@@ -34,13 +67,12 @@ def _swa_principal(user_id: str = "bridge-user") -> str:
 def test_diagram_upload_accepts_authenticated_user_bearer_session(monkeypatch):
     monkeypatch.setattr(shared, "API_KEY", "test-api-key")
 
-    user = User(id="aad_bridge-user", email="bridge@example.com", provider=AuthProvider.MICROSOFT)
-    token = generate_session_token(user)
+    headers = _owner_headers()
 
     with TestClient(app, raise_server_exceptions=False) as client:
         response = client.post(
             "/api/projects/demo-project/diagrams",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             files={"file": ("diagram.png", io.BytesIO(_png_bytes()), "image/png")},
         )
 
@@ -49,6 +81,59 @@ def test_diagram_upload_accepts_authenticated_user_bearer_session(monkeypatch):
     assert payload["status"] == "uploaded"
     assert payload["diagram_id"].startswith("diag-")
     diagrams.IMAGE_STORE.delete(payload["diagram_id"])
+    shared.DIAGRAM_PROJECT_STORE.delete(payload["diagram_id"])
+    shared.PROJECT_STORE.delete("demo-project")
+
+
+def test_project_status_accepts_authenticated_user_bearer_session_when_api_key_configured(monkeypatch):
+    monkeypatch.setattr(shared, "API_KEY", "test-api-key")
+    headers = _owner_headers()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        upload = client.post(
+            "/api/projects/demo-project/diagrams",
+            headers=headers,
+            files={"file": ("diagram.png", io.BytesIO(_png_bytes()), "image/png")},
+        )
+        assert upload.status_code == 200, upload.text
+        response = client.get("/api/projects/demo-project", headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["project_id"] == "demo-project"
+    diagram_id = upload.json()["diagram_id"]
+    diagrams.IMAGE_STORE.delete(diagram_id)
+    shared.DIAGRAM_PROJECT_STORE.delete(diagram_id)
+    shared.PROJECT_STORE.delete("demo-project")
+
+
+def test_guided_questions_accept_authenticated_user_bearer_session_when_api_key_configured(monkeypatch):
+    monkeypatch.setattr(shared, "API_KEY", "test-api-key")
+    diagram_id = "diag-bearer-questions"
+    shared.SESSION_STORE[diagram_id] = _owned_analysis(diagram_id)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(f"/api/diagrams/{diagram_id}/questions", headers=_owner_headers())
+
+    assert response.status_code == 200, response.text
+    assert response.json()["diagram_id"] == diagram_id
+    shared.SESSION_STORE.delete(diagram_id)
+
+
+def test_architecture_package_accepts_authenticated_user_bearer_session_when_api_key_configured(monkeypatch):
+    monkeypatch.setattr(shared, "API_KEY", "test-api-key")
+    monkeypatch.setenv("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "false")
+    diagram_id = "diag-bearer-architecture-package"
+    shared.SESSION_STORE[diagram_id] = _owned_analysis(diagram_id)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            f"/api/diagrams/{diagram_id}/export-architecture-package?format=html",
+            headers=_owner_headers(),
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["format"] == "architecture-package-html"
+    shared.SESSION_STORE.delete(diagram_id)
 
 
 def test_swa_session_bridge_requires_configured_api_key(monkeypatch):


### PR DESCRIPTION
## Summary\n- allow signed-in bearer sessions on project status/analysis/generate routes\n- allow signed-in bearer sessions on guided questions, apply answers, add-services, and architecture-package export\n- add regressions for the production 401s from project status, questions, and architecture package export\n\n## Validation\n- cd backend && .venv/bin/python -m pytest -q tests/test_swa_session_bridge.py tests/test_projects.py tests/test_export_capabilities.py tests/test_diagram_access_hardening.py\n- cd backend && .venv/bin/python -m ruff check routers/projects.py routers/analysis.py tests/test_swa_session_bridge.py\n- git diff --check\n- gitleaks dir . --redact --verbose