### PR TITLE
fix(deploy): restore private storage discovery

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -30,6 +30,7 @@ These secrets are required in `.github/workflows/ci.yml`:
 | `TF_RESOURCE_GROUP_ENVIRONMENT` | Existing stack suffix used only during reviewed adoption | `configured-stack-suffix` |
 | `TF_REDIS_NAME_OVERRIDE` | Existing Redis name used only during reviewed adoption | `configured-redis-name` |
 | `TF_WORKBOOK_ID` | Existing Azure Monitor Workbook UUID used during state adoption | `00000000-0000-0000-0000-000000000000` |
+| `LEGACY_METRICS_STORAGE_ACCOUNT` | Legacy metrics-only storage account excluded from Terraform-managed app storage discovery | `configured-legacy-storage-name` |
 | `SWA_NAME` | Static Web App name | `your-static-web-app` |
 | `API_URL` | Backend API URL (with `/api` suffix) | `https://your-api.example.com/api` |
 | `SWA_DEPLOYMENT_TOKEN` | Static Web App deployment token | (from Azure Portal) |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,6 +593,7 @@ jobs:
       TRUSTED_FRONT_DOOR_FDID: ${{ secrets.TRUSTED_FRONT_DOOR_FDID }}
       TRUSTED_FRONT_DOOR_HOSTS: ${{ secrets.TRUSTED_FRONT_DOOR_HOSTS }}
       ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+      LEGACY_METRICS_STORAGE_ACCOUNT: ${{ secrets.LEGACY_METRICS_STORAGE_ACCOUNT }}
       TFSTATE_RESOURCE_GROUP: ${{ secrets.TFSTATE_RESOURCE_GROUP }}
       TFSTATE_STORAGE_ACCOUNT: ${{ secrets.TFSTATE_STORAGE_ACCOUNT }}
       TFSTATE_CONTAINER: ${{ secrets.TFSTATE_CONTAINER }}
@@ -633,6 +634,7 @@ jobs:
             ARCHMORPH_API_KEY \
             JWT_SECRET \
             ALLOWED_ORIGINS \
+            LEGACY_METRICS_STORAGE_ACCOUNT \
             TFSTATE_RESOURCE_GROUP \
             TFSTATE_STORAGE_ACCOUNT \
             TFSTATE_CONTAINER \
@@ -847,7 +849,7 @@ jobs:
           fi
           CONTAINER_APP_STORAGE_NAME=$(echo "$CONTAINER_APP_STORAGE_ACCOUNT_URL" | sed -E 's#^https://([^.]+)\.blob\.core\.windows\.net/?$#\1#')
           if [ -z "$CONTAINER_APP_STORAGE_NAME" ] || [ "$CONTAINER_APP_STORAGE_NAME" = "$CONTAINER_APP_STORAGE_ACCOUNT_URL" ]; then
-            echo "::error::Unable to parse storage account name from AZURE_STORAGE_ACCOUNT_URL=$CONTAINER_APP_STORAGE_ACCOUNT_URL"
+            echo "::error::Unable to parse storage account name from the configured AZURE_STORAGE_ACCOUNT_URL"
             exit 1
           fi
           TERRAFORM_STORAGE_CANDIDATES=$(az storage account list \
@@ -859,7 +861,7 @@ jobs:
             TERRAFORM_STORAGE_CANDIDATES=$(az storage account list \
               --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
               --query "[?starts_with(name, 'archmorph')].name" \
-              -o tsv | grep -vxF "$CONTAINER_APP_STORAGE_NAME" || true)
+              -o tsv | grep -vxF "$LEGACY_METRICS_STORAGE_ACCOUNT" || true)
           fi
           if [ -z "$TERRAFORM_STORAGE_CANDIDATES" ]; then
             echo "::error::No Terraform-managed Archmorph storage account candidates were found in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
@@ -889,8 +891,7 @@ jobs:
             elif grep -Eiq 'StatusCode=404|ResourceNotFound|ContainerNotFound|NotFound' "$CANDIDATE_METRICS_CONTAINER_ERROR"; then
               NOT_FOUND_STORAGE_NAMES+=("$CANDIDATE_STORAGE_NAME")
             else
