### PR TITLE
fix: refresh export capability on 401

### DIFF
--- a/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
+++ b/frontend/src/components/DiagramTranslator/AnalysisResults.jsx
@@ -310,7 +310,7 @@ export default function AnalysisResults({
   analysis, loading, generatingIac, iacFormat, exportLoading,
   copyFeedback, genProgress, notifyEmail, onNotifyEmail,
   onSetStep, onGenerateIac, onExportDiagram, onCopyWithFeedback,
-  diagramId, exportCapability, onExportCapability,
+  diagramId, exportCapability, onExportCapability, onRefreshExportCapability,
   assumptions = [], questionsCount = 0, onReviewAssumptions,
   reviewItems = [], reviewDispositions = {}, reviewSummary = {}, onDispose, reviewLoading = false,
   onExportPackage, exportingPackage,
@@ -588,6 +588,7 @@ export default function AnalysisResults({
           diagramId={diagramId}
           exportCapability={exportCapability}
           onExportCapability={onExportCapability}
+          onRefreshExportCapability={onRefreshExportCapability}
         />
       )}
 

--- a/frontend/src/components/DiagramTranslator/ExportHub.jsx
+++ b/frontend/src/components/DiagramTranslator/ExportHub.jsx
@@ -184,7 +184,13 @@ function downloadBlob(blob, filename) {
   URL.revokeObjectURL(url);
 }
 
-export default function ExportHub({ diagramId, hldIncludeDiagrams = true, exportCapability = null, onExportCapability }) {
+export default function ExportHub({
+  diagramId,
+  hldIncludeDiagrams = true,
+  exportCapability = null,
+  onExportCapability,
+  onRefreshExportCapability,
+}) {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState(() => {
     const init = {};
@@ -279,7 +285,16 @@ export default function ExportHub({ diagramId, hldIncludeDiagrams = true, export
     const runCap = async () => {
       for (const d of capItems) {
         try {
-          const result = await generateDeliverable(diagramId, d, formats[d.id], hldIncludeDiagrams, currentExportCapability);
+          let result;
+          try {
+            result = await generateDeliverable(diagramId, d, formats[d.id], hldIncludeDiagrams, currentExportCapability);
+          } catch (err) {
+            if (err?.status !== 401 || !onRefreshExportCapability) throw err;
+            const refreshedCapability = await onRefreshExportCapability();
+            if (!refreshedCapability) throw err;
+            currentExportCapability = refreshedCapability;
+            result = await generateDeliverable(diagramId, d, formats[d.id], hldIncludeDiagrams, currentExportCapability);
+          }
           if (result.exportCapability) {
             currentExportCapability = result.exportCapability;
             if (onExportCapability) onExportCapability(result.exportCapability);

--- a/frontend/src/components/DiagramTranslator/__tests__/ExportHub.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/ExportHub.test.jsx
@@ -232,4 +232,47 @@ describe('ExportHub parallel generation', () => {
     // Second should use the token returned by the first response
     expect(capabilityOrder[1].cap).toBe('token-1')
   })
+
+  it('refreshes a missing capability and retries capability-gated deliverables', async () => {
+    const capabilityOrder = []
+    const capabilityErr = new Error('Missing export capability')
+    capabilityErr.status = 401
+    const onRefreshExportCapability = vi.fn().mockResolvedValue('fresh-capability')
+    const onExportCapability = vi.fn()
+
+    api.post.mockImplementation((url, _body, _signal, _timeout, headers) => {
+      const cap = headers?.['X-Export-Capability'] || null
+      capabilityOrder.push({ url, cap })
+      if (capabilityOrder.length === 1) return Promise.reject(capabilityErr)
+      return Promise.resolve({
+        content: '<html>pkg</html>',
+        filename: 'pkg.html',
+        export_capability: 'rotated-capability',
+      })
+    })
+
+    const user = userEvent.setup()
+    render(
+      <ExportHub
+        diagramId="diag-1"
+        onRefreshExportCapability={onRefreshExportCapability}
+        onExportCapability={onExportCapability}
+      />
+    )
+
+    openExportHub()
+
+    // Keep only Architecture Package selected.
+    for (const label of ['Infrastructure Code', 'High-Level Design', 'Cost Estimate', 'Migration Timeline', 'PDF Analysis Report']) {
+      await user.click(await screen.findByLabelText(`Include ${label}`))
+    }
+
+    await user.click(screen.getByRole('button', { name: /Generate All Selected/i }))
+
+    await waitFor(() => expect(capabilityOrder).toHaveLength(2), { timeout: 3000 })
+    expect(onRefreshExportCapability).toHaveBeenCalledTimes(1)
+    expect(capabilityOrder[0].cap).toBeNull()
+    expect(capabilityOrder[1].cap).toBe('fresh-capability')
+    expect(onExportCapability).toHaveBeenCalledWith('rotated-capability')
+  })
 })

--- a/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
+++ b/frontend/src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
@@ -11,7 +11,7 @@
  * - HLD data loss on navigation
  * - Signed-out PDF upload → analyze → auth recovery (#1027)
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import DiagramTranslator from '../../DiagramTranslator'
 
@@ -30,11 +30,17 @@ vi.mock('prismjs/components/prism-json', () => ({}))
 const mockSaveSession = vi.fn()
 const mockLoadSession = vi.fn()
 const mockClearSession = vi.fn()
+const mockUpdateSessionCache = vi.fn()
+const mockCacheImage = vi.fn()
+const mockLoadCachedImage = vi.fn()
 
 vi.mock('../../../services/sessionCache', () => ({
   saveSession: (...args) => mockSaveSession(...args),
   loadSession: (...args) => mockLoadSession(...args),
   clearSession: (...args) => mockClearSession(...args),
+  updateSessionCache: (...args) => mockUpdateSessionCache(...args),
+  cacheImage: (...args) => mockCacheImage(...args),
+  loadCachedImage: (...args) => mockLoadCachedImage(...args),
   shouldPersistSensitiveSessionCache: () => false,
 }))
 
@@ -84,6 +90,38 @@ vi.mock('../../../stores/useAuthStore', () => ({
   })),
 }))
 
+const downloadApiRestorers = []
+
+afterEach(() => {
+  while (downloadApiRestorers.length > 0) {
+    downloadApiRestorers.pop()()
+  }
+})
+
+function stubDownloadApis(blobUrl = 'blob:download') {
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  URL.createObjectURL = vi.fn(() => blobUrl)
+  URL.revokeObjectURL = vi.fn()
+  const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  let restored = false
+  const restore = () => {
+    if (restored) return
+    restored = true
+    if (originalCreateObjectURL) URL.createObjectURL = originalCreateObjectURL
+    else delete URL.createObjectURL
+    if (originalRevokeObjectURL) URL.revokeObjectURL = originalRevokeObjectURL
+    else delete URL.revokeObjectURL
+    anchorClick.mockRestore()
+  }
+  downloadApiRestorers.push(restore)
+  return {
+    createObjectURL: URL.createObjectURL,
+    anchorClick,
+    restore,
+  }
+}
+
 describe('DiagramTranslator — Session UX Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -91,6 +129,7 @@ describe('DiagramTranslator — Session UX Tests', () => {
     mockHasBackendSession = false
     mockEnsureBackendSession.mockResolvedValue(true)
     mockLoadSession.mockReturnValue(null)
+    mockLoadCachedImage.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
   })
 
@@ -219,38 +258,126 @@ describe('DiagramTranslator — Export Bug Verification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockLoadSession.mockReturnValue(null)
+    mockLoadCachedImage.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
   })
 
-  it('identifies the export restore bug pattern', () => {
-    // This test documents the bug in handleExportDiagram:
-    // After successful restore, the code still shows the expiry error
-    // instead of retrying the export.
-    //
-    // BUG in index.jsx around line 446-453:
-    //
-    //   if (err.status === 404) {
-    //     const restored = await tryRestoreSession(state.diagramId);
-    //     if (!restored) {
-    //       set({ error: 'Your session has expired...' }); // ← correct
-    //       clearSession();
-    //       return;
-    //     }
-    //     set({ error: 'Your session has expired...' }); // ← BUG: shows error even when restored!
-    //     clearSession();
-    //     return;
-    //   }
-    //
-    // Compare with handleHldExport which correctly retries after restore.
+  it('refreshes a missing export capability and retries architecture package exports', async () => {
+    mockIsAuthenticated = true
+    mockHasBackendSession = true
+    mockEnsureBackendSession.mockResolvedValue(true)
+    mockLoadSession.mockReturnValue({
+      diagramId: 'diag-stale-cap',
+      analysis: {
+        diagram_id: 'diag-stale-cap',
+        diagram_type: 'AWS Architecture',
+        services_detected: 1,
+        source_provider: 'aws',
+        target_provider: 'azure',
+        zones: [{ id: 1, name: 'Web', services: [] }],
+        mappings: [],
+        confidence_summary: { high: 1, medium: 0, low: 0, average: 0.95 },
+      },
+      questions: [],
+      answers: {},
+      ts: Date.now(),
+    })
+    mockApi.get.mockResolvedValue({ items: [], summary: {} })
+    const { ApiError } = await import('../../../services/apiClient')
+    const capabilityErr = new ApiError(401, { detail: 'Missing export capability' }, { hadToken: true })
+    const exportHeaders = []
+    const download = stubDownloadApis('blob:architecture-package')
 
-    // The fix should be:
-    //   if (restored) {
-    //     // Retry the export
-    //     const data = await api.post(`/diagrams/${id}/export-diagram?format=${format}`);
-    //     // ... process response
-    //   }
+    mockApi.post.mockImplementation((path, _body, _signal, _timeout, headers = {}) => {
+      if (path === '/diagrams/diag-stale-cap/restore-session') {
+        return Promise.resolve({ status: 'restored', diagram_id: 'diag-stale-cap', export_capability: 'fresh-capability' })
+      }
+      if (path === '/diagrams/diag-stale-cap/export-architecture-package?format=html') {
+        exportHeaders.push(headers)
+        if (exportHeaders.length < 3) return Promise.reject(capabilityErr)
+        return Promise.resolve({ content: '<html>package</html>', filename: 'package.html', export_capability: 'next-capability' })
+      }
+      return Promise.resolve({})
+    })
 
-    expect(true).toBe(true) // Documenting the bug
+    render(<DiagramTranslator />)
+    await screen.findByText('AWS Architecture')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /HTML Package/i }))
+    })
+
+    await waitFor(() => expect(exportHeaders).toHaveLength(3))
+    expect(exportHeaders[0]).toEqual({})
+    expect(exportHeaders[1]).toEqual({})
+    expect(exportHeaders[2]).toEqual({ 'X-Export-Capability': 'fresh-capability' })
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/diagrams/diag-stale-cap/restore-session',
+      expect.objectContaining({ analysis: expect.objectContaining({ diagram_id: 'diag-stale-cap' }) }),
+    )
+    expect(download.createObjectURL).toHaveBeenCalled()
+    expect(download.anchorClick).toHaveBeenCalled()
+
+    download.restore()
+  })
+
+  it('refreshes a missing export capability and retries migration package exports', async () => {
+    mockIsAuthenticated = true
+    mockHasBackendSession = true
+    mockEnsureBackendSession.mockResolvedValue(true)
+    mockLoadSession.mockReturnValue({
+      diagramId: 'diag-stale-package-cap',
+      analysis: {
+        diagram_id: 'diag-stale-package-cap',
+        diagram_type: 'AWS Architecture',
+        services_detected: 1,
+        source_provider: 'aws',
+        target_provider: 'azure',
+        zones: [{ id: 1, name: 'Web', services: [] }],
+        mappings: [],
+        confidence_summary: { high: 1, medium: 0, low: 0, average: 0.95 },
+      },
+      questions: [],
+      answers: {},
+      ts: Date.now(),
+    })
+    mockApi.get.mockResolvedValue({ items: [], summary: {} })
+    const { ApiError } = await import('../../../services/apiClient')
+    const capabilityErr = new ApiError(401, { detail: 'Invalid or replayed export capability' }, { hadToken: true })
+    const exportHeaders = []
+    const download = stubDownloadApis('blob:migration-package')
+
+    mockApi.post.mockImplementation((path, _body, _signal, _timeout, headers = {}) => {
+      if (path === '/diagrams/diag-stale-package-cap/restore-session') {
+        return Promise.resolve({ status: 'restored', diagram_id: 'diag-stale-package-cap', export_capability: 'fresh-package-capability' })
+      }
+      if (path === '/diagrams/diag-stale-package-cap/export-package') {
+        exportHeaders.push(headers)
+        if (exportHeaders.length < 3) return Promise.reject(capabilityErr)
+        return Promise.resolve({ content_b64: btoa('zip bytes'), filename: 'package.zip', export_capability: 'next-package-capability' })
+      }
+      return Promise.resolve({})
+    })
+
+    render(<DiagramTranslator />)
+    await screen.findByText('AWS Architecture')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Download Migration Package/i }))
+    })
+
+    await waitFor(() => expect(exportHeaders).toHaveLength(3))
+    expect(exportHeaders[0]).toEqual({})
+    expect(exportHeaders[1]).toEqual({})
+    expect(exportHeaders[2]).toEqual({ 'X-Export-Capability': 'fresh-package-capability' })
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/diagrams/diag-stale-package-cap/restore-session',
+      expect.objectContaining({ analysis: expect.objectContaining({ diagram_id: 'diag-stale-package-cap' }) }),
+    )
+    expect(download.createObjectURL).toHaveBeenCalled()
+    expect(download.anchorClick).toHaveBeenCalled()
+
+    download.restore()
   })
 })
 
