### PR TITLE
fix: skip diagram artifacts for combined projects

### DIFF
--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -316,6 +316,7 @@ export default function AnalysisResults({
   onExportPackage, exportingPackage,
 }) {
   const [resultsView, setResultsView] = useState('card');
+  const hasDiagramExports = !!diagramId && !!onExportDiagram;
 
   return (
     <div className="space-y-6">
@@ -570,21 +571,25 @@ export default function AnalysisResults({
       )}
 
       {/* Export Diagram + Export Hub (secondary classic exports) */}
-      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
-        <div className="flex-1">
-          <ExportPanel exportLoading={exportLoading} onExportDiagram={onExportDiagram} secondary />
+      {hasDiagramExports && (
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+          <div className="flex-1">
+            <ExportPanel exportLoading={exportLoading} onExportDiagram={onExportDiagram} secondary />
+          </div>
+          <Button onClick={() => document.dispatchEvent(new CustomEvent('archmorph:command', { detail: 'export-hub' }))} variant="secondary" icon={Package}>
+            Export All
+          </Button>
         </div>
-        <Button onClick={() => document.dispatchEvent(new CustomEvent('archmorph:command', { detail: 'export-hub' }))} variant="secondary" icon={Package}>
-          Export All
-        </Button>
-      </div>
+      )}
 
       {/* Export Hub Modal */}
-      <ExportHub
-        diagramId={diagramId}
-        exportCapability={exportCapability}
-        onExportCapability={onExportCapability}
-      />
+      {hasDiagramExports && (
+        <ExportHub
+          diagramId={diagramId}
+          exportCapability={exportCapability}
+          onExportCapability={onExportCapability}
+        />
+      )}
 
       {/* Generation Progress Indicator (#311) */}
       {generatingIac && (

--- a/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx
@@ -57,6 +57,7 @@ describe('AnalysisResults', () => {
     onHldExport: vi.fn(),
     onCopyWithFeedback: vi.fn(),
     onReviewAssumptions: vi.fn(),
+    diagramId: 'diag-1',
   }
 
   it('renders diagram type title', () => {
@@ -265,6 +266,12 @@ describe('AnalysisResults', () => {
     expect(
       cta.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
+  })
+
+  it('hides diagram-only exports when no real diagram id is available', () => {
+    render(<AnalysisResults {...defaultProps} diagramId={null} />)
+    expect(screen.queryByTestId('export-panel')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /export all/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
@@ -115,6 +115,35 @@ describe('DiagramTranslator — Session UX Tests', () => {
     await waitFor(() => expect(screen.queryByText('Upload Architecture Diagram')).not.toBeInTheDocument());
   })
 
+  it('does not call diagram-only endpoints for combined project pseudo ids', async () => {
+    mockLoadSession.mockReturnValue({
+      diagramId: 'project-demo-project',
+      analysis: {
+        diagram_id: 'project-demo-project',
+        project_id: 'demo-project',
+        combined: true,
+        diagram_type: 'Multi-diagram Architecture',
+        services_detected: 2,
+        source_provider: 'aws',
+        target_provider: 'azure',
+        zones: [],
+        mappings: [],
+        confidence_summary: { high: 2, medium: 0, low: 0, average: 0.9 },
+      },
+      questions: [],
+      answers: {},
+      ts: Date.now(),
+    })
+
+    render(<DiagramTranslator />)
+
+    await waitFor(() => expect(screen.getByText('Multi-diagram Architecture')).toBeInTheDocument())
+    expect(mockApi.get).not.toHaveBeenCalledWith('/diagrams/project-demo-project/review-queue')
+    expect(mockApi.post).not.toHaveBeenCalledWith('/diagrams/project-demo-project/export-package', expect.anything(), expect.anything(), expect.anything(), expect.anything())
+    expect(screen.queryByTestId('migration-package-cta')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /export all/i })).not.toBeInTheDocument()
+  })
+
   // ── Session expiry error display ──
 
   it('shows session expiry message correctly', () => {

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -346,6 +346,7 @@ export default function DiagramTranslator() {
   const ensureBackendSession = useAuthStore((s) => s.ensureBackendSession);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [authUploadRecovery, setAuthUploadRecovery] = useState(null);
+  const hasDiagramArtifactContext = !!state.diagramId && !state.analysis?.combined && !String(state.diagramId).startsWith('project-');
 
   // ── Architect Review Queue — Issue #1137 ──────────────────────────────────
   const [reviewItems, setReviewItems] = useState([]);
@@ -501,24 +502,31 @@ export default function DiagramTranslator() {
 
   // ── Auto-trigger HLD generation when entering HLD tab (#400) ──
   useEffect(() => {
-    if (state.step === 'hld' && !state.hldData && !state.hldLoading && state.diagramId) {
+    if (state.step === 'hld' && !state.hldData && !state.hldLoading && hasDiagramArtifactContext) {
       handleGenerateHld();
     }
-  }, [state.step]);
+  }, [hasDiagramArtifactContext, state.step]);
 
   // ── Auto-fetch cost breakdown when entering Pricing tab (#401) ──
   useEffect(() => {
-    if (state.step === 'pricing' && !state.costBreakdown && !state.costBreakdownLoading && state.diagramId) {
+    if (state.step === 'pricing' && !state.costBreakdown && !state.costBreakdownLoading && hasDiagramArtifactContext) {
       set({ costBreakdownLoading: true });
       api.get(`/diagrams/${state.diagramId}/cost-breakdown`)
         .then(data => set({ costBreakdown: data, costBreakdownLoading: false }))
         .catch(() => set({ costBreakdownLoading: false }));
     }
-  }, [state.step]);
+  }, [hasDiagramArtifactContext, state.diagramId, state.step]);
 
   // ── Review Queue — fetch when analysis results become available (#1137) ──
   useEffect(() => {
-    if (!state.diagramId || state.step !== 'results') return;
+    if (state.step !== 'results') return;
+    if (!hasDiagramArtifactContext) {
+      setReviewItems([]);
+      setReviewDispositions({});
+      setReviewSummary({});
+      setReviewLoading(false);
+      return;
+    }
     setReviewLoading(true);
     Promise.resolve(api.get(`/diagrams/${state.diagramId}/review-queue`))
       .then(data => {
@@ -534,7 +542,7 @@ export default function DiagramTranslator() {
       })
       .catch(() => { /* Non-blocking — queue is best-effort */ })
       .finally(() => setReviewLoading(false));
-  }, [state.diagramId, state.step]);
+  }, [hasDiagramArtifactContext, state.diagramId, state.step]);
 
   const handleReviewDispose = useCallback(async (itemId, action, editedText) => {
     const nextDisposition = { action, edited_text: editedText };
@@ -545,7 +553,7 @@ export default function DiagramTranslator() {
       return next;
     });
     // Persist to backend
-    if (!state.diagramId) return;
+    if (!hasDiagramArtifactContext) return;
     try {
       const result = await api.post(
         `/diagrams/${state.diagramId}/review-queue/${itemId}/disposition`,
@@ -555,7 +563,7 @@ export default function DiagramTranslator() {
     } catch {
       // Best-effort — optimistic update already applied
     }
-  }, [state.diagramId, reviewItems]);
+  }, [hasDiagramArtifactContext, state.diagramId, reviewItems]);
 
   // ── Drag & drop ──
   const refreshProjectStatus = useCallback(async (projectId) => {
@@ -574,7 +582,7 @@ export default function DiagramTranslator() {
     set({ loading: true, error: null });
     try {
       const combined = await api.get(`/projects/${state.projectId}/analysis`);
-      set({ analysis: combined, step: 'results', loading: false, iacCode: null, diagramId: combined.diagram_id || state.diagramId });
+      set({ analysis: combined, step: 'results', loading: false, iacCode: null, diagramId: null, exportCapability: null });
       await refreshProjectStatus(state.projectId);
     } catch (err) {
       set({ error: err.message, loading: false });
@@ -1552,15 +1560,15 @@ export default function DiagramTranslator() {
         </Card>
       )}
 
-      {(state.diagramId || state.purgeReceipt) && (
+      {(hasDiagramArtifactContext || state.purgeReceipt) && (
         <Suspense fallback={null}>
           <DataLifecyclePanel
-            diagramId={state.diagramId}
+            diagramId={hasDiagramArtifactContext ? state.diagramId : null}
             analysis={state.analysis}
             exportCapability={state.exportCapability}
             purgeReceipt={state.purgeReceipt}
-            purgeLoading={state.loading && !!state.diagramId}
-            onPurge={handlePurgeCurrentAnalysis}
+            purgeLoading={state.loading && hasDiagramArtifactContext}
+            onPurge={hasDiagramArtifactContext ? handlePurgeCurrentAnalysis : undefined}
           />
         </Suspense>
       )}
@@ -1697,9 +1705,9 @@ export default function DiagramTranslator() {
           genProgress={state.genProgress}
           notifyEmail={state.notifyEmail}
           onNotifyEmail={handleNotifyEmail}
-          onExportDiagram={handleExportDiagram}
+          onExportDiagram={hasDiagramArtifactContext ? handleExportDiagram : undefined}
           onCopyWithFeedback={copyWithFeedback}
-          diagramId={state.diagramId}
+          diagramId={hasDiagramArtifactContext ? state.diagramId : null}
           exportCapability={state.exportCapability}
           assumptions={state.questionAssumptions}
           questionsCount={(state.questions || []).length}
@@ -1711,7 +1719,7 @@ export default function DiagramTranslator() {
           reviewSummary={reviewSummary}
           onDispose={handleReviewDispose}
           reviewLoading={reviewLoading}
-          onExportPackage={state.diagramId ? handleExportPackage : undefined}
+          onExportPackage={hasDiagramArtifactContext ? handleExportPackage : undefined}
           exportingPackage={state.exportingPackage}
         />
       )}


### PR DESCRIPTION
## Summary\n- treat combined project analysis as project-level, not a diagram artifact\n- clear the pseudo project diagram id when viewing combined analysis\n- skip review queue, lifecycle, diagram export, export hub, and migration-package calls without a real diagram id\n\n## Validation\n- cd frontend && npx vitest run src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx\n- cd frontend && npx eslint src/components/DiagramTranslator/index.jsx src/components/DiagramTranslator/AnalysisResults.jsx src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx --max-warnings 0\n- cd frontend && npm run build\n- git diff --check\n- gitleaks dir . --redact --verbose