### PR TITLE
fix(release): support Azure CLI Blob response contracts

### DIFF
--- a/backend/tests/test_azure_rollout_lease.py
+++ b/backend/tests/test_azure_rollout_lease.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from subprocess import CompletedProcess
 import sys
@@ -16,6 +17,7 @@ assert SPEC and SPEC.loader
 coordination = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = coordination
 SPEC.loader.exec_module(coordination)
+LEASE_ID_PLACEHOLDER = "00000000-0000-0000-0000-000000000000"
 
 
 class FakeClock:
@@ -428,6 +430,50 @@ def test_fake_azure_cli_uses_login_auth_and_never_account_keys_or_sas():
     ]
     assert "--account-key" not in command
     assert "--sas-token" not in command
+    assert "--query" not in command
+    assert command[command.index("--output") + 1] == "json"
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        f'"{LEASE_ID_PLACEHOLDER}"\n',
+        f'{{"leaseId":"{LEASE_ID_PLACEHOLDER}"}}\n',
+        f"{LEASE_ID_PLACEHOLDER}\n",
+    ],
+)
+def test_lease_id_accepts_current_and_legacy_azure_cli_response_shapes(stdout):
+    assert (
+        coordination.AzureCliBlobLeaseStorage._lease_id(stdout) == LEASE_ID_PLACEHOLDER
+    )
+
+
+def test_azure_cli_blob_listing_uses_supported_compact_metadata_selector():
+    storage = coordination.AzureCliBlobLeaseStorage(
+        account="exampleaccount",
+        container="state",
+    )
+    payload = [
+        {
+            "name": ".archmorph-rollout/production/exclusive.lock",
+            "properties": {
+                "lastModified": "2026-07-31T00:00:00Z",
+                "leaseState": "available",
+                "leaseStatus": "unlocked",
+            },
+        }
+    ]
+    with patch.object(
+        coordination.subprocess,
+        "run",
+        return_value=CompletedProcess([], 0, stdout=json.dumps(payload)),
+    ) as run:
+        records = storage.list_blobs(".archmorph-rollout/production/")
+
+    assert len(records) == 1
+    command = run.call_args.args[0]
+    assert command[command.index("--include") + 1] == "m"
+    assert "metadata" not in command
 
 
 @pytest.mark.parametrize(

--- a/scripts/azure_rollout_lease.py
+++ b/scripts/azure_rollout_lease.py
@@ -149,12 +149,16 @@ class AzureCliBlobLeaseStorage:
     @staticmethod
     def _lease_id(stdout: str) -> str:
         value = stdout.strip()
-        if value.startswith("{"):
-            try:
-                payload = json.loads(value)
-            except json.JSONDecodeError as error:
-                raise AzureCliError("Azure lease response is malformed") from error
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError:
+            payload = value
+        if isinstance(payload, dict):
             value = str(payload.get("leaseId") or payload.get("lease_id") or "")
+        elif isinstance(payload, str):
+            value = payload
+        else:
+            value = ""
         if not re.fullmatch(r"[A-Za-z0-9-]{16,128}", value):
             raise AzureCliError("Azure lease response omitted a valid lease ID")
         return value
@@ -229,7 +233,8 @@ class AzureCliBlobLeaseStorage:
                 "--prefix",
                 prefix,
                 "--include",
-                "metadata",
+                # Azure CLI requires compact dataset codes; "metadata" is rejected.
+                "m",
                 "--output",
                 "json",
             ]
@@ -285,10 +290,9 @@ class AzureCliBlobLeaseStorage:
                     name,
                     "--lease-duration",
                     str(duration_seconds),
-                    "--query",
-                    "leaseId",
                     "--output",
-                    "tsv",
+                    # Azure CLI 2.86 returns the lease ID as a top-level JSON string.
+                    "json",
                 ]
             )
         except AzureCliError as error:


### PR DESCRIPTION
## Description

Azure CLI 2.86 differs from the rollout adapter’s assumed Blob response contracts in two ways:

1. Blob listing rejects the full-word selector `--include metadata`; it requires the compact selector `--include m`.
2. Lease acquisition returns the lease capability as a top-level JSON string, not an object with `.leaseId`.

These mismatches caused production rollout attempts to stop before durable ownership and immediately after finite lease acquisition, respectively. The adapter now uses the supported selector, parses current and legacy lease response shapes, and adds subprocess-level regression contracts.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [x] CI/CD or infrastructure change
- [ ] Dependency update

## Related Issues

- Unblocks production verification of #1237 after PR #1264.

## Testing

- [x] Unit tests added/updated
- [x] All relevant existing tests pass (`131` release/rollout tests)
- [x] Manual testing performed against Azure CLI 2.86 and private Azure Blob Storage
- [x] E2E tests pass (not applicable: no UI change; previous full exact-head E2E suite is green)

## Definition of Done Checklist

### Code Quality
- [x] PR title follows Semantic Pull Request format (`feat:`, `fix:`, `chore:`, etc.)
- [x] Code follows project style guidelines (Ruff lint/format)
- [x] Self-review completed
- [x] No `console.log` / debug prints left in production code
- [x] No TODO/FIXME without a linked issue

### Security
- [x] No secrets or credentials in code; Gitleaks reports zero findings
- [x] No breaking API changes
- [x] Input validation on all new endpoints (not applicable: no endpoint change)
- [x] XSS/injection risks reviewed (not applicable: no user input/UI change)

### Testing Thresholds
- [x] Backend changed behavior is covered by focused subprocess contracts
- [x] Frontend coverage not applicable
- [x] Generated IaC validation not applicable

### Observability
- [x] No new error path; existing fail-closed error handling is preserved
- [x] Metrics/counters not applicable

### Documentation
- [x] API docs not applicable
- [x] Inline comments document both non-obvious Azure CLI response contracts

### Accessibility (if UI changes)
- [x] Not applicable: no UI change
- [x] Not applicable: no UI change

### Deployment Readiness
- [x] Alembic migration not required
- [x] Feature flag not required
- [x] Rollback plan: revert the adapter changes; current production traffic and schema remained unchanged

## Screenshots / Evidence

- Exact reviewed head: `b0b0befbae5438b531b4c6808b39a7526278ffb6`.
- `131` release/rollout tests passed.
- Ruff lint and format checks passed.
- Gitleaks scanned the worktree with zero findings.
- `git diff --check` passed.
- Exact-commit live integration on the private production path passed Blob listing plus finite lease acquire/release.
- Temporary integration-test managed identity and Blob role were removed immediately after validation.
- Failed rollout attempts made no traffic or schema change and created no migration Job.