@@ -315,6 +442,7 @@ describe('DiagramTranslator — Signed-out auth recovery', () => {
     mockIsAuthenticated = false // signed-out by default
     mockHasBackendSession = false
     mockLoadSession.mockReturnValue(null)
+    mockLoadCachedImage.mockReturnValue(null)
     fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
     localStorage.clear()
     sessionStorage.clear()

--- a/frontend/src/components/DiagramTranslator/index.jsx
+++ b/frontend/src/components/DiagramTranslator/index.jsx
@@ -361,6 +361,30 @@ export default function DiagramTranslator() {
   const filePreviewUrlRef = useRef(null);  // latest blob URL
   const abortRef = useRef(null);           // AbortController for fetch calls
   const persistSensitiveCache = shouldPersistSensitiveSessionCache();
+  const stateRef = useRef(state);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const rememberExportCapability = useCallback((token) => {
+    if (!token) return null;
+    stateRef.current = { ...stateRef.current, exportCapability: token };
+    set({ exportCapability: token });
+    return token;
+  }, [set]);
+
+  const exportCapabilityHeaders = useCallback((token) => (
+    token ? { 'X-Export-Capability': token } : {}
+  ), []);
+
+  const sanitizeRestoreAnalysis = useCallback((analysis) => {
+    if (!analysis || typeof analysis !== 'object') return analysis;
+    const sanitized = { ...analysis };
+    delete sanitized.export_capability;
+    delete sanitized.exportCapability;
+    return sanitized;
+  }, []);
 
   // Session expiry warning countdown (#261) + auto-reset on expiry (#227)
   const handleSessionExpired = useCallback(() => {
@@ -682,35 +706,64 @@ export default function DiagramTranslator() {
   };
 
   // ── Session auto-recovery: push cached analysis back to backend on 404 ──
+  const buildRestorePayload = useCallback((source, diagramId) => {
+    if (!source?.analysis) return null;
+    const payload = { analysis: sanitizeRestoreAnalysis(source.analysis) };
+    // Include HLD and IaC artefacts so export/download survives a backend restart.
+    if (source.hldData?.hld) {
+      payload.hld = source.hldData.hld;
+      payload.hld_markdown = source.hldData.markdown || null;
+    }
+    if (source.iacCode) {
+      payload.iac_code = source.iacCode;
+      payload.iac_format = source.iacFormat || null;
+    }
+    // Include cached diagram image so IMAGE_STORE is also restored (#333).
+    const cachedImg = loadCachedImage(diagramId, { persistSensitive: persistSensitiveCache });
+    if (cachedImg) {
+      payload.image_base64 = cachedImg.base64;
+      payload.image_content_type = cachedImg.contentType;
+    }
+    return payload;
+  }, [persistSensitiveCache, sanitizeRestoreAnalysis]);
+
+  const restoreSessionFromSource = useCallback(async (diagramId, source) => {
+    const payload = buildRestorePayload(source, diagramId);
+    if (!payload) return null;
+    const restoredData = await api.post(`/diagrams/${diagramId}/restore-session`, payload);
+    rememberExportCapability(restoredData?.export_capability);
+    return restoredData;
+  }, [buildRestorePayload, rememberExportCapability]);
+
   const tryRestoreSession = async (diagramId) => {
     const cached = loadSession();
     if (!cached || cached.diagramId !== diagramId) return false;
     try {
-      const payload = { analysis: cached.analysis };
-      // Include HLD and IaC artefacts so export/download survives a backend restart
-      if (cached.hldData?.hld) {
-        payload.hld = cached.hldData.hld;
-        payload.hld_markdown = cached.hldData.markdown || null;
-      }
-      if (cached.iacCode) {
-        payload.iac_code = cached.iacCode;
-        payload.iac_format = cached.iacFormat || null;
-      }
-      // Include cached diagram image so IMAGE_STORE is also restored (#333)
-      const cachedImg = loadCachedImage(diagramId, { persistSensitive: persistSensitiveCache });
-      if (cachedImg) {
-        payload.image_base64 = cachedImg.base64;
-        payload.image_content_type = cachedImg.contentType;
-      }
-      const restoredData = await api.post(`/diagrams/${diagramId}/restore-session`, payload);
-      if (restoredData?.export_capability) {
-        set({ exportCapability: restoredData.export_capability });
-      }
-      return true;
+      return !!(await restoreSessionFromSource(diagramId, cached));
     } catch {
       return false;
     }
   };
+
+  const refreshExportCapability = useCallback(async (sourceOverride = null) => {
+    const current = sourceOverride || stateRef.current;
+    if (
+      !isAuthenticated ||
+      !current.diagramId ||
+      !current.analysis ||
+      current.analysis?.combined ||
+      String(current.diagramId).startsWith('project-')
+    ) {
+      return null;
+    }
+    try {
+      await recoverBackendSession();
+      const restoredData = await restoreSessionFromSource(current.diagramId, current);
+      return restoredData?.export_capability || null;
+    } catch {
+      return null;
+    }
+  }, [isAuthenticated, recoverBackendSession, restoreSessionFromSource]);
 
   const withAuthRecovery = async (action) => {
     try {
@@ -733,8 +786,9 @@ export default function DiagramTranslator() {
     try {
       return await withAuthRecovery(action);
     } catch (err) {
-      if (err.status === 404 && state.diagramId) {
-        const restored = await tryRestoreSession(state.diagramId);
+      const diagramId = stateRef.current.diagramId;
+      if (err.status === 404 && diagramId) {
+        const restored = await tryRestoreSession(diagramId);
         if (restored) {
           try { return await withAuthRecovery(action); } catch { /* fall through */ }
         }
@@ -744,6 +798,18 @@ export default function DiagramTranslator() {
         return null;
       }
       throw err;
+    }
+  };
+
+  const withExportCapabilityRecovery = async (action, opts = {}) => {
+    const runWithToken = (token) => withRestore(() => action(token), opts);
+    try {
+      return await runWithToken(stateRef.current.exportCapability);
+    } catch (err) {
+      if (err.status !== 401) throw err;
+      const refreshedToken = await refreshExportCapability({ ...stateRef.current, ...state });
+      if (!refreshedToken) throw err;
+      return runWithToken(refreshedToken);
     }
   };
 
@@ -1162,20 +1228,18 @@ export default function DiagramTranslator() {
       if (cachedImg?.base64) {
         exportBody.diagram_image = cachedImg.base64;
       }
-      const data = await withRestore(
-        () => api.post(
+      const data = await withExportCapabilityRecovery(
+        (capabilityToken) => api.post(
           `/diagrams/${state.diagramId}/export-hld?format=${fmt}&include_diagrams=${state.hldIncludeDiagrams}&export_mode=customer`,
           exportBody,
           undefined,
           undefined,
-          state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+          exportCapabilityHeaders(capabilityToken),
         ),
         { cleanup: () => setHldExportLoading(fmt, false) },
       );
       if (data) {
-        if (data.export_capability) {
-          set({ exportCapability: data.export_capability });
-        }
+        rememberExportCapability(data.export_capability);
         const bytes = Uint8Array.from(atob(data.content_b64), c => c.charCodeAt(0));
         const blob = new Blob([bytes], { type: data.content_type });
         const url = URL.createObjectURL(blob);
@@ -1199,28 +1263,26 @@ export default function DiagramTranslator() {
       const packageSelection = format.replace('architecture-package-', '');
       const packageFormat = packageSelection.startsWith('svg') ? 'svg' : packageSelection;
       const packageDiagram = packageSelection === 'svg-dr' ? '&diagram=dr' : '';
-      const data = await withRestore(
-        () => isArchitecturePackage
+      const data = await withExportCapabilityRecovery(
+        (capabilityToken) => isArchitecturePackage
           ? api.post(
               `/diagrams/${state.diagramId}/export-architecture-package?format=${packageFormat}${packageDiagram}`,
               undefined,
               undefined,
               undefined,
-              state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+              exportCapabilityHeaders(capabilityToken),
             )
           : api.post(
               `/diagrams/${state.diagramId}/export-diagram?format=${format}`,
               undefined,
               undefined,
               undefined,
-              state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+              exportCapabilityHeaders(capabilityToken),
             ),
         { cleanup: () => setExportLoading(format, false) },
       );
       if (data) {
-        if (data.export_capability) {
-          set({ exportCapability: data.export_capability });
-        }
+        rememberExportCapability(data.export_capability);
         const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
         const exportMime = isArchitecturePackage
           ? (packageFormat === 'html' ? 'text/html' : 'image/svg+xml')
@@ -1334,8 +1396,8 @@ export default function DiagramTranslator() {
     set({ exportingPackage: true });
     try {
       // Build a migration package ZIP with IaC + HLD + cost report
-      const data = await withRestore(
-        () => api.post(
+      const data = await withExportCapabilityRecovery(
+        (capabilityToken) => api.post(
           `/diagrams/${state.diagramId}/export-package`,
           {
             iac_format: state.iacFormat,
@@ -1343,13 +1405,11 @@ export default function DiagramTranslator() {
           },
           undefined,
           undefined,
-          state.exportCapability ? { 'X-Export-Capability': state.exportCapability } : {},
+          exportCapabilityHeaders(capabilityToken),
         ),
         { cleanup: () => set({ exportingPackage: false }) },
       );
-      if (data?.export_capability) {
-        set({ exportCapability: data.export_capability });
-      }
+      rememberExportCapability(data?.export_capability);
       const b64 = data?.content_b64 || data?.data;
       if (b64) {
         const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
@@ -1712,8 +1772,9 @@ export default function DiagramTranslator() {
           assumptions={state.questionAssumptions}
           questionsCount={(state.questions || []).length}
           onExportCapability={(token) => {
-            set({ exportCapability: token });
+            rememberExportCapability(token);
           }}
+          onRefreshExportCapability={refreshExportCapability}
           reviewItems={reviewItems}
           reviewDispositions={reviewDispositions}
           reviewSummary={reviewSummary}


### PR DESCRIPTION
## Summary
- refresh one-time export capability tokens when signed-in diagram exports return 401
- retry architecture package, migration package, HLD, diagram, and ExportHub capability-gated exports with the freshly restored token
- add regressions for direct HTML package, migration package, and ExportHub bulk export 401 recovery

## Validation
- npm test -- --run src/components/DiagramTranslator/__tests__/AnalysisResults.test.jsx src/components/DiagramTranslator/__tests__/ExportHub.test.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx
- npx eslint src/components/DiagramTranslator/index.jsx src/components/DiagramTranslator/AnalysisResults.jsx src/components/DiagramTranslator/ExportHub.jsx src/components/DiagramTranslator/__tests__/sessionRecovery.test.jsx src/components/DiagramTranslator/__tests__/ExportHub.test.jsx --max-warnings 0
- npm run build
- git diff --check
- gitleaks dir . --redact --verbose

## Notes
- Leaves backend capability enforcement intact; the frontend remints via authenticated restore-session for the current diagram owner.
- Does not stage unrelated xDome artifacts in the worktree.