### PR TITLE
test: stabilize analyze latency smoke budget

### DIFF
--- a/backend/tests/performance/analyze_latency_budget.json
+++ b/backend/tests/performance/analyze_latency_budget.json
@@ -1,5 +1,5 @@
 {
-  "baseline_p95_ms": 8.0,
+  "baseline_p95_ms": 10.0,
   "max_regression_ratio": 1.5,
   "warmup_samples": 5,
   "samples": 20


### PR DESCRIPTION
## Summary
- Raise the CI smoke /analyze latency baseline from 8 ms to 10 ms while keeping the 1.5x regression guard
- Keeps the gate capped at 15 ms after two main CI failures at 13.28 ms and 12.46 ms on unchanged backend code

## Validation
- backend: .venv/bin/python -m pytest tests/test_analyze_latency_regression.py tests/test_perf_budget.py -q
- gitleaks detect --no-git --source backend/tests/performance/analyze_latency_budget.json --redact