### PR TITLE
fix: allow bearer auth on package export

### DIFF
--- a/backend/routers/hld_routes.py
+++ b/backend/routers/hld_routes.py
@@ -17,6 +17,7 @@ from routers.shared import (
     limiter,
     require_diagram_access,
     verify_api_key,
+    verify_api_key_or_user_session,
 )
 from job_queue import job_manager
 from usage_metrics import record_event
@@ -352,7 +353,7 @@ async def _run_hld_job(job_id: str, diagram_id: str) -> None:
 async def export_migration_package(
     request: Request,
     diagram_id: str,
-    _auth=Depends(verify_api_key),
+    _auth=Depends(verify_api_key_or_user_session),
     capability=Depends(verify_export_capability),
 ):
     """Export a complete migration package as a ZIP file.

--- a/backend/tests/test_swa_session_bridge.py
+++ b/backend/tests/test_swa_session_bridge.py
@@ -44,6 +44,9 @@ def _owned_analysis(diagram_id: str) -> dict:
             {"source_service": "Amazon EC2", "azure_service": "Azure Virtual Machines", "confidence": 0.95},
             {"source_service": "Amazon S3", "azure_service": "Azure Blob Storage", "confidence": 0.92},
         ],
+        "confidence_summary": {"average": 0.94, "high": 2, "medium": 0, "low": 0},
+        "hld": {"title": "Bearer Session HLD", "services": [], "executive_summary": "Test HLD"},
+        "hld_markdown": "# Bearer Session HLD\n",
         "_owner_user_id": OWNER_USER_ID,
         "_tenant_id": OWNER_TENANT_ID,
     }
@@ -133,6 +136,26 @@ def test_architecture_package_accepts_authenticated_user_bearer_session_when_api
 
     assert response.status_code == 200, response.text
     assert response.json()["format"] == "architecture-package-html"
+    shared.SESSION_STORE.delete(diagram_id)
+
+
+def test_migration_package_accepts_authenticated_user_bearer_session_when_api_key_configured(monkeypatch):
+    monkeypatch.setattr(shared, "API_KEY", "test-api-key")
+    monkeypatch.setenv("ARCHMORPH_EXPORT_CAPABILITY_REQUIRED", "false")
+    diagram_id = "diag-bearer-migration-package"
+    shared.SESSION_STORE[diagram_id] = _owned_analysis(diagram_id)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            f"/api/diagrams/{diagram_id}/export-package",
+            headers=_owner_headers(),
+            json={"iac_format": "terraform", "include_diagrams": False},
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["content_type"] == "application/zip"
+    assert payload["content_b64"]
     shared.SESSION_STORE.delete(diagram_id)
 
 


### PR DESCRIPTION
## Summary\n- allow signed-in bearer sessions on POST /api/diagrams/{diagram_id}/export-package\n- keep diagram ownership and export capability checks intact\n- add regression for migration package export with bearer auth while API key auth is configured\n\n## Validation\n- cd backend && .venv/bin/python -m pytest -q tests/test_swa_session_bridge.py tests/test_export_capabilities.py tests/test_diagram_access_hardening.py\n- cd backend && .venv/bin/python -m ruff check routers/hld_routes.py tests/test_swa_session_bridge.py\n- git diff --check\n- gitleaks dir . --redact --verbose