-              echo "::error::Unable to query metrics container for storage account $CANDIDATE_STORAGE_NAME through Azure Resource Manager"
-              sed 's/^/az rest: /' "$CANDIDATE_METRICS_CONTAINER_ERROR" >&2
+              echo "::error::Unable to query a candidate metrics container through Azure Resource Manager; inventory details withheld"
               rm -f "$CANDIDATE_METRICS_CONTAINER_ERROR"
               exit 1
             fi
@@ -903,22 +904,21 @@ jobs:
           elif [ "${#MATCHED_STORAGE_NAMES[@]}" -eq 0 ] && [ "${#CANDIDATE_STORAGE_NAMES[@]}" -eq 1 ] && [ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]; then
             STORAGE_NAME="${CANDIDATE_STORAGE_NAMES[0]}"
             CREATE_METRICS_CONTAINER=true
-            echo "::notice::Metrics container was not found on storage account $STORAGE_NAME; creating it through Azure Resource Manager before validation."
+            echo "::notice::Metrics container was not found on the selected storage account; creating it through Azure Resource Manager before validation."
           else
             echo "::error::Expected exactly one Terraform-managed Archmorph storage account with a metrics container, found ${#MATCHED_STORAGE_NAMES[@]}"
-            printf 'Candidates: %s\n' $TERRAFORM_STORAGE_CANDIDATES
             exit 1
           fi
 
           STORAGE_ACCOUNT_URL="https://${STORAGE_NAME}.blob.core.windows.net"
           if [ "$CONTAINER_APP_STORAGE_NAME" != "$STORAGE_NAME" ]; then
-            echo "::notice::Container App still references legacy storage account ${CONTAINER_APP_STORAGE_NAME}; deploying Terraform-managed storage account ${STORAGE_NAME} for metrics cutover."
+            echo "::notice::Container App storage differs from the selected Terraform-managed account; validating the reviewed metrics cutover."
           fi
           echo "STORAGE_NAME=$STORAGE_NAME" >> "$GITHUB_ENV"
           echo "STORAGE_ACCOUNT_URL=$STORAGE_ACCOUNT_URL" >> "$GITHUB_ENV"
 
           if ! az storage account show --name "$STORAGE_NAME" --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" &>/dev/null; then
-            echo "::error::Storage account $STORAGE_NAME was not found in resource group ${{ env.AZURE_RESOURCE_GROUP }}"
+            echo "::error::Selected storage account was not found in the configured resource group"
             exit 1
           fi
 
@@ -927,7 +927,7 @@ jobs:
             --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
             --query id -o tsv)
           if [ -z "$STORAGE_ID" ]; then
-            echo "::error::Unable to resolve storage account resource ID for $STORAGE_NAME"
+            echo "::error::Unable to resolve the selected storage account resource ID"
             exit 1
           fi
           echo "STORAGE_ID=$STORAGE_ID" >> "$GITHUB_ENV"
@@ -937,7 +937,7 @@ jobs:
             --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
             --query allowSharedKeyAccess -o tsv | tr '[:upper:]' '[:lower:]')
           if [ "$ALLOW_SHARED_KEY" != "false" ]; then
-            echo "::error::Storage account $STORAGE_NAME must have shared-key access disabled"
+            echo "::error::Selected storage account must have shared-key access disabled"
             exit 1
           fi
 
@@ -956,7 +956,7 @@ jobs:
             PRIVATE_ENDPOINT_STATUS=$?
             set -e
             if [ "$PRIVATE_ENDPOINT_STATUS" -ne 0 ]; then
-              echo "::error::Unable to query private endpoint connections for storage account $STORAGE_NAME"
+              echo "::error::Unable to query private endpoint connections for the selected storage account"
               sed 's/^/az network private-endpoint-connection list: /' "$PRIVATE_ENDPOINT_ERROR" >&2
               rm -f "$PRIVATE_ENDPOINT_ERROR"
               exit 1
@@ -991,7 +991,7 @@ jobs:
                   echo "::error::Unable to discover container-apps-subnet ID for storage network rule cutover"
                   exit 1
                 fi
-                echo "::notice::Storage account $STORAGE_NAME is missing the container-apps-subnet rule; adding it before public network cutover."
+                echo "::notice::Selected storage account is missing the approved subnet rule; adding it before public network cutover."
                 az storage account network-rule add \
                   --account-name "$STORAGE_NAME" \
                   --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \

