### PR TITLE
fix(ci): delete public release packages

### DIFF
--- a/.github/workflows/emergency-delete-public-release-packages.yml
+++ b/.github/workflows/emergency-delete-public-release-packages.yml
@@ -1,0 +1,32 @@
+name: Emergency delete public release packages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  delete-public-release-packages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete accidentally public release staging packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for package in \
+            archmorph-api-release-build \
+            archmorph-api-bridge-release-build; do
+            metadata=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}")
+            visibility=$(jq -er '.visibility' <<<"$metadata")
+            repository=$(jq -er '.repository.full_name' <<<"$metadata")
+            if [ "$visibility" != public ] || [ "$repository" != "$GITHUB_REPOSITORY" ]; then
+              echo "::error::Refusing to delete package with unexpected identity or visibility"
+              exit 1
+            fi
+            gh api --method DELETE \
+              "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}"
+          done

--- a/.github/workflows/emergency-delete-public-release-packages.yml
+++ b/.github/workflows/emergency-delete-public-release-packages.yml
@@ -23,8 +23,8 @@ jobs:
             metadata=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}")
             visibility=$(jq -er '.visibility' <<<"$metadata")
             repository=$(jq -er '.repository.full_name' <<<"$metadata")
-            if [ "$visibility" != public ] || [ "$repository" != "$GITHUB_REPOSITORY" ]; then
-              echo "::error::Refusing to delete package with unexpected identity or visibility"
+            if [ "$visibility" != "public" ] || [ "$repository" != "$GITHUB_REPOSITORY" ]; then
+              echo "::error::Refusing to delete ${package}: visibility=${visibility}, repository=${repository}"
               exit 1
             fi
             gh api --method DELETE \


### PR DESCRIPTION
## Description

Adds a one-use, manually dispatched workflow that deletes only the two exact public GHCR release-staging packages created by failed main run 30644558722. The job fails closed unless each package is public and bound to this repository.

## Type of Change

- [x] Bug fix (security cleanup)
- [x] CI/CD or infrastructure change

## Related Issues

Follow-up to #1237 and PR #1267.

## Testing

- [x] `actionlint` passed
- [x] `git diff --check` passed
- [x] Package names, visibility, and repository identity are verified before deletion

## Deployment Readiness

- [x] No application, Azure, schema, or traffic mutation
- [x] Workflow will be removed in the follow-up release hotfix after successful cleanup