--- a/backend/tests/test_ci_workflow_post_deploy_smoke.py
+++ b/backend/tests/test_ci_workflow_post_deploy_smoke.py
@@ -208,6 +208,7 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
         "TFSTATE_KEY",
     ):
         assert deploy_env[name] == f"${{{{ secrets.{name} }}}}"
+    assert deploy_env["LEGACY_METRICS_STORAGE_ACCOUNT"] == "${{ secrets.LEGACY_METRICS_STORAGE_ACCOUNT }}"
 
     assert 'if [ "$PUBLIC_NETWORK_ACCESS" = "Disabled" ]; then' in validate_script
     assert "APPROVED_PRIVATE_ENDPOINT_COUNT=$(az network private-endpoint-connection list" in validate_script
@@ -217,16 +218,16 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "tags.project=='archmorph'" in validate_script
     assert "tags.managed_by=='terraform'" in validate_script
     assert "No tagged Terraform-managed Archmorph storage accounts were found" in validate_script
-    assert 'grep -vxF "$CONTAINER_APP_STORAGE_NAME"' in validate_script
+    assert 'grep -vxF "$LEGACY_METRICS_STORAGE_ACCOUNT"' in validate_script
     assert "No Terraform-managed Archmorph storage account candidates were found" in validate_script
     assert "CANDIDATE_METRICS_CONTAINER_ID" in validate_script
     assert "NOT_FOUND_STORAGE_NAMES=()" in validate_script
     assert "StatusCode=404|ResourceNotFound|ContainerNotFound|NotFound" in validate_script
-    assert "Unable to query metrics container for storage account" in validate_script
+    assert "Unable to query a candidate metrics container" in validate_script
     assert "CREATE_METRICS_CONTAINER=true" in validate_script
     assert '[ "${#CANDIDATE_STORAGE_NAMES[@]}" -eq 1 ]' in validate_script
     assert '[ "${#NOT_FOUND_STORAGE_NAMES[@]}" -eq 1 ]' in validate_script
-    assert "Metrics container was not found on storage account" in validate_script
+    assert "Metrics container was not found on the selected storage account" in validate_script
     assert "publicAccess\":\"None" in validate_script
     assert "STORAGE_NETWORK_RULES=$(az storage account show" in validate_script
     assert "--query networkRuleSet" in validate_script
@@ -286,8 +287,8 @@ def test_backend_storage_validation_requires_private_endpoint_when_public_access
     assert "az storage account update" in validate_script
     assert "--public-network-access Enabled" in validate_script
     assert "Expected exactly one Terraform-managed Archmorph storage account with a metrics container" in validate_script
-    assert "Container App still references legacy storage account" in validate_script
-    assert "deploying Terraform-managed storage account" in validate_script
+    assert "Container App storage differs from the selected Terraform-managed account" in validate_script
+    assert "validating the reviewed metrics cutover" in validate_script
     assert "has public network access disabled but no approved private endpoint connection" in validate_script
     assert "ALLOW_PUBLIC_STORAGE_NETWORK_CUTOVER" in validate_script
     assert "managed-identity blob preflight will prove RBAC data-plane access" in validate_script


### PR DESCRIPTION
## Description

Restores the pre-#1240 storage discovery semantics without republishing the legacy metrics account name. The exclusion now comes from a private repository secret, the deploy job fails closed when that setting is absent, and dynamic storage inventory is removed from workflow diagnostics.

## Related Issues

Follow-up to #1240 and #1252.

## Root Cause

The metadata-hardening change replaced the previous concrete legacy-account exclusion with exclusion of the Container App current account. In the live legacy topology those are not equivalent, so fallback discovery selected the metrics-only account and attempted to add a subnet ACL where the required Storage service endpoint was absent. No backend traffic shift occurred.

## Validation

- [x] Focused CI workflow tests passed
- [x] Metadata hygiene passed, including untracked files
- [x] Gitleaks found no leaks
- [x] Diff/whitespace checks passed
- [x] Failed deployment run and inventory-bearing logs deleted

## Security

- Legacy account identifier is held only in `LEGACY_METRICS_STORAGE_ACCOUNT` repository secret.
- Workflow logs no longer print candidate/current storage names in the changed discovery path.
- No resource mutation is introduced beyond restoring the previously successful account selection